### PR TITLE
Add `hcloud_datacenter(s)` resources

### DIFF
--- a/hcloud/data_source_hcloud_datacenter.go
+++ b/hcloud/data_source_hcloud_datacenter.go
@@ -1,0 +1,103 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+func dataSourceHcloudDatacenter() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHcloudDatacenterRead,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"location": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"supported_server_type_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+			"available_server_type_ids": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+			},
+		},
+	}
+}
+
+func dataSourceHcloudDatacenterRead(data *schema.ResourceData, m interface{}) (err error) {
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+	var d *hcloud.Datacenter
+	if id, ok := data.GetOk("id"); ok {
+		d, _, err = client.Datacenter.GetByID(ctx, id.(int))
+		if err != nil {
+			return err
+		}
+		if d == nil {
+			return fmt.Errorf("no datacenter found with id %d", id)
+		}
+		setDatacenterSchema(data, d)
+		return
+	}
+	if name, ok := data.GetOk("name"); ok {
+		d, _, err = client.Datacenter.GetByName(ctx, name.(string))
+		if err != nil {
+			return err
+		}
+		if d == nil {
+			return fmt.Errorf("no datacenter found with name %v", name)
+		}
+		setDatacenterSchema(data, d)
+		return
+	}
+
+	return fmt.Errorf("please specify an id, or a name to lookup for a datacenter")
+}
+
+func setDatacenterSchema(data *schema.ResourceData, d *hcloud.Datacenter) {
+	data.SetId(strconv.Itoa(d.ID))
+	data.Set("name", d.Name)
+	data.Set("description", d.Description)
+	data.Set("location", map[string]interface{}{
+		"id":          d.Location.ID,
+		"name":        d.Location.Name,
+		"description": d.Location.Description,
+		"country":     d.Location.Country,
+		"city":        d.Location.City,
+		"latitude":    d.Location.Latitude,
+		"longitude":   d.Location.Longitude,
+	})
+	var supported, available []int
+	for _, v := range d.ServerTypes.Supported {
+		supported = append(supported, v.ID)
+	}
+	for _, v := range d.ServerTypes.Available {
+		available = append(available, v.ID)
+	}
+	sort.Ints(available)
+	sort.Ints(supported)
+	data.Set("supported_server_type_ids", supported)
+	data.Set("available_server_type_ids", available)
+}

