### PR TITLE
Bugfix for private isos

### DIFF
--- a/hcloud/resource_hcloud_server.go
+++ b/hcloud/resource_hcloud_server.go
@@ -389,7 +389,7 @@ func setBackups(ctx context.Context, client *hcloud.Client, server *hcloud.Serve
 	return nil
 }
 
-func setISO(ctx context.Context, client *hcloud.Client, server *hcloud.Server, iso string) error {
+func setISO(ctx context.Context, client *hcloud.Client, server *hcloud.Server, isoIDOrName string) error {
 	isoChange := false
 	if server.ISO != nil {
 		isoChange = true
@@ -401,9 +401,19 @@ func setISO(ctx context.Context, client *hcloud.Client, server *hcloud.Server, i
 			return err
 		}
 	}
-	if iso != "" {
+	if isoIDOrName != "" {
 		isoChange = true
-		action, _, err := client.Server.AttachISO(ctx, server, &hcloud.ISO{Name: iso})
+
+		iso, _, err := client.ISO.Get(ctx, isoIDOrName)
+		if err != nil {
+			return err
+		}
+
+		if iso == nil {
+			return fmt.Errorf("ISO not found: %s", isoIDOrName)
+		}
+
+		action, _, err := client.Server.AttachISO(ctx, server, iso)
 		if err != nil {
 			return err
 		}

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -37,7 +37,7 @@ data "hcloud_server" "s_3" {
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (boolean) Whether backups are enabled.
-- `iso` - (string) Name of the mounted ISO image.
+- `iso` - (string) ID or Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.
 - `ipv6_network` - (string) The IPv6 network.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -33,7 +33,7 @@ The following arguments are supported:
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation
 - `ssh_keys` - (Optional, list) SSH key IDs or names which should be injected into the server at creation time
 - `keep_disk` - (Optional, bool) If true, do not upgrade the disk. This allows downgrading the server type later.
-- `iso` - (Optional, string) Name of an ISO image to mount.
+- `iso` - (Optional, string) ID or Name of an ISO image to mount.
 - `rescue` - (Optional, string) Enable and boot in to the specified rescue system. This enables simple installation of custom operating systems. `linux64` `linux32` or `freebsd64`
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `backups` - (Optional, boolean) Enable or disable backups.
@@ -50,7 +50,7 @@ The following attributes are exported:
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (boolean) Whether backups are enabled.
-- `iso` - (string) Name of the mounted ISO image.
+- `iso` - (string) ID or Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.
 - `ipv6_network` - (string) The IPv6 network.


### PR DESCRIPTION
According to the documentation, ISOs can currently only be specified by their name. As private ISOs do not have a name, the server ressource should support ID/name.

Unfortunately I could not create an acceptance testcase with a private ISO, as you can not upload it via the API.