### PR TITLE
hcloud_ssh_keys datasource

### DIFF
--- a/hcloud/data_source_hcloud_sshkey.go
+++ b/hcloud/data_source_hcloud_sshkey.go
@@ -80,7 +80,7 @@ func dataSourceHcloudSSHKeyRead(d *schema.ResourceData, m interface{}) (err erro
 			return err
 		}
 		if s == nil {
-			return fmt.Errorf("no sshkey found with name %v", fingerprint)
+			return fmt.Errorf("no sshkey found with fingerprint %v", fingerprint)
 		}
 		setSSHKeySchema(d, s)
 		return

--- a/hcloud/data_source_hcloud_sshkeys.go
+++ b/hcloud/data_source_hcloud_sshkeys.go
@@ -1,0 +1,84 @@
+package hcloud
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+func dataSourceHcloudSSHKeys() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceHcloudSSHKeysRead,
+		Schema: map[string]*schema.Schema{
+			"with_selector": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ssh_keys": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"fingerprint": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"public_key": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+func dataSourceHcloudSSHKeysRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*hcloud.Client)
+
+	labelSelector := d.Get("with_selector")
+	labelSelectorStr, _ := labelSelector.(string)
+
+	opts := hcloud.SSHKeyListOpts{
+		ListOpts: hcloud.ListOpts{
+			LabelSelector: labelSelectorStr,
+		},
+	}
+	keys, err := client.SSHKey.AllWithOpts(context.Background(), opts)
+	if err != nil {
+		return err
+	}
+	var keyMaps []map[string]interface{}
+	id := ""
+	for _, key := range keys {
+		if id != "" {
+			id += "-"
+		}
+		id += fmt.Sprintf("%d", key.ID)
+		keyMaps = append(keyMaps, map[string]interface{}{
+			"id":          key.ID,
+			"name":        key.Name,
+			"fingerprint": key.Fingerprint,
+			"public_key":  key.PublicKey,
+			"labels":      key.Labels,
+		})
+	}
+
+	d.SetId(id)
+	d.Set("ssh_keys", keyMaps)
+	return nil
+}

--- a/hcloud/data_source_hcloud_sshkeys_test.go
+++ b/hcloud/data_source_hcloud_sshkeys_test.go
@@ -1,0 +1,48 @@
+package hcloud
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+const dataSSHKeysConfig = `
+data "hcloud_ssh_keys" "keys_with_label" {
+  with_selector = "foo=bar"
+}
+`
+
+func TestAccHcloudDataSourceSSHKeys(t *testing.T) {
+	rInt := acctest.RandInt()
+	publicKeyMaterial, _, err := acctest.RandSSHKeyPair("hcloud-ds@ssh-acceptance-test")
+	if err != nil {
+		t.Fatalf("Cannot generate test SSH key pair: %s", err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccHcloudPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHcloudCheckSSHKeysDataSourceConfig(rInt, publicKeyMaterial),
+			},
+			{
+				Config: dataSSHKeysConfig,
+				Check: resource.TestCheckResourceAttr(
+					"data.hcloud_ssh_keys.keys_with_label", "ssh_keys.0.name", fmt.Sprintf("sshkeys-%d", rInt)),
+			},
+		},
+	})
+}
+func testAccHcloudCheckSSHKeysDataSourceConfig(rInt int, key string) string {
+	return fmt.Sprintf(`
+resource "hcloud_ssh_key" "sshkeys_ds" {
+  name       = "sshkeys-%d"
+  public_key = "%s"
+  labels  = {
+    foo = "bar"
+  }
+}
+`, rInt, key)
+}

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -54,6 +54,7 @@ func Provider() terraform.ResourceProvider {
 			"hcloud_locations":   dataSourceHcloudLocations(),
 			"hcloud_server":      dataSourceHcloudServer(),
 			"hcloud_ssh_key":     dataSourceHcloudSSHKey(),
+			"hcloud_ssh_keys":    dataSourceHcloudSSHKeys(),
 			"hcloud_volume":      dataSourceHcloudVolume(),
 			"hcloud_network":     dataSourceHcloudNetwork(),
 		},

--- a/website/docs/d/ssh_keys.html.md
+++ b/website/docs/d/ssh_keys.html.md
@@ -1,0 +1,33 @@
+---
+layout: "hcloud"
+page_title: "Hetzner Cloud: hcloud_ssh_keys"
+sidebar_current: "docs-hcloud-datasource-ssh-keys"
+description: |-
+  Provides details about multiple Hetzner Cloud SSH Keys.
+---
+
+# Data Source: hcloud_sshkey
+
+Provides details about Hetzner Cloud SSH Keys.
+This resource is useful if you want to use a non-terraform managed SSH Key.
+
+## Example Usage
+
+```hcl
+data "hcloud_ssh_keys" "all_keys" {
+}
+data "hcloud_ssh_keys" "keys_by_selector" {
+  with_selector = "foo=bar"
+}
+resource "hcloud_server" "main" {
+  ssh_keys  = "${data.hcloud_ssh_keys.all_keys.ssh_keys.*.name}"
+}
+```
+
+## Argument Reference
+
+- `with_selector` - (Optional, string) [Label selector](https://docs.hetzner.cloud/#overview-label-selector)
+
+## Attributes Reference
+
+- `ssh_keys` - (list) List of all matches SSH keys. See `data.hcloud_ssh_key` for schema.


### PR DESCRIPTION
As discussed in https://github.com/terraform-providers/terraform-provider-hcloud/issues/95, adds a resource to retrieve multiple ssh keys by label selector. If no label selector is specified, returns all ssh keys associated with the project.

Also, sneaks in a commit to fix a typo in an error message. I ran the acceptance tests `TestAccHcloudDataSourceSSHKey` and `TestAccHcloudDataSourceSSHKeys` against a new Hetzner Cloud project.