### PR TITLE
Fix test when running concurrently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - "1.11.x"
 script:
   - export HCLOUD_TOKEN=$(./scripts/get-token.sh)
+  - cat resp.json
   - make test
   - travis_wait 30 make testacc
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ script:
   - make test
   - travis_wait 30 make testacc
   - make
+  - ./scripts/delete-token.sh $HCLOUD_TOKEN
 env:
   - GOFLAGS=-mod=vendor GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 go:
   - "1.11.x"
 script:
+  - export HCLOUD_TOKEN=$(./scripts/get-token.sh)
   - make test
   - travis_wait 30 make testacc
   - make

--- a/hcloud/data_source_hcloud_floatingip_test.go
+++ b/hcloud/data_source_hcloud_floatingip_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
@@ -17,12 +19,13 @@ func init() {
 
 func TestAccHcloudDataSourceFloatingIP(t *testing.T) {
 	var floatingIP hcloud.FloatingIP
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccHcloudPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHcloudCheckFloatingIPDataSourceConfig(),
+				Config: testAccHcloudCheckFloatingIPDataSourceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccHcloudCheckFloatingIPExists("data.hcloud_floating_ip.ip_1", &floatingIP),
 					resource.TestCheckResourceAttr(
@@ -30,21 +33,21 @@ func TestAccHcloudDataSourceFloatingIP(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"data.hcloud_floating_ip.ip_1", "home_location", "fsn1"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_floating_ip.ip_1", "description", "Hashi Test"),
+						"data.hcloud_floating_ip.ip_1", "description", fmt.Sprintf("Hashi-Test-%d", rInt)),
 
 					resource.TestCheckResourceAttr(
 						"data.hcloud_floating_ip.ip_2", "type", "ipv4"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_floating_ip.ip_2", "home_location", "fsn1"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_floating_ip.ip_2", "description", "Hashi Test"),
+						"data.hcloud_floating_ip.ip_2", "description", fmt.Sprintf("Hashi-Test-%d", rInt)),
 
 					resource.TestCheckResourceAttr(
 						"data.hcloud_floating_ip.ip_3", "type", "ipv4"),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_floating_ip.ip_3", "home_location", "fsn1"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_floating_ip.ip_3", "description", "Hashi Test"),
+						"data.hcloud_floating_ip.ip_3", "description", fmt.Sprintf("Hashi-Test-%d", rInt)),
 				),
 			},
 		},
@@ -53,18 +56,18 @@ func TestAccHcloudDataSourceFloatingIP(t *testing.T) {
 	testDataSourceCleanup()
 }
 
-func testAccHcloudCheckFloatingIPDataSourceConfig() string {
+func testAccHcloudCheckFloatingIPDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 variable "labels" {
   type = "map"
   default = {
-    "key" = "value"
+    "key" = "%d"
   }
 }
 resource "hcloud_floating_ip" "floating_ip" {
   type      = "ipv4"
   home_location = "fsn1"
-  description = "Hashi Test"
+  description = "Hashi-Test-%d"
   labels  = "${var.labels}"
 }
 data "hcloud_floating_ip" "ip_1" {
@@ -76,7 +79,7 @@ data "hcloud_floating_ip" "ip_2" {
 data "hcloud_floating_ip" "ip_3" {
   with_selector =  "key=${hcloud_floating_ip.floating_ip.labels["key"]}"
 }
-`)
+`, rInt, rInt)
 }
 
 func testDataSourceCleanup() {

--- a/hcloud/data_source_hcloud_server_test.go
+++ b/hcloud/data_source_hcloud_server_test.go
@@ -55,7 +55,7 @@ func testAccHcloudCheckServerDataSourceConfig(rInt int) string {
 variable "labels" {
   type = "map"
   default = {
-    "key" = "value"
+    "key" = "%d"
   }
 }
 resource "hcloud_server" "server" {
@@ -74,5 +74,5 @@ data "hcloud_server" "s_3" {
   with_selector =  "key=${hcloud_server.server.labels["key"]}"
   with_status = ["running","starting"]
 }
-`, rInt)
+`, rInt, rInt)
 }

--- a/hcloud/data_source_hcloud_server_test.go
+++ b/hcloud/data_source_hcloud_server_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
@@ -17,37 +19,38 @@ func init() {
 
 func TestAccHcloudDataSourceServer(t *testing.T) {
 	var server hcloud.Server
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccHcloudPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccHcloudCheckServerDataSourceConfig(),
+				Config: testAccHcloudCheckServerDataSourceConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccHcloudCheckServerExists("hcloud_server.server", &server),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_server.s_1", "server_type", "cx11"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_server.s_1", "name", "Hashi-Test"),
+						"data.hcloud_server.s_1", "name", fmt.Sprintf("Hashi-Test-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"data.hcloud_server.s_1", "backups", "false"),
 
 					resource.TestCheckResourceAttr(
 						"data.hcloud_server.s_2", "server_type", "cx11"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_server.s_2", "name", "Hashi-Test"),
+						"data.hcloud_server.s_2", "name", fmt.Sprintf("Hashi-Test-%d", rInt)),
 
 					resource.TestCheckResourceAttr(
 						"data.hcloud_server.s_3", "server_type", "cx11"),
 					resource.TestCheckResourceAttr(
-						"data.hcloud_server.s_3", "name", "Hashi-Test"),
+						"data.hcloud_server.s_3", "name", fmt.Sprintf("Hashi-Test-%d", rInt)),
 				),
 			},
 		},
 	})
 }
 
