### PR TITLE
New resource hcloud_load_balancer_target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 1.18.0 (Unreleased)
+
+FEATURES:
+
+* **New Resource**: `hcloud_load_balancer_target` which allows to add a
+  target to a load balancer. This resource extends the `target` property
+  of the `hcloud_load_balancer` resource.  `hcloud_load_balancer_target`
+  should be preferred over the `target` property of
+  `hcloud_load_balancer`.
+
 ## 1.17.0 (June 22, 2020)
 
 FEATURES:

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 			"hcloud_load_balancer":          resourceLoadBalancer(),
 			"hcloud_load_balancer_service":  resourceLoadBalancerService(),
 			"hcloud_load_balancer_network":  resourceLoadBalancerNetwork(),
+			"hcloud_load_balancer_target":   resourceLoadBalancerTarget(),
 			"hcloud_certificate":            resourceCertificate(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{

--- a/hcloud/resource_hcloud_load_balancer.go
+++ b/hcloud/resource_hcloud_load_balancer.go
@@ -99,9 +99,10 @@ func resourceLoadBalancer() *schema.Resource {
 							Optional: true,
 						},
 						"use_private_ip": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							Default:  false,
+							Type:       schema.TypeBool,
+							Optional:   true,
+							Default:    false,
+							Deprecated: "Does not work. Use the hcloud_load_balancer_target resource instead.",
 						},
 					},
 				},
