### PR TITLE
Adjust Image Name Attribute Documentation

### DIFF
--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -21,7 +21,7 @@ data "hcloud_image" "image_3" {
 }
 
 resource "hcloud_server" "main" {
-  image  = "${data.hcloud_image.image_1.name}"
+  image  = "${data.hcloud_image.image_1.id}"
 }
 ```
 ## Argument Reference

--- a/website/docs/d/image.html.md
+++ b/website/docs/d/image.html.md
@@ -21,7 +21,7 @@ data "hcloud_image" "image_3" {
 }
 
 resource "hcloud_server" "main" {
-  image  = "${data.hcloud_image.image_1.id}"
+  image  = "${data.hcloud_image.image_1.name}"
 }
 ```
 ## Argument Reference
@@ -33,7 +33,7 @@ resource "hcloud_server" "main" {
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Image.
-- `name` - (string) Name of the Image.
+- `name` - (string) Name of the Image, only present when the Image is of type `system`.
 - `type` - (string) Type of the Image, could be `system`, `backup` or `snapshot`.
 - `status` - (string) Status of the Image.
 - `description` - (string) Description of the Image.


### PR DESCRIPTION
provider 1.15 outputs this error: "Error: "image" must have more then 0 characters. Have you set the name instead of an ID?" when name attribute is used. By using id, it works fine.