-func testAccHcloudCheckServerDataSourceConfig() string {
+func testAccHcloudCheckServerDataSourceConfig(rInt int) string {
 	return fmt.Sprintf(`
 variable "labels" {
   type = "map"
@@ -57,7 +60,7 @@ variable "labels" {
 }
 resource "hcloud_server" "server" {
   server_type      = "cx11"
-  name    = "Hashi-Test"
+  name    = "Hashi-Test-%d"
   labels  = "${var.labels}"
   image   = "ubuntu-18.04"
 }
@@ -71,5 +74,5 @@ data "hcloud_server" "s_3" {
   with_selector =  "key=${hcloud_server.server.labels["key"]}"
   with_status = ["running","starting"]
 }
-`)
+`, rInt)
 }

--- a/hcloud/data_source_hcloud_sshkey_test.go
+++ b/hcloud/data_source_hcloud_sshkey_test.go
@@ -50,7 +50,7 @@ func testAccHcloudCheckSSHKeyDataSourceConfig(rInt int, key string) string {
 variable "labels" {
   type = "map"
   default = {
-    "key" = "value"
+    "key" = "%d"
   }
 }
 resource "hcloud_ssh_key" "sshkey_ds" {
@@ -70,5 +70,5 @@ data "hcloud_ssh_key" "ssh_3" {
 data "hcloud_ssh_key" "ssh_4" {
   with_selector =  "key=${hcloud_ssh_key.sshkey_ds.labels["key"]}"
 }
-`, rInt, key)
+`, rInt, rInt, key)
 }

--- a/hcloud/data_source_hcloud_volume_test.go
+++ b/hcloud/data_source_hcloud_volume_test.go
@@ -52,7 +52,7 @@ func testAccHcloudCheckVolumeDataSourceConfig(rInt int) string {
 variable "labels" {
   type = "map"
   default = {
-    "key" = "value"
+    "key" = "%d"
   }
 }
 resource "hcloud_volume" "volume_ds" {
@@ -70,7 +70,7 @@ data "hcloud_volume" "volume_2" {
 data "hcloud_volume" "volume_3" {
   with_selector =  "key=${hcloud_volume.volume_ds.labels["key"]}"
 }
-`, rInt)
+`, rInt, rInt)
 }
 
 func testAccHcloudCheckVolumeDataSourceLinuxDevice(n string, volume *hcloud.Volume) resource.TestCheckFunc {

--- a/scripts/delete-token.sh
+++ b/scripts/delete-token.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+token=$1
+$(curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"'')

--- a/scripts/delete-token.sh
+++ b/scripts/delete-token.sh
@@ -2,4 +2,4 @@
 
 set -e
 token=$1
-$(curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"'')
+curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X DELETE https://tt-service.hetzner.cloud/token?token=''"$token"''

--- a/scripts/get-token.sh
+++ b/scripts/get-token.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-resp=$(cur# -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
+resp=$(curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
 if grep -q Unauthorized "resp.json"
 then
     cat resp.json

--- a/scripts/get-token.sh
+++ b/scripts/get-token.sh
@@ -2,12 +2,10 @@
 
 set -e
 resp=$(curl -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
-if grep -q Unauthorized "resp.json"
+if grep -q token "resp.json"
 then
-    cat resp.json
-    exit 1
-
-else
     token=$(cat resp.json | jq -r '.token')
     echo $token
+else
+    exit 1
 fi

--- a/scripts/get-token.sh
+++ b/scripts/get-token.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+resp=$(curl --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
+if grep -q Unauthorized "resp.json"
+then
+    echo "Wrong token"
+    exit 1
+
+else
+    token=$(cat resp.json | jq -r '.token')
+    echo $token
+fi

--- a/scripts/get-token.sh
+++ b/scripts/get-token.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 set -e
-resp=$(curl --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
+resp=$(cur# -A 'travis-terraform-provider' --header 'Authorization: Bearer '"$TTS_TOKEN"'' -X POST https://tt-service.hetzner.cloud/token -o resp.json)
 if grep -q Unauthorized "resp.json"
 then
-    echo "Wrong token"
+    cat resp.json
     exit 1
 
 else


### PR DESCRIPTION
The tests fail when running concurrently because we have sometimes a resource with a not unique label value. (on the datasources) or because we set a name to the same value every time. 