### PR TITLE
Update 'git clone' command from ssh to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Clone repository to: `$GOPATH/src/github.com/hetznercloud/terraform-provider-hcl
 
 ```sh
 $ mkdir -p $GOPATH/src/github.com/hetznercloud; cd $GOPATH/src/github.com/hetznercloud
-$ git clone git@github.com:hetznercloud/terraform-provider-hcloud
+$ git clone https://github.com/hetznercloud/terraform-provider-hcloud.git
 ```
 
 Enter the provider directory and build the provider


### PR DESCRIPTION
The old command: "git clone git@github.com:hetznercloud/terraform-provider-hcloud" gave me the following output:

    Cloning into 'terraform-provider-hcloud'...
    Permission denied (publickey).
    fatal: Could not read from remote repository.
    
    Please make sure you have the correct access rights
    and the repository exists.

A simple way to solve this is to use the web address of the repository. Like this the access rights do not matter in a public repository.