--- a/hcloud/data_source_hcloud_datacenter_test.go
+++ b/hcloud/data_source_hcloud_datacenter_test.go
@@ -1,0 +1,50 @@
+package hcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("data_source_datacenter", &resource.Sweeper{
+		Name: "hcloud_datacenter_data_source",
+	})
+}
+func TestAccHcloudDataSourceDatasource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccHcloudPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHcloudCheckDatacenterDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_1", "id", "1"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_1", "name", "fsn1-dc8"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_1", "description", "Falkenstein 1 DC 8"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_2", "id", "4"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_2", "name", "fsn1-dc14"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenter.ds_2", "description", "Falkenstein 1 DC14"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHcloudCheckDatacenterDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "hcloud_datacenter" "ds_1" {
+  name = "fsn1-dc8"
+}
+data "hcloud_datacenter" "ds_2" {
+  id = 4
+}
+`)
+}

--- a/hcloud/data_source_hcloud_datacenters.go
+++ b/hcloud/data_source_hcloud_datacenters.go
@@ -1,0 +1,54 @@
+package hcloud
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+func dataSourceHcloudDatacenters() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHcloudDatacentersRead,
+		Schema: map[string]*schema.Schema{
+			"datacenter_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"descriptions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceHcloudDatacentersRead(data *schema.ResourceData, m interface{}) (err error) {
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+	ds, err := client.Datacenter.All(ctx)
+	if err != nil {
+		return err
+	}
+
+	data.SetId(time.Now().UTC().String())
+	var names, descriptions, ids []string
+	for _, v := range ds {
+		ids = append(ids, strconv.Itoa(v.ID))
+		descriptions = append(descriptions, v.Description)
+		names = append(names, v.Name)
+	}
+	data.Set("datacenter_ids", ids)
+	data.Set("names", names)
+	data.Set("descriptions", descriptions)
+	return
+}

--- a/hcloud/data_source_hcloud_datacenters_test.go
+++ b/hcloud/data_source_hcloud_datacenters_test.go
@@ -1,0 +1,64 @@
+package hcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("data_source_datacenters", &resource.Sweeper{
+		Name: "hcloud_datacenters_data_source",
+	})
+}
+func TestAccHcloudDataSourceDatasources(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccHcloudPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHcloudCheckDatacentersDataSourceConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "datacenter_ids.#", "4"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "datacenter_ids.0", "1"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "datacenter_ids.1", "2"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "datacenter_ids.2", "3"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "datacenter_ids.3", "4"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "names.#", "4"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "names.0", "fsn1-dc8"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "names.1", "nbg1-dc3"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "names.2", "hel1-dc2"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "names.3", "fsn1-dc14"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "descriptions.#", "4"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "descriptions.0", "Falkenstein 1 DC 8"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "descriptions.1", "Nuremberg 1 DC 3"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "descriptions.2", "Helsinki 1 DC 2"),
+					resource.TestCheckResourceAttr(
+						"data.hcloud_datacenters.ds", "descriptions.3", "Falkenstein 1 DC14"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHcloudCheckDatacentersDataSourceConfig() string {
+	return fmt.Sprintf(`
+data "hcloud_datacenters" "ds" {
+}
+`)
+}

--- a/hcloud/data_source_hcloud_datacenters_test.go
+++ b/hcloud/data_source_hcloud_datacenters_test.go
@@ -21,8 +21,6 @@ func TestAccHcloudDataSourceDatasources(t *testing.T) {
 				Config: testAccHcloudCheckDatacentersDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"data.hcloud_datacenters.ds", "datacenter_ids.#", "4"),
-					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "datacenter_ids.0", "1"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "datacenter_ids.1", "2"),
@@ -31,8 +29,6 @@ func TestAccHcloudDataSourceDatasources(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "datacenter_ids.3", "4"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_datacenters.ds", "names.#", "4"),
-					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "names.0", "fsn1-dc8"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "names.1", "nbg1-dc3"),
@@ -40,8 +36,6 @@ func TestAccHcloudDataSourceDatasources(t *testing.T) {
 						"data.hcloud_datacenters.ds", "names.2", "hel1-dc2"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "names.3", "fsn1-dc14"),
-					resource.TestCheckResourceAttr(
-						"data.hcloud_datacenters.ds", "descriptions.#", "4"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_datacenters.ds", "descriptions.0", "Falkenstein 1 DC 8"),
 					resource.TestCheckResourceAttr(

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -34,6 +34,8 @@ func Provider() terraform.ResourceProvider {
 			"hcloud_volume_attachment":      resourceVolumeAttachment(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
+			"hcloud_datacenter":  dataSourceHcloudDatacenter(),
+			"hcloud_datacenters": dataSourceHcloudDatacenters(),
 			"hcloud_floating_ip": dataSourceHcloudFloatingIP(),
 			"hcloud_image":       dataSourceHcloudImage(),
 			"hcloud_ssh_key":     dataSourceHcloudSSHKey(),

--- a/website/docs/d/datacenter.html.md
+++ b/website/docs/d/datacenter.html.md
@@ -1,0 +1,31 @@
+---
+layout: "hcloud"
+page_title: "Hetzner Cloud: hcloud_datacenter"
+sidebar_current: "docs-hcloud-datasource-datacenter"
+description: |-
+  Provides details about a specific Hetzner Cloud Datacenter.
+---
+# Data Source: hcloud_datacenter
+Provides details about a specific Hetzner Cloud Datacenter.
+Use this resource to get detailed information about specific datacenter.
+
+## Example Usage
+```hcl
+data "hcloud_datacenter" "ds_1" {
+  name = "fsn1-dc8"
+}
+data "hcloud_datacenter" "ds_2" {
+  id = 4
+}
+```
+## Argument Reference
+- `id` - (Optional, string) ID of the datacenter.
+- `name` - (Optional, string) Name of the datacenter.
+
+## Attributes Reference
+- `id` - (int) Unique ID of the datacenter.
+- `name` - (string) Name of the datacenter.
+- `description` - (string) Description of the datacenter.
+- `location` - (map) Physical datacenter location.
+- `supported_server_type_ids` - (list) List of server types supported by the datacenter.
+- `available_server_type_ids` - (list) List of available server types.

--- a/website/docs/d/datacenters.html.md
+++ b/website/docs/d/datacenters.html.md
@@ -1,0 +1,30 @@
+---
+layout: "hcloud"
+page_title: "Hetzner Cloud: hcloud_datacenters"
+sidebar_current: "docs-hcloud-datasource-datacenters"
+description: |-
+  List all available Hetzner Cloud Datacenters.
+---
+# Data Source: hcloud_datacenters
+Provides a list of available Hetzner Cloud Datacenters.
+This resource may be useful to create highly available infrastructure, distributed across several datacenters.
+
+## Example Usage
+```hcl
+data "hcloud_datacenters" "ds" {
+}
+
+resource "hcloud_server" "workers" {
+  name = "node1"
+  image = "debian-9"
+  server_type = "cx31"
+  datacenter = "${element(data.hcloud_datacenters.ds.names, count.index)}"
+
+  count = 3
+}
+```
+
+## Attributes Reference
+- `datacenter_ids` - (list) List of unique datacenter identifiers.
+- `names` - (list) List of datacenter names.
+- `descriptions` - (list) List of all datacenter descriptions.

--- a/website/hcloud.erb
+++ b/website/hcloud.erb
@@ -12,6 +12,12 @@
         <li<%= sidebar_current("docs-hcloud-data-source") %>>
         <a href="#">Data Sources</a>
           <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-hcloud-datasource-datacenter") %>>
+               <a href="/docs/providers/hcloud/d/datacenter.html">hcloud_datacenter</a>
+            </li>
+            <li<%= sidebar_current("docs-hcloud-datasource-datacenters") %>>
+               <a href="/docs/providers/hcloud/d/datacenters.html">hcloud_datacenters</a>
+            </li>
             <li<%= sidebar_current("docs-hcloud-datasource-floating-ip") %>>
               <a href="/docs/providers/hcloud/d/floating_ip.html">hcloud_floating_ip</a>
             </li>


### PR DESCRIPTION
Hello, here is a typical tf-file, which we need to implement to distribute our cluster across different datacenters for HA.

As a reference I've taken [aws_availability_zones](https://www.terraform.io/docs/providers/aws/d/availability_zones.html) and [aws_availability_zone](https://www.terraform.io/docs/providers/aws/d/availability_zone.html) AWS provider data sources.

```
data "hcloud_datacenters" "ds" {
}

resource "hcloud_server" "workers" {
  name = "node1"
  image = "debian-9"
  server_type = "cx31"
  datacenter = "${element(data.hcloud_datacenters.ds.names, count.index)}"

  count = 3
}
```