@@ -371,8 +372,7 @@ func parseTerraformTarget(tfTargets []interface{}) (opts []hcloud.LoadBalancerCr
 	for _, _tfTarget := range tfTargets {
 		tfTarget := _tfTarget.(map[string]interface{})
 		opt := hcloud.LoadBalancerCreateOptsTarget{
-			Type:         hcloud.LoadBalancerTargetType(tfTarget["type"].(string)),
-			UsePrivateIP: hcloud.Bool(tfTarget["use_private_ip"].(bool)),
+			Type: hcloud.LoadBalancerTargetType(tfTarget["type"].(string)),
 		}
 		if serverID, ok := tfTarget["server_id"]; ok {
 			opt.Server = hcloud.LoadBalancerCreateOptsTargetServer{Server: &hcloud.Server{ID: serverID.(int)}}

--- a/hcloud/resource_hcloud_load_balancer_target.go
+++ b/hcloud/resource_hcloud_load_balancer_target.go
@@ -1,0 +1,239 @@
+package hcloud
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+var errLoadBalancerTargetNotFound = errors.New("load balancer target not found")
+
+func resourceLoadBalancerTarget() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLoadBalancerTargetCreate,
+		Read:   resourceLoadBalancerTargetRead,
+		Update: resourceLoadBalancerTargetUpdate,
+		Delete: resourceLoadBalancerTargetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"type": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"server"}, false),
+				Required:     true,
+			},
+			"load_balancer_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"server_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"use_private_ip": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLoadBalancerTargetCreate(d *schema.ResourceData, m interface{}) error {
+	var usePrivateIP bool
+
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+
+	tgtType := d.Get("type").(string)
+	if tgtType != "server" {
+		return fmt.Errorf("unsupported target type: %s", tgtType)
+	}
+
+	lbID := d.Get("load_balancer_id").(int)
+	lb, _, err := client.LoadBalancer.GetByID(ctx, lbID)
+	if err != nil {
+		return fmt.Errorf("get load balancer by id: %d: %v", lbID, err)
+	}
+	if lb == nil {
+		return fmt.Errorf("load balancer %d: not found", lbID)
+	}
+
+	sid, ok := d.GetOk("server_id")
+	if !ok {
+		return fmt.Errorf("target type server: missing server_id")
+	}
+	serverID := sid.(int)
+
+	server, _, err := client.Server.GetByID(ctx, serverID)
+	if err != nil {
+		return fmt.Errorf("get server by id: %d: %v", serverID, err)
+	}
+	if server == nil {
+		return fmt.Errorf("server %d: not found", serverID)
+	}
+
+	opts := hcloud.LoadBalancerAddServerTargetOpts{
+		Server: server,
+	}
+	if v, ok := d.GetOk("use_private_ip"); ok {
+		usePrivateIP = v.(bool)
+		opts.UsePrivateIP = hcloud.Bool(usePrivateIP)
+	}
+
+	if usePrivateIP && len(lb.PrivateNet) == 0 {
+		log.Printf("[INFO] Load balancer (%d) not (yet) attached to a network. Retrying in one second", lb.ID)
+		time.Sleep(time.Second)
+
+		lb, _, err = client.LoadBalancer.GetByID(ctx, lbID)
+		if err != nil {
+			return fmt.Errorf("get load balancer by id: %d: %v", lbID, err)
+		}
+		if lb == nil {
+			return fmt.Errorf("load balancer %d: not found", lbID)
+		}
+	}
+
+	action, _, err := client.LoadBalancer.AddServerTarget(ctx, lb, opts)
+	if err != nil {
+		return fmt.Errorf("add server target: %v", err)
+	}
+	if err := waitForLoadBalancerAction(ctx, client, action, lb); err != nil {
+		return fmt.Errorf("add server target: %v", err)
+	}
+	setLoadBalancerTarget(d, lb.ID, hcloud.LoadBalancerTarget{
+		Type:         hcloud.LoadBalancerTargetTypeServer,
+		Server:       &hcloud.LoadBalancerTargetServer{Server: server},
+		UsePrivateIP: usePrivateIP,
+	})
+	return nil
+}
+
+func resourceLoadBalancerTargetRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+	lbID := d.Get("load_balancer_id").(int)
+
+	_, tgt, err := findLoadBalancerTarget(ctx, client, lbID, d)
+	if err != nil {
+		return err
+	}
+
+	setLoadBalancerTarget(d, lbID, tgt)
+	return nil
+}
+
+func resourceLoadBalancerTargetUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+	lbID := d.Get("load_balancer_id").(int)
+
+	lb, tgt, err := findLoadBalancerTarget(ctx, client, lbID, d)
+	if errors.Is(err, errLoadBalancerTargetNotFound) {
+		return resourceLoadBalancerTargetCreate(d, m)
+	}
+	if err != nil {
+		return err
+	}
+
+	action, _, err := client.LoadBalancer.RemoveServerTarget(ctx, lb, tgt.Server.Server)
+	if hcloud.IsError(err, hcloud.ErrorCodeConflict) || hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+		// Retry after a short delay
+		time.Sleep(time.Second)
+		action, _, err = client.LoadBalancer.RemoveServerTarget(ctx, lb, tgt.Server.Server)
+	}
+	if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+		return resourceLoadBalancerTargetCreate(d, m)
+	}
+	if err != nil {
+		return fmt.Errorf("remove existing target: %v", err)
+	}
+	if err := waitForLoadBalancerAction(ctx, client, action, lb); err != nil {
+		return fmt.Errorf("remove existing target: %v", err)
+	}
+
+	return resourceLoadBalancerTargetCreate(d, m)
+}
+
+func resourceLoadBalancerTargetDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*hcloud.Client)
+	ctx := context.Background()
+	lbID := d.Get("load_balancer_id").(int)
+
+	lb, tgt, err := findLoadBalancerTarget(ctx, client, lbID, d)
+	if errors.Is(err, errLoadBalancerTargetNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	action, _, err := client.LoadBalancer.RemoveServerTarget(ctx, lb, tgt.Server.Server)
+	if hcloud.IsError(err, hcloud.ErrorCodeConflict) || hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+		// Retry after a short delay
+		time.Sleep(time.Second)
+		action, _, err = client.LoadBalancer.RemoveServerTarget(ctx, lb, tgt.Server.Server)
+	}
+	if err != nil {
+		if hcErr, ok := err.(hcloud.Error); ok {
+			if hcErr.Code == "load_balancer_target_not_found" || strings.Contains(hcErr.Message, "target not found") {
+				// Target has been deleted already (e.g. by deleting the
+				// network it was attached to)
+				return nil
+			}
+		}
+		return fmt.Errorf("remove server target: %v", err)
+	}
+	if err := waitForLoadBalancerAction(ctx, client, action, lb); err != nil {
+		return fmt.Errorf("remove server target: wait for action: %v", err)
+	}
+
+	return nil
+}
+
+func findLoadBalancerTarget(
+	ctx context.Context, client *hcloud.Client, lbID int, d *schema.ResourceData,
+) (*hcloud.LoadBalancer, hcloud.LoadBalancerTarget, error) {
+	var serverID int
+
+	lb, _, err := client.LoadBalancer.GetByID(ctx, lbID)
+	if err != nil {
+		return nil, hcloud.LoadBalancerTarget{}, fmt.Errorf("get load balancer by id: %d: %v", lbID, err)
+	}
+	if lb == nil {
+		return nil, hcloud.LoadBalancerTarget{}, fmt.Errorf("load balancer %d: not found", lbID)
+	}
+	if sid, ok := d.GetOk("server_id"); ok {
+		serverID = sid.(int)
+	}
+
+	for _, tgt := range lb.Targets {
+		if tgt.Type == hcloud.LoadBalancerTargetTypeServer && tgt.Server.Server.ID == serverID {
+			return lb, tgt, nil
+		}
+	}
+	return nil, hcloud.LoadBalancerTarget{}, errLoadBalancerTargetNotFound
+}
+
+func setLoadBalancerTarget(d *schema.ResourceData, lbID int, tgt hcloud.LoadBalancerTarget) {
+	d.Set("type", tgt.Type)
+	d.Set("load_balancer_id", lbID)
+	d.Set("use_private_ip", tgt.UsePrivateIP)
+
+	if tgt.Type == hcloud.LoadBalancerTargetTypeServer {
+		d.Set("server_id", tgt.Server.Server.ID)
+
+		tgtID := generateLoadBalancerServerTargetID(tgt.Server.Server, lbID)
+		d.SetId(tgtID)
+	}
+}
+
+func generateLoadBalancerServerTargetID(srv *hcloud.Server, lbID int) string {
+	return fmt.Sprintf("lb-srv-tgt-%d-%d", srv.ID, lbID)
+}

