### PR TITLE
Fix: Updating certificate within hcloud_certificate does not work correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## master (Unreleased)
+BUG FIXES:
+
+* `hcloud_certificate` resource: Updating the certificate needs to recreate the certificate.
+
+NOTES:
+* The provider is now build with Go 1.15
+* We overhauled parts of the underlying test suite
 
 ## 1.20.0 (August 10, 2020)
 

--- a/hcloud/resource_hcloud_certificate.go
+++ b/hcloud/resource_hcloud_certificate.go
@@ -26,10 +26,12 @@ func resourceCertificate() *schema.Resource {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
+				ForceNew:  true,
 			},
 			"certificate": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"labels": {
 				Type:     schema.TypeMap,

--- a/internal/certificate/resource_test.go
+++ b/internal/certificate/resource_test.go
@@ -2,6 +2,7 @@ package certificate_test
 
 import (
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/terraform-providers/terraform-provider-hcloud/internal/certificate"
 	"testing"
 
@@ -50,4 +51,62 @@ func TestCertificateResource_Basic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestCertificateResource_ChangeCertRequiresNewResource(t *testing.T) {
+	var cert, newCert hcloud.Certificate
+
+	res := certificate.NewRData(t, "basic-cert", "TFAccTests")
+
+	rCert, rKey, err := acctest.RandTLSCert("TFAccTests")
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	resOtherCert := &certificate.RData{Name: res.Name, PrivateKey: rKey, Certificate: rCert}
+	resOtherCert.SetRName(res.Name)
+	tmplMan := testtemplate.Manager{}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     testsupport.AccTestPreCheck(t),
+		Providers:    testsupport.AccTestProviders(),
+		CheckDestroy: testsupport.CheckResourcesDestroyed(certificate.ResourceType, certificate.ByID(t, &cert)),
+		Steps: []resource.TestStep{
+			{
+				// Create a new Certificate using the required values
+				// only.
+				Config: tmplMan.Render(t, "testdata/r/hcloud_certificate", res),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(res.TFID(), certificate.ByID(t, &cert)),
+					resource.TestCheckResourceAttr(res.TFID(), "name",
+						fmt.Sprintf("basic-cert--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(res.TFID(), "private_key", res.PrivateKey),
+					resource.TestCheckResourceAttr(res.TFID(), "certificate", res.Certificate),
+				),
+			},
+			{
+				// Update the Certificate created in the previous step by
+				// setting all optional fields and renaming the Certificate.
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_certificate", resOtherCert,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+
+					testsupport.CheckResourceExists(res.TFID(), certificate.ByID(t, &newCert)),
+					resource.TestCheckResourceAttr(resOtherCert.TFID(), "name",
+						fmt.Sprintf("basic-cert--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(resOtherCert.TFID(), "private_key", rKey),
+					resource.TestCheckResourceAttr(resOtherCert.TFID(), "certificate", rCert),
+					testsupport.LiftTCF(isAnotherCert(&newCert, &cert)),
+				),
+			},
+		},
+	})
+}
+
+func isAnotherCert(newCert *hcloud.Certificate, oldCert *hcloud.Certificate) func() error {
+	return func() error {
+		if newCert.ID == oldCert.ID {
+			return fmt.Errorf("new cert is the same as old cert %d", oldCert.ID)
+		}
+		return nil
+	}
 }


### PR DESCRIPTION
Changing the Certificate or private key within hcloud_certificate needs recreation instead of updating.

Closes #224 