### PR TITLE
resources/hcloud_server: Add retry mechanism for enabling the rescue mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 1.14.1 (Unreleased)
+## 1.15.0 (Unreleased)
+
+IMPROVEMENTS:
+
+* resources/hcloud_server: Add retry mechanism for enabling the rescue mode.
+
+NOTES:
+* This release uses Terraform Plugin SDK v1.3.0.
+
 ## 1.14.0 (October 01, 2019)
 
 NOTES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 TEST?=$$(go list ./... |grep -v 'vendor')
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
-VERSION="v1.11-internal"
+VERSION=$(shell ./scripts/git-version.sh)
 PKG_NAME=hcloud
 WEBSITE_REPO=github.com/hashicorp/terraform-website
 export CGO_ENABLED:=0


### PR DESCRIPTION
Sometimes the enabling of the rescue mode fails because of a host-side behavior. After talking to Jonas, we should just retry in this case. 