### PR TITLE
Add image_type configuration key to hcloud_server resource.

### DIFF
--- a/hcloud/resource_hcloud_server.go
+++ b/hcloud/resource_hcloud_server.go
@@ -33,6 +33,12 @@ func resourceServer() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
+			"image_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "system",
+			},
 			"location": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -100,6 +106,7 @@ func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
 		},
 		Image: &hcloud.Image{
 			Name: d.Get("image").(string),
+			Type: hcloud.ImageType(d.Get("image_type").(string)),
 		},
 		UserData: d.Get("user_data").(string),
 	}
@@ -177,6 +184,9 @@ func resourceServerRead(d *schema.ResourceData, m interface{}) error {
 			d.Set("image", server.Image.Name)
 		} else {
 			d.Set("image", server.Image.ID)
+		}
+		if server.Image.Type != "" {
+			d.Set("image_type", string(server.Image.Type))
 		}
 	}
 

--- a/hcloud/resource_hcloud_server_test.go
+++ b/hcloud/resource_hcloud_server_test.go
@@ -232,6 +232,9 @@ func testAccCheckServerAttributes(server *hcloud.Server) resource.TestCheckFunc 
 		if server.Image.Name != "debian-9" {
 			return fmt.Errorf("Bad server.Image.Name: %s", server.Image.Name)
 		}
+		if server.Image.Type != hcloud.ImageTypeSystem {
+			return fmt.Errorf("Bad server.Image.Type: %s", server.Image.Type)
+		}
 
 		if server.ServerType.Name != "cx11" {
 			return fmt.Errorf("Bad server.ServerType.Name: %s", server.ServerType.Name)
@@ -268,6 +271,7 @@ resource "hcloud_server" "foobar" {
   name          = "foo-%d"
   server_type   = "cx11"
   image         = "debian-9"
+  image_type    = "system"
   datacenter    = "fsn1-dc8"
 	user_data     = "stuff"
 	backup_window = "22-02"


### PR DESCRIPTION
I would like to be able to select a snapshot image, built with Packer, when creating a server.

This PR adds an `image_type` configuration key, that defaults to `system`, to the `hcloud_server` resource.