### PR TITLE
resource/hcloud_ssh_key: Fix panic when we update labels in SSH keys

### DIFF
--- a/hcloud/resource_hcloud_sshkey.go
+++ b/hcloud/resource_hcloud_sshkey.go
@@ -133,7 +133,10 @@ func resourceSSHKeyUpdate(d *schema.ResourceData, m interface{}) error {
 		d.SetPartial("name")
 	}
 	if d.HasChange("labels") {
-		labels := d.Get("labels").(map[string]string)
+		labels := make(map[string]string)
+		for k, v := range d.Get("labels").(map[string]interface{}) {
+			labels[k] = v.(string)
+		}
 		_, _, err := client.SSHKey.Update(ctx, &hcloud.SSHKey{ID: sshKeyID}, hcloud.SSHKeyUpdateOpts{
 			Labels: labels,
 		})


### PR DESCRIPTION
First of all, thanks for this provider.
I found a panic behavior when we update a label on an existing SSH key; `d.Get("labels").(map[string]string)` expects a `map[string]string` but `d.Get("labels")` returns a `map[string]interface{}`.

I don't know if I need to create an issue before, but I fixed it using the same way you made for the SSH key creation (https://github.com/xunleii/terraform-provider-hcloud/blob/43e0b1e25040230cf54935219b1f104079bd1429/hcloud/resource_hcloud_sshkey.go#L67).