### PR TITLE
force recreate of hcloud_network if ip_range changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ BUG FIXES
 * Set correct defaults for `cookie_name` and `cookie_lifetime`
   properties of `hcloud_load_balancer_service`.
 * Remove unsupported `https` protocol from health check documentation.
+* Force recreate of `hcloud_network` if `ip_range` changes
 
 ## 1.18.0 (June 30, 2020)
 

--- a/hcloud/resource_hcloud_network.go
+++ b/hcloud/resource_hcloud_network.go
@@ -28,6 +28,7 @@ func resourceNetwork() *schema.Resource {
 			"ip_range": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"labels": {
 				Type:     schema.TypeMap,


### PR DESCRIPTION
This change forces a recreation of a network if the `ip_range` is changed.

```
  # hcloud_network.testnet must be replaced
-/+ resource "hcloud_network" "testnet" {
      ~ id       = "111823" -> (known after apply)
      ~ ip_range = "192.168.42.0/24" -> "192.168.44.0/24" # forces replacement
      - labels   = {} -> null
        name     = "testnet"
    }
```

This should fix #179 