### PR TITLE
Add sample for label selector to the documentation

### DIFF
--- a/website/docs/d/floating_ip.html.md
+++ b/website/docs/d/floating_ip.html.md
@@ -23,7 +23,10 @@ This resource can be useful when you need to determine a Floating IP ID based on
 data "hcloud_floating_ip" "ip_1" {
   ip_address = "1.2.3.4"
 }
- resource "hcloud_floating_ip_assignment" "main" {
+data "hcloud_floating_ip" "image_2" {
+  selector = "key=value"
+}
+resource "hcloud_floating_ip_assignment" "main" {
   count          = "${var.counter}"
   floating_ip_id = "${data.hcloud_floating_ip.ip_1.id}"
   server_id      = "${hcloud_server.main.id}"
@@ -31,6 +34,7 @@ data "hcloud_floating_ip" "ip_1" {
 ```
 ## Argument Reference
 - `ip_address` - (Optional, string) IP address of the Floating IP.
+- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Floating IP.

--- a/website/docs/d/floating_ip.html.md
+++ b/website/docs/d/floating_ip.html.md
@@ -34,7 +34,7 @@ resource "hcloud_floating_ip_assignment" "main" {
 ```
 ## Argument Reference
 - `ip_address` - (Optional, string) IP address of the Floating IP.
-- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
+- `selector` - (Optional, string) [Label selector](https://docs.hetzner.cloud/#overview-label-selector)
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Floating IP.

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -27,8 +27,7 @@ resource "hcloud_server" "main" {
 ## Argument Reference
 - `id` - (Optional, string) ID of the Image.
 - `name` - (Optional, string) Name of the Image.
-- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
-
+- `selector` - (Optional, string) [Label selector](https://docs.hetzner.cloud/#overview-label-selector)
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Image.

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -16,6 +16,9 @@ data "hcloud_image" "image_1" {
 data "hcloud_image" "image_2" {
   name = "ubuntu-18.04"
 }
+data "hcloud_image" "image_3" {
+  selector = "key=value"
+}
 
 resource "hcloud_server" "main" {
   image  = "${data.hcloud_image.image_1.name}"
@@ -24,6 +27,8 @@ resource "hcloud_server" "main" {
 ## Argument Reference
 - `id` - (Optional, string) ID of the Image.
 - `name` - (Optional, string) Name of the Image.
+- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
+
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Image.

--- a/website/docs/d/ssh_key.html.md
+++ b/website/docs/d/ssh_key.html.md
@@ -19,6 +19,9 @@ data "hcloud_ssh_key" "ssh_key_2" {
 data "hcloud_ssh_key" "ssh_key_3" {
   fingerprint = "43:51:43:a1:b5:fc:8b:b7:0a:3a:a9:b1:0f:66:73:a8"
 }
+data "hcloud_ssh_key" "ssh_key_4" {
+  selector = "key=value"
+}
 resource "hcloud_server" "main" {
   ssh_keys  = ["${data.hcloud_ssh_key.ssh_key_1.id}","${data.hcloud_ssh_key.ssh_key_2.id}","${data.hcloud_ssh_key.ssh_key_3.id}"]
 }
@@ -27,6 +30,7 @@ resource "hcloud_server" "main" {
 - `id` - (Optional, string) ID of the SSH Key.
 - `name` - (Optional, string) Name of the SSH Key.
 - `fingerprint` - (Optional, string) Fingerprint of the SSH Key.
+- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the SSH Key.

--- a/website/docs/d/ssh_key.html.md
+++ b/website/docs/d/ssh_key.html.md
@@ -30,7 +30,7 @@ resource "hcloud_server" "main" {
 - `id` - (Optional, string) ID of the SSH Key.
 - `name` - (Optional, string) Name of the SSH Key.
 - `fingerprint` - (Optional, string) Fingerprint of the SSH Key.
-- `selector` - (Optional, string) Label selector for the [label selector](https://docs.hetzner.cloud/#overview-label-selector).
+- `selector` - (Optional, string) [Label selector](https://docs.hetzner.cloud/#overview-label-selector)
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the SSH Key.


### PR DESCRIPTION
This adds some samples for the label selector to the data source documentations.



@thcyron 
Can you review this?