### PR TITLE
Add `backups` Attribute for enable or disable backups.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.5.0 (Unreleased)
+
+IMPROVEMENTS:
+* resources/hcloud_server: Add `backups` attribute for enable or disable backups.
+
+NOTES:
+* **Read Only**: resources/hcloud_server: `backup_window`, removed the ability to set the attribute. This attribute is now read only.
+
 ## 1.4.0 (October 18, 2018)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.5.0 (Unreleased)
 
 IMPROVEMENTS:
-* resources/hcloud_server: Add `backups` attribute for enable or disable backups.
+* resources/hcloud_server: Add `backups` attribute to enable or disable backups.
 
 NOTES:
 * **Read Only**: resources/hcloud_server: `backup_window`, removed the ability to set the attribute. This attribute is now read only.

--- a/hcloud/resource_hcloud_server.go
+++ b/hcloud/resource_hcloud_server.go
@@ -178,7 +178,7 @@ func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	backups := d.Get("backups").(bool)
-	if err := setBackupWindow(ctx, client, res.Server, backups); err != nil {
+	if err := setBackups(ctx, client, res.Server, backups); err != nil {
 		return err
 	}
 
@@ -311,12 +311,12 @@ func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
 		d.SetPartial("server_type")
 	}
 
-	if d.HasChange("backup") {
-		backups := d.Get("backup").(bool)
-		if err := setBackupWindow(ctx, client, server, backups); err != nil {
+	if d.HasChange("backups") {
+		backups := d.Get("backups").(bool)
+		if err := setBackups(ctx, client, server, backups); err != nil {
 			return err
 		}
-		d.SetPartial("backup")
+		d.SetPartial("backups")
 	}
 
 	if d.HasChange("iso") {
@@ -368,8 +368,8 @@ func resourceServerIsNotFound(err error, d *schema.ResourceData) bool {
 	return false
 }
 
-func setBackupWindow(ctx context.Context, client *hcloud.Client, server *hcloud.Server, backups bool) error {
-	if server.BackupWindow != "" && backups == false {
+func setBackups(ctx context.Context, client *hcloud.Client, server *hcloud.Server, backups bool) error {
+	if server.BackupWindow != "" && !backups {
 		action, _, err := client.Server.DisableBackup(ctx, server)
 		if err != nil {
 			return err
@@ -379,7 +379,7 @@ func setBackupWindow(ctx context.Context, client *hcloud.Client, server *hcloud.
 		}
 		return nil
 	}
-	if server.BackupWindow == "" && backups == true {
+	if server.BackupWindow == "" && backups {
 		action, _, err := client.Server.EnableBackup(ctx, server, "")
 		if err != nil {
 			return err

--- a/hcloud/resource_hcloud_server.go
+++ b/hcloud/resource_hcloud_server.go
@@ -77,7 +77,12 @@ func resourceServer() *schema.Resource {
 			"backup_window": {
 				Type:       schema.TypeString,
 				Deprecated: "You should remove this property from your terraform configuration.",
-				Optional:   true,
+				Computed:   true,
+			},
+			"backups": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
 			},
 			"ipv4_address": {
 				Type:     schema.TypeString,
@@ -172,11 +177,9 @@ func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	backupWindow := d.Get("backup_window").(string)
-	if backupWindow != "" {
-		if err := setBackupWindow(ctx, client, res.Server, backupWindow); err != nil {
-			return err
-		}
+	backups := d.Get("backups").(bool)
+	if err := setBackupWindow(ctx, client, res.Server, backups); err != nil {
+		return err
 	}
 
 	if iso, ok := d.GetOk("iso"); ok {
@@ -219,6 +222,7 @@ func resourceServerRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("ipv6_address", server.PublicNet.IPv6.IP.String())
 	d.Set("ipv6_network", server.PublicNet.IPv6.Network.String())
 	d.Set("backup_window", server.BackupWindow)
+	d.Set("backups", server.BackupWindow != "")
 	d.Set("labels", server.Labels)
 	if server.Image != nil {
 		if server.Image.Name != "" {
@@ -307,12 +311,12 @@ func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
 		d.SetPartial("server_type")
 	}
 
-	if d.HasChange("backup_window") {
-		backupWindow := d.Get("backup_window").(string)
-		if err := setBackupWindow(ctx, client, server, backupWindow); err != nil {
+	if d.HasChange("backup") {
+		backups := d.Get("backup").(bool)
+		if err := setBackupWindow(ctx, client, server, backups); err != nil {
 			return err
 		}
-		d.SetPartial("backup_window")
+		d.SetPartial("backup")
 	}
 
 	if d.HasChange("iso") {
@@ -364,8 +368,8 @@ func resourceServerIsNotFound(err error, d *schema.ResourceData) bool {
 	return false
 }
 
-func setBackupWindow(ctx context.Context, client *hcloud.Client, server *hcloud.Server, backupWindow string) error {
-	if backupWindow == "" {
+func setBackupWindow(ctx context.Context, client *hcloud.Client, server *hcloud.Server, backups bool) error {
+	if server.BackupWindow != "" && backups == false {
 		action, _, err := client.Server.DisableBackup(ctx, server)
 		if err != nil {
 			return err
@@ -375,13 +379,14 @@ func setBackupWindow(ctx context.Context, client *hcloud.Client, server *hcloud.
 		}
 		return nil
 	}
-
-	action, _, err := client.Server.EnableBackup(ctx, server, backupWindow)
-	if err != nil {
-		return err
-	}
-	if err := waitForServerAction(ctx, client, action, server); err != nil {
-		return err
+	if server.BackupWindow == "" && backups == true {
+		action, _, err := client.Server.EnableBackup(ctx, server, "")
+		if err != nil {
+			return err
+		}
+		if err := waitForServerAction(ctx, client, action, server); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/hcloud/resource_hcloud_server_test.go
+++ b/hcloud/resource_hcloud_server_test.go
@@ -58,7 +58,7 @@ func TestAccHcloudServer_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"hcloud_server.foobar", "location", "fsn1"),
 					resource.TestCheckResourceAttr(
-						"hcloud_server.foobar", "backup_window", "22-02"),
+						"hcloud_server.foobar", "backups", "true"),
 				),
 			},
 		},
@@ -82,7 +82,7 @@ func TestAccHcloudServer_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"hcloud_server.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
-						"hcloud_server.foobar", "backup_window", "22-02"),
+						"hcloud_server.foobar", "backups", "true"),
 				),
 			},
 
@@ -96,7 +96,7 @@ func TestAccHcloudServer_Update(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"hcloud_server.foobar", "server_type", "cx21"),
 					resource.TestCheckResourceAttr(
-						"hcloud_server.foobar", "backup_window", "10-14"),
+						"hcloud_server.foobar", "backups", "false"),
 				),
 			},
 		},
@@ -250,7 +250,7 @@ func testAccHcloudCheckServerAttributes(server *hcloud.Server) resource.TestChec
 			return fmt.Errorf("Bad server.Datacenter.Location.Name: %s", server.Datacenter.Location.Name)
 		}
 
-		if server.BackupWindow != "22-02" {
+		if server.BackupWindow == "" {
 			return fmt.Errorf("Bad server.BackupWindow: %s", server.BackupWindow)
 		}
 
@@ -278,9 +278,9 @@ resource "hcloud_server" "foobar" {
   server_type   = "cx11"
   image         = "debian-9"
   datacenter    = "fsn1-dc14"
-	user_data     = "stuff"
-	backup_window = "22-02"
-	ssh_keys  = ["${hcloud_ssh_key.foobar.id}"]
+  user_data     = "stuff"
+  backups       = true
+  ssh_keys      = ["${hcloud_ssh_key.foobar.id}"]
 }`, rInt, testAccSSHPublicKey, rInt)
 }
 
@@ -295,9 +295,9 @@ resource "hcloud_server" "foobar" {
   server_type = "cx11"
   image       = "debian-9"
   datacenter  = "fsn1-dc14"
-	backup_window = "22-02"
-	iso         = "%s"
-	ssh_keys  = ["${hcloud_ssh_key.foobar.id}"]
+  backups     = true
+  iso         = "%s"
+  ssh_keys    = ["${hcloud_ssh_key.foobar.id}"]
 }`, rInt, testAccSSHPublicKey, rInt, testHcloudISOName)
 }
 
@@ -310,10 +310,10 @@ resource "hcloud_ssh_key" "foobar" {
 resource "hcloud_server" "foobar" {
   name        = "baz-%d"
   server_type = "cx21"
-	image       = "debian-9"
+  image       = "debian-9"
   datacenter  = "fsn1-dc14"
-	ssh_keys  = ["${hcloud_ssh_key.foobar.id}"]
-	backup_window = "10-14"
+  ssh_keys    = ["${hcloud_ssh_key.foobar.id}"]
+  backups     = "false"
 }
 `, rInt, testAccSSHPublicKey, rInt)
 }
@@ -327,10 +327,10 @@ resource "hcloud_ssh_key" "foobar" {
 resource "hcloud_server" "foobar" {
   name      = "foo-%d"
   server_type = "cx11"
-	image       = "debian-9"
+  image       = "debian-9"
   datacenter  = "fsn1-dc14"
-	user_data   = "updated stuff"
-	ssh_keys  = ["${hcloud_ssh_key.foobar.id}"]
+  user_data   = "updated stuff"
+  ssh_keys  = ["${hcloud_ssh_key.foobar.id}"]
 }
 `, rInt, testAccSSHPublicKey, rInt)
 }

--- a/hcloud/resource_hcloud_server_test.go
+++ b/hcloud/resource_hcloud_server_test.go
@@ -313,7 +313,7 @@ resource "hcloud_server" "foobar" {
   image       = "debian-9"
   datacenter  = "fsn1-dc14"
   ssh_keys    = ["${hcloud_ssh_key.foobar.id}"]
-  backups     = "false"
+  backups     =  false
 }
 `, rInt, testAccSSHPublicKey, rInt)
 }

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -49,7 +49,7 @@ The following attributes are exported:
 - `location` - (string) The location name.
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
-- `backups` - (boolean) Backups enabled or not.
+- `backups` - (boolean) Whether backups are enabled.
 - `iso` - (string) Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -36,6 +36,7 @@ The following arguments are supported:
 - `iso` - (Optional, string) Name of an ISO image to mount.
 - `rescue` - (Optional, string) Enable and boot in to the specified rescue system. This enables simple installation of custom operating systems. `linux64` `linux32` or `freebsd64`
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
+- `backups` - (Optional, boolean) Enable or disable backups.
 
 ## Attributes Reference
 
@@ -48,6 +49,7 @@ The following attributes are exported:
 - `location` - (string) The location name.
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
+- `backups` - (boolean) Backups enabled or not.
 - `iso` - (string) Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.


### PR DESCRIPTION
Add `backups` Attribute for enable or disable backups.
Make `backup_window` readonly.

This PR closes #44 

@thcyron can you please review it?