### PR TITLE
Fix and test importing of hcloud_rdns resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+BUG FIXES:
+* `hcloud_rdns` resource: It is now possible to import the resource as documented.
+
 ## 1.21.0 (September 09, 2020)
 
 CHANGED:

--- a/hcloud/resource_hcloud_rdns.go
+++ b/hcloud/resource_hcloud_rdns.go
@@ -20,7 +20,9 @@ func resourceReverseDNS() *schema.Resource {
 		Read:   resourceReverseDNSRead,
 		Update: resourceReverseDNSUpdate,
 		Delete: resourceReverseDNSDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"server_id": {
 				Type:     schema.TypeInt,
@@ -83,7 +85,7 @@ func resourceReverseDNSRead(d *schema.ResourceData, m interface{}) error {
 		d.SetId(generateRDNSID(server, nil, ip.String()))
 		d.Set("dns_ptr", server.PublicNet.IPv4.DNSPtr)
 		d.Set("server_id", server.ID)
-		d.Set("ip_address", server.PublicNet.IPv4.IP)
+		d.Set("ip_address", server.PublicNet.IPv4.IP.String())
 		return nil
 	}
 


### PR DESCRIPTION
Part of #241 

We already had the importing of `hcloud_rdns` resources documented, but the implementation was missing. This MR now adds the implementation and also adds tests for the available cases.