### PR TITLE
Determine default listen port based on protocol

### DIFF
--- a/hcloud/resource_hcloud_load_balancer_service.go
+++ b/hcloud/resource_hcloud_load_balancer_service.go
@@ -301,8 +301,22 @@ func resourceLoadBalancerServiceDelete(d *schema.ResourceData, m interface{}) er
 		return err
 	}
 
+	protocol := d.Get("protocol")
+	listenPort := d.Get("listen_port").(int)
+	if listenPort == 0 {
+		if protocol == hcloud.LoadBalancerServiceProtocolHTTP {
+			listenPort = 80
+		}
+		if protocol == hcloud.LoadBalancerServiceProtocolHTTPS {
+			listenPort = 443
+		}
+	}
+
 	for _, svc := range lb.Services {
-		action, _, err := client.LoadBalancer.DeleteService(ctx, lb, svc.ListenPort)
+		if svc.ListenPort != listenPort {
+			continue
+		}
+		action, _, err := client.LoadBalancer.DeleteService(ctx, lb, listenPort)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As discovered by @vmozgovoy in PR #185 the listen port needs to be
derived from the protocol if it is not set in the Terraform
configuration. This commit extracts @vmozgovoy's solution as PR#185
contains additional changes which are already fixed in hcloud-go
v1.18.2.