### PR TITLE
Use a set for inline load balancer targets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/hetznercloud/terraform-provider-hcloud
 
 require (
-	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.0.3
 	github.com/hetznercloud/hcloud-go v1.23.1
 	github.com/stretchr/testify v1.6.1

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -177,12 +177,12 @@ func TestLoadBalancerResource_InlineTarget(t *testing.T) {
 					testsupport.CheckResourceExists(resServer1.TFID(), server.ByID(t, &srv0)),
 					testsupport.CheckResourceExists(resServer2.TFID(), server.ByID(t, &srv1)),
 					testsupport.CheckResourceAttrFunc(res.TFID(),
-						"target.0.server_id", func() string {
-							return strconv.Itoa(srv0.ID)
+						"target.0.server_id", func() []string {
+							return []string{strconv.Itoa(srv0.ID), strconv.Itoa(srv1.ID)}
 						}),
 					testsupport.CheckResourceAttrFunc(res.TFID(),
-						"target.1.server_id", func() string {
-							return strconv.Itoa(srv1.ID)
+						"target.1.server_id", func() []string {
+							return []string{strconv.Itoa(srv0.ID), strconv.Itoa(srv1.ID)}
 						}),
 				),
 			},


### PR DESCRIPTION
This hopefully makes the state independent of the actual order the
targets were returned by the Hetzner Cloud Backend API.