--- a/hcloud/resource_hcloud_load_balancer_target_test.go
+++ b/hcloud/resource_hcloud_load_balancer_target_test.go
@@ -1,0 +1,147 @@
+package hcloud
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+func TestAccHcloudLoadBalancerTarget(t *testing.T) {
+	var (
+		lb  hcloud.LoadBalancer
+		srv hcloud.Server
+	)
+
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccHcloudPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccHcloudLoadBalancerTarget(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccHcloudCheckLoadBalancerExists("hcloud_load_balancer.target_test_lb", &lb),
+					testAccHcloudCheckServerExists("hcloud_server.lb_server_target", &srv),
+					testAccHcloudLoadBalancerTargetHasServerTarget("lb_test_target", &srv, &lb),
+				),
+			},
+			{
+
+				Config: testAccHcloudLoadBalancerTarget_UsePrivateIP(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccHcloudCheckLoadBalancerExists("hcloud_load_balancer.target_test_lb", &lb),
+					testAccHcloudCheckServerExists("hcloud_server.lb_server_target", &srv),
+					testAccHcloudLoadBalancerTargetHasServerTarget("lb_test_target", &srv, &lb),
+					resource.TestCheckResourceAttr("hcloud_load_balancer_target.lb_test_target", "use_private_ip", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccHcloudLoadBalancerTarget(rInt int) string {
+	return fmt.Sprintf(`
+resource "hcloud_server" "lb_server_target" {
+	name        = "lb-server-target-%d"
+	server_type = "cx11"
+	image       = "ubuntu-18.04"
+}
+
+resource "hcloud_load_balancer" "target_test_lb" {
+	name               = "target-test-lb-%d"
+	load_balancer_type = "lb11"
+	network_zone       = "eu-central"
+
+	algorithm {
+		type = "round_robin"
+	}
+}
+
+resource "hcloud_load_balancer_target" "lb_test_target" {
+	type             = "server"
+	load_balancer_id = "${hcloud_load_balancer.target_test_lb.id}"
+	server_id        = "${hcloud_server.lb_server_target.id}"
+}
+	`, rInt, rInt)
+}
+
+func testAccHcloudLoadBalancerTarget_UsePrivateIP(rInt int) string {
+	return fmt.Sprintf(`
+resource "hcloud_network" "lb_target_test_network" {
+	name         = "lb-target-test-network-%d"
+	ip_range     = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "lb_target_test_subnet" {
+	network_id   = "${hcloud_network.lb_target_test_network.id}"
+	type         = "cloud"
+	network_zone = "eu-central"
+	ip_range     = "10.0.1.0/24"
+}
+
+resource "hcloud_server" "lb_server_target" {
+	name        = "lb-server-target-%d"
+	server_type = "cx11"
+	image       = "ubuntu-18.04"
+}
+
+resource "hcloud_server_network" "lb_server_network" {
+	server_id  = "${hcloud_server.lb_server_target.id}"
+	network_id = "${hcloud_network.lb_target_test_network.id}"
+}
+
+resource "hcloud_load_balancer" "target_test_lb" {
+	name               = "target-test-lb-%d"
+	load_balancer_type = "lb11"
+	network_zone       = "eu-central"
+
+	algorithm {
+		type = "round_robin"
+	}
+}
+
+resource "hcloud_load_balancer_network" "target_test_lb_network" {
+	load_balancer_id        = "${hcloud_load_balancer.target_test_lb.id}"
+	network_id              = "${hcloud_network.lb_target_test_network.id}"
+	enable_public_interface = true
+}
+
+resource "hcloud_load_balancer_target" "lb_test_target" {
+	type             = "server"
+	load_balancer_id = "${hcloud_load_balancer.target_test_lb.id}"
+	server_id        = "${hcloud_server.lb_server_target.id}"
+	use_private_ip   = true
+}
+	`, rInt, rInt, rInt)
+}
+
+func testAccHcloudLoadBalancerTargetHasServerTarget(
+	name string, srv *hcloud.Server, lb *hcloud.LoadBalancer,
+) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resName := fmt.Sprintf("hcloud_load_balancer_target.%s", name)
+		if err := resource.TestCheckResourceAttr(resName, "type", "server")(s); err != nil {
+			return err
+		}
+		if err := resource.TestCheckResourceAttr(resName, "load_balancer_id", strconv.Itoa(lb.ID))(s); err != nil {
+			return err
+		}
+		if err := resource.TestCheckResourceAttr(resName, "server_id", strconv.Itoa(srv.ID))(s); err != nil {
+			return err
+		}
+
+		for _, tgt := range lb.Targets {
+			if tgt.Type == hcloud.LoadBalancerTargetTypeServer && tgt.Server.Server.ID == srv.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("load balancer has no target for server with id: %d", srv.ID)
+	}
+}

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -44,9 +44,8 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `type` - (Required, string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`
 
 `target` support the following fields:
-- `type` - (Required, string) Type of the target. `server` or `label_selector`
+- `type` - (Required, string) Type of the target. `server`
 - `server_id` - (Optional, int) ID of the server which should be a target for this Load Balancer. Required if `type` is `server`
-- `label_selector` - (Optional, string) Label Selector to add a group of resources based on the label. Required if `type` is `label_selector`
 
 
 ## Attributes Reference
@@ -65,10 +64,10 @@ resource "hcloud_load_balancer" "load_balancer" {
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connection`
 
-`target` support the following fields:
-- `type` - (string) Type of the target. `server` or `label_selector`
+`target` supports the following fields, which are a restricted sub-set
+of the fields supported by `hcloud_load_balancer_target`:
+- `type` - (string) Type of the target. `server`
 - `server_id` - (int) ID of the server which should be a target for this Load Balancer.
-- `label_selector` - (string) Label Selector to add a group of resources based on the label.
 
 ## Import
 

--- a/website/docs/r/load_balancer_target.html.md
+++ b/website/docs/r/load_balancer_target.html.md
@@ -1,0 +1,51 @@
+---
+layout: "hcloud"
+page_title: "Hetzner Cloud: hcloud_load_balancer_target"
+sidebar_current: "docs-hcloud-resource-load-balancer-target-x"
+description: |-
+  Adds a target to a Hetzner Cloud Load Balancer.
+---
+
+# hcloud_load_balancer_target
+
+Adds a target to a Hetzner Cloud Load Balancer.
+
+## Example Usage
+
+```hcl
+resource "hcloud_server" "my_server" {
+  name        = "my-server"
+  server_type = "cx11"
+  image       = "ubuntu-18.04"
+}
+
+resource "hcloud_load_balancer" "load_balancer" {
+  name               = "my-load-balancer"
+  load_balancer_type = "lb11"
+  location           = "nbg1"
+}
+
+resource "hcloud_load_balancer_target" "load_balancer_target" {
+  type             = "server"
+  load_balancer_id = "${hcloud_load_balancer.load_balcancer.id}"
+  server_id        = "${hcloud_server.my_server.id}"
+}
+```
+
+## Argument Reference
+
+- `type` - (Required, string) Type of the target. `server`
+- `load_balancer_id` - (Required, int) ID of the Load Balancer to which
+  the target gets attached.
+- `server_id` - (Optional, int) ID of the server which should be a
+  target for this Load Balancer. Required if `type` is `server`
+- `use_private_ip` - (Optional, string) use the private IP to connect to
+  Load Balancer targets.
+
+## Attributes Reference
+
+- `type` - (string) Type of the target. `server`
+- `server_id` - (int) ID of the server which should be a target for this
+  Load Balancer.
+- `use_private_ip` - (string) use the private IP to connect to Load
+  Balancer targets.


### PR DESCRIPTION
While investigating #170 it we discovered a chicken and egg problem with
respect to the `use_private_ip` property:

The load balancer needs to be attached to a private network for
`use_private_ip` to work. Attaching the load balancer to a private
network is done using the `hcloud_load_balancer_network` resource, which
requires a load balancer id to be set. Therefore the load balancer can
never be attached to a private network upon creation and thus setting
`use_private_ip` to true will always fail.

This PR deprecates the `use_private_ip` property in the
`hcloud_load_balancer` resource. Instead it introduces a new resource
`hcloud_load_balancer_target` which allows to set `use_private_ip` after
the load balancer has been attached to a private network.