### PR TITLE
Enable and Disable `proxyprotocol` on a Load Balancer didn't work after creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGED:
   stuck with the `network_id` property can create an explicit dependency
   on the subnet using `depends_on` to work around this issue.
 
+BUG FIXES:
+* Enable and Disable `proxyprotocol` on a Load Balancer didn't work after creation
+
 ## 1.19.1 (July 16, 2020)
 
 NOTES:

--- a/hcloud/resource_hcloud_load_balancer_service.go
+++ b/hcloud/resource_hcloud_load_balancer_service.go
@@ -231,6 +231,9 @@ func resourceLoadBalancerServiceUpdate(d *schema.ResourceData, m interface{}) er
 	}
 	listenPort := lp.(int)
 
+	pp := d.Get("proxyprotocol")
+	opts.Proxyprotocol = hcloud.Bool(pp.(bool))
+
 	if p, ok := d.GetOk("destination_port"); ok {
 		opts.DestinationPort = hcloud.Int(p.(int))
 	}

--- a/internal/loadbalancer/resource_service_test.go
+++ b/internal/loadbalancer/resource_service_test.go
@@ -50,6 +50,31 @@ func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 					resource.TestCheckResourceAttr(svcResName, "proxyprotocol", "true"),
 				),
 			},
+
+			{ // Test disable Proxyprotocol
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
+						Name:            svcName,
+						Protocol:        "tcp",
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						ListenPort:      70,
+						DestinationPort: 70,
+						Proxyprotocol:   false,
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(lbResName, loadbalancer.ByID(t, &lb)),
+					testsupport.LiftTCF(hasService(&lb, 70)),
+					testsupport.CheckResourceAttrFunc(svcResName, "load_balancer_id", func() string {
+						return strconv.Itoa(lb.ID)
+					}),
+					resource.TestCheckResourceAttr(svcResName, "protocol", "tcp"),
+					resource.TestCheckResourceAttr(svcResName, "listen_port", "70"),
+					resource.TestCheckResourceAttr(svcResName, "destination_port", "70"),
+					resource.TestCheckResourceAttr(svcResName, "proxyprotocol", "false"),
+				),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Closes #200 