### PR TITLE
states that Go 1.9 is required to build it

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Requirements
 ------------
 
 -	[Terraform](https://www.terraform.io/downloads.html) 0.10.x
--	[Go](https://golang.org/doc/install) 1.8 (to build the provider plugin)
+-	[Go](https://golang.org/doc/install) 1.9 (to build the provider plugin)
 
 Building The Provider
 ---------------------


### PR DESCRIPTION
Changes README.md to specify Go 1.9 as the version to use to build the provider. Fixes https://github.com/hetznercloud/terraform-provider-hcloud/issues/8