### PR TITLE
Fix typos in ssh key datasources

### DIFF
--- a/website/docs/d/ssh_key.html.md
+++ b/website/docs/d/ssh_key.html.md
@@ -5,7 +5,7 @@ sidebar_current: "docs-hcloud-datasource-ssh-key"
 description: |-
   Provides details about a specific Hetzner Cloud SSH Key.
 ---
-# Data Source: hcloud_sshkey
+# Data Source: hcloud_ssh_key
 Provides details about a Hetzner Cloud SSH Key.
 This resource is useful if you want to use a non-terraform managed SSH Key.
 ## Example Usage

--- a/website/docs/d/ssh_keys.html.md
+++ b/website/docs/d/ssh_keys.html.md
@@ -6,7 +6,7 @@ description: |-
   Provides details about multiple Hetzner Cloud SSH Keys.
 ---
 
-# Data Source: hcloud_sshkey
+# Data Source: hcloud_ssh_keys
 
 Provides details about Hetzner Cloud SSH Keys.
 This resource is useful if you want to use a non-terraform managed SSH Key.


### PR DESCRIPTION
I've also noticed that https://www.terraform.io/docs/providers/hcloud/d/ssh_keys.html (plural, not singular) is not discoverable in the navigation menus on the left, but I'm not sure how to fix this.