### PR TITLE
Fix HTTP health check defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 1.19.0 (Unreleased)
+
+BUG FIXES
+
+* Set correct defaults for `cookie_name` and `cookie_lifetime`
+  properties of `hcloud_load_balancer_service`.
+* Remove unsupported `https` protocol from health check documentation.
+
 ## 1.18.0 (June 30, 2020)
 
 FEATURES:

--- a/hcloud/resource_hcloud_load_balancer_service.go
+++ b/hcloud/resource_hcloud_load_balancer_service.go
@@ -385,10 +385,10 @@ func parseTFHTTP(tfHTTP []interface{}) *hcloud.LoadBalancerAddServiceOptsHTTP {
 	if stickySessions, ok := httpMap["sticky_sessions"]; ok {
 		http.StickySessions = hcloud.Bool(stickySessions.(bool))
 	}
-	if cookieName, ok := httpMap["cookie_name"]; ok {
+	if cookieName, ok := httpMap["cookie_name"]; ok && cookieName != "" {
 		http.CookieName = hcloud.String(cookieName.(string))
 	}
-	if cookieLifetime, ok := httpMap["cookie_lifetime"]; ok {
+	if cookieLifetime, ok := httpMap["cookie_lifetime"]; ok && cookieLifetime != 0 {
 		http.CookieLifetime = hcloud.Duration(time.Duration(cookieLifetime.(int)) * time.Second)
 	}
 

--- a/hcloud/resource_hcloud_load_balancer_target_test.go
+++ b/hcloud/resource_hcloud_load_balancer_target_test.go
@@ -117,6 +117,8 @@ resource "hcloud_load_balancer_target" "lb_test_target" {
 	load_balancer_id = "${hcloud_load_balancer.target_test_lb.id}"
 	server_id        = "${hcloud_server.lb_server_target.id}"
 	use_private_ip   = true
+
+	depends_on = [ hcloud_load_balancer_network.target_test_lb_network ]
 }
 	`, rInt, rInt, rInt)
 }

--- a/website/docs/r/load_balancer_service.html.md
+++ b/website/docs/r/load_balancer_service.html.md
@@ -45,12 +45,12 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 
 `health_check` supports the following fields:
 
-- `protocol` - (Required, string) Protocol the health check uses. `http`, `https` or `tcp`
+- `protocol` - (Required, string) Protocol the health check uses. `http` or `tcp`
 - `port` - (Optional, int) Port the health check tries to connect to, required if protocol is `tcp`. Can be everything between `1` and `65535`. Must be unique per Load Balancer.
 - `interval` - (Optional, int) Interval how often the health check will be performed, in seconds. Default: `15`
 - `timeout` - (Optional, int) Timeout when a health check try will be canceled if there is no response, in seconds. Default: `10`
 - `retries` - (Optional, int) Number of tries a health check will be performed until a target will be listed as `unhealthy`. Default: `3`
-- `http` - (Optional, list) List of http configurations when `protocol` is `http` or `https`.
+- `http` - (Optional, list) List of http configurations. Required if `protocol` is `http`.
 
 (health check) `http` supports the following fields:
 
@@ -58,7 +58,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `path` - (Optional, string) Path we try to access when performing the Health Check.
 - `response` - (Optional, string) Response we expect to be included in the Target response when a Health Check was performed.
 - `tls` - (Optional, bool) Enable TLS certificate checking.
-- `status_codes` - (Optional, list[int]) We expect that the target answers with these status codes. If not the target is marked as `unhealthy`.
+- `status_codes` - (Required, list[string]) We expect that the target answers with these status codes. If not the target is marked as `unhealthy`.
 
 
 ## Attribute Reference
@@ -83,7 +83,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `interval` - (int) Interval how often the health check will be performed, in seconds.
 - `timeout` - (int) Timeout when a health check try will be canceled if there is no response, in seconds.
 - `retries` - (int) Number of tries a health check will be performed until a target will be listed as `unhealthy`.
-- `http` - (list) List of http configurations when `protocol` is `http` or `https`.
+- `http` - (list) List of http configurations when `protocol` is `http`.
 
 (health check) `http` supports the following fields:
 
@@ -91,4 +91,4 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `path` - (string) Path we try to access when performing the Health Check.
 - `response` - (string) Response we expect to be included in the Target response when a Health Check was performed.
 - `tls` - (bool) Enable TLS certificate checking.
-- `status_codes` - (list[int]) We expect that the target answers with these status codes. If not the target is marked as `unhealthy`.
+- `status_codes` - (list[string]) We expect that the target answers with these status codes. If not the target is marked as `unhealthy`.


### PR DESCRIPTION
The default values for HTTP health checks were not set as documented.

Additionally the documentation stated a health check protocol `https`
which does not exist. To enable TLS support for HTTP health checks the
protocol `http` has to be used and the `tls` property has to be set to
true.

Closes #173