### PR TITLE
Un-deprecate network_id property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+CHANGED:
+
+* Un-deprecate `network_id` property of `hcloud_load_balancer_network` and
+  `hcloud_server_network` resources.
+
 ## 1.20.1 (August 18, 2020)
 BUG FIXES:
 

--- a/hcloud/resource_hcloud_load_balancer_network.go
+++ b/hcloud/resource_hcloud_load_balancer_network.go
@@ -21,10 +21,9 @@ func resourceLoadBalancerNetwork() *schema.Resource {
 		Delete: resourceLoadBalancerNetworkDelete,
 		Schema: map[string]*schema.Schema{
 			"network_id": {
-				Type:       schema.TypeInt,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "use subnet_id instead",
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,

--- a/hcloud/resource_hcloud_server_network.go
+++ b/hcloud/resource_hcloud_server_network.go
@@ -23,10 +23,9 @@ func resourceServerNetwork() *schema.Resource {
 		Delete: resourceServerNetworkDelete,
 		Schema: map[string]*schema.Schema{
 			"network_id": {
-				Type:       schema.TypeInt,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "use subnet_id instead",
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
 			},
 			"subnet_id": {
 				Type:     schema.TypeString,

--- a/website/docs/r/load_balancer_network.html.md
+++ b/website/docs/r/load_balancer_network.html.md
@@ -45,10 +45,14 @@ resource "hcloud_load_balancer_network" "srvnetwork" {
   to the Load Balancer. Required if `subnet_id` is not set. Successful
   creation of the resource depends on the existence of a subnet in the
   Hetzner Cloud Backend. Using `network_id` will not create an explicit
-  dependency between load balancer and subnet. It is thus better to use
-  the `subnet_id` property. This property is deprecated.
+  dependency between the Load Balancer and the subnet. Therefore
+  `depends_on` may need to be used. Alternatively the `subnet_id`
+  property can be used, which will create an explicit dependency between
+  `hcloud_load_balancer_network` and the existence of a subnet.
 - `subnet_id` - (Optional, string) ID of the sub-network which should be
   added to the Load Balancer. Required if `network_id` is not set.
+  *Note*: if the `ip` property is missing, the Load Balancer is
+  currently added to the last created subnet.
 - `ip` - (Optional, string) IP to request to be assigned to this Load
   Balancer. If you do not provide this then you will be auto assigned an
   IP address.

--- a/website/docs/r/server_network.html.md
+++ b/website/docs/r/server_network.html.md
@@ -38,20 +38,24 @@ resource "hcloud_server_network" "srvnetwork" {
 
 ## Argument Reference
 
+- `server_id` - (Required, int) ID of the server.
+- `alias_ips` - (Required, list[string]) Additional IPs to be assigned
+  to this server.
 - `network_id` - (Optional, int) ID of the network which should be added
   to the server. Required if `subnet_id` is not set. Successful creation
   of the resource depends on the existence of a subnet in the Hetzner
   Cloud Backend. Using `network_id` will not create an explicit
-  dependency between server and subnet. It is thus better to use the
-  `subnet_id` property. This property is deprecated.
+  dependency between server and subnet. Therefore `depends_on` may need
+  to be used. Alternatively the `subnet_id` property can be used, which
+  will create an explicit dependency between `hcloud_server_network` and
+  the existence of a subnet.
 - `subnet_id` - (Optional, string) ID of the sub-network which should be
   added to the Server. Required if `network_id` is not set.
-- `server_id` - (Required, int) ID of the server.
+  *Note*: if the `ip` property is missing, the Server is currently added
+  to the last created subnet.
 - `ip` - (Optional, string) IP to request to be assigned to this server.
   If you do not provide this then you will be auto assigned an IP
   address.
-- `alias_ips` - (Required, list[string]) Additional IPs to be assigned
-  to this server.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Hetzner Cloud Networks require at least one subnet to exist, before a
resource can be attached to them. In Terraform it is therefore necessary
to create such a subnet using the hcloud_network_subnet resource.
However, the network_id property of hcloud_load_balancer_network as well
as hcloud_server_network references the parent hcloud_network resource.
For Terraform they do not depend on the existence of a subnet. Due to
Terraform executing plan steps it deems independent in parallel, this
creates a race-condition between the creation of the
hcloud_network_subnet and the hcloud_load_balancer_network or
hcloud_server_network resources. The request to create the latter fails
if it reaches the Hetzner Cloud API before the subnet was created.

To alleviate this issue the subnet_id property was introduced to the
hcloud_load_balancer_network and hcloud_server_network resources. The
intention behind this property was to create an explicit dependency
between those resources and the existence of a subnet without requiring
the users to use depends_on. Unfortunately this was done in a haste and
lead to some confusion and issues for users (#234, #235, #236).

This commit un-deprecates the network_id property and retains its
original behavior. The current limitations of the subnet_id property are
documented more clearly.