### PR TITLE
resource_hcloud_server_network: sleep before creating a hcloud_server_network resource

### DIFF
--- a/hcloud/resource_hcloud_server_network.go
+++ b/hcloud/resource_hcloud_server_network.go
@@ -93,6 +93,9 @@ func resourceServerNetworkCreate(ctx context.Context, d *schema.ResourceData, m 
 		ip := net.ParseIP(aliasIP.(string))
 		opts.AliasIPs = append(opts.AliasIPs, ip)
 	}
+	// workaround for
+	// https://github.com/hetznercloud/terraform-provider-hcloud/issues/161#issuecomment-621125799
+	time.Sleep(5 * time.Second)
 	action, _, err := client.Server.AttachToNetwork(ctx, server, opts)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeConflict) {


### PR DESCRIPTION
There seems to be a bug in the Hetzner platform when private networks
are attached immediately after the corresponding server has been
created.

Attaching shortly after, or detaching and reattaching seems to work.

This has been confirmed to be a bug in April at
https://github.com/hetznercloud/terraform-provider-hcloud/issues/161#issuecomment-621125799,
but according to the issue history there, there's still no fix deployed.

Simply sleeping some time before creating the `hcloud_server_network`
resource seems to give the platform enough time to create the machine,
so let's use this as a workaround until the bug in the platform has been
fixed.