### PR TITLE
Suppress ssh key diff if the fingerprint is the same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /*.sh
 /*.json
 /*.yaml
+/*.log

--- a/hcloud/resource_hcloud_sshkey.go
+++ b/hcloud/resource_hcloud_sshkey.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hetznercloud/hcloud-go/hcloud"
+	"golang.org/x/crypto/ssh"
 )
 
 func resourceSSHKey() *schema.Resource {
@@ -40,6 +41,14 @@ func resourceSSHKey() *schema.Resource {
 }
 
 func resourceSSHKeyPublicKeyDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	fingerprint := d.Get("fingerprint").(string)
+	if new != "" && fingerprint != "" {
+		publicKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(new))
+		if err != nil {
+			return false
+		}
+		return ssh.FingerprintLegacyMD5(publicKey) == fingerprint
+	}
 	return strings.TrimSpace(old) == strings.TrimSpace(new)
 }
 


### PR DESCRIPTION
When importing an ssh key via `terraform import hcloud_sshkey.<name> <id>` the public key cannot be imported into terraforms state, because the ssh keys API does not expose the public key.

This will lead to terraform recreating the resource because the public key always changes from empty to the provided value, even if the public key is still the same as the resource was created with.

To fix this I check if the fingerprint of the public key has changed, and if it did not change I suppress the diff in terraform.