### PR TITLE
Fix rescue mode timing

### DIFF
--- a/hcloud/resource_hcloud_server.go
+++ b/hcloud/resource_hcloud_server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -205,6 +206,7 @@ func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if rescue, ok := d.GetOk("rescue"); ok {
+		time.Sleep(1 * time.Second)
 		if err := setRescue(ctx, client, res.Server, rescue.(string), opts.SSHKeys); err != nil {
 			return err
 		}


### PR DESCRIPTION
Workaround for a timing issue when entering rescue mode during creation
of hcloud_server resources

Found this problem while trying to deploy a Flatcar Linux cluster on Hetzner Cloud via rescue mode and a remote-exec provisioner. When creating a bunch of hcloud_server instances with the rescue attribute enabled, entering rescue mode fails pretty reproducably for any count > 2 (I could even get it with count = 1, but only very infrequently). Example:

resource "hcloud_server" "ticket-2019110203010522" {
  count       = 3
  name        = "ticket-2019110203010522-${count.index}"
  server_type = "cx11"
  image       = "fedora-31"
  location    = "nbg1"
  rescue      = "linux64"
}

Resulting error is just:


Error: Unknown Error (unknown_error)

  on main.tf line 5, in resource "hcloud_server" "ticket-2019110203010522":
   5: resource "hcloud_server" "ticket-2019110203010522" {

(with TF_LOG, terraform apply with actually hang in a loop, so I can't paste any useful debug output).

In the cloud console I just get "Server Notfallsystem konnte nicht aktiviert werden" (Couldn't activate rescue system).

I wouldn't consider this change a real fix, but a (for me) very reliable workaround.

Hetzner support ticket #2019110203010522 for anyone with access to it.