### PR TITLE
Improve Testsetup

### DIFF
--- a/internal/floatingip/resource_assignment_test.go
+++ b/internal/floatingip/resource_assignment_test.go
@@ -3,6 +3,7 @@ package floatingip_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"testing"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
@@ -19,23 +20,27 @@ func TestFloatingIPAssignmentResource_Basic(t *testing.T) {
 	var s2 hcloud.Server
 	var f hcloud.FloatingIP
 	tmplMan := testtemplate.Manager{}
+
+	resSSHKey := sshkey.NewRData(t, "server-floating-ip-basic")
 	resServer := &server.RData{
 		Name:  "fip-assignment",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-fip-assignment-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("server_assignment")
 
 	resServer2 := &server.RData{
 		Name:  "fip-assignment-2",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-fip-assignment-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer2.SetRName("server2_assignment")
 
@@ -64,6 +69,7 @@ func TestFloatingIPAssignmentResource_Basic(t *testing.T) {
 				// Create a new RDNS using the required values
 				// only.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server", resServer2,
 					"testdata/r/hcloud_floating_ip", resFloatingIP,
@@ -86,6 +92,7 @@ func TestFloatingIPAssignmentResource_Basic(t *testing.T) {
 			{
 				// Move the floating IP to another server
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server", resServer2,
 					"testdata/r/hcloud_floating_ip", resFloatingIP,

--- a/internal/floatingip/resource_test.go
+++ b/internal/floatingip/resource_test.go
@@ -2,6 +2,7 @@ package floatingip_test
 
 import (
 	"fmt"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"testing"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
@@ -65,13 +66,16 @@ func TestFloatingIPResource_Basic(t *testing.T) {
 func TestFloatingIPResource_WithServer(t *testing.T) {
 	var fip hcloud.FloatingIP
 	tmplMan := testtemplate.Manager{}
+
+	resSSHKey := sshkey.NewRData(t, "server-floating-ip-withserver")
 	resServer := &server.RData{
 		Name:  "floating-ip-test",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-fip-assignment-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("server_assignment")
 
@@ -91,6 +95,7 @@ func TestFloatingIPResource_WithServer(t *testing.T) {
 				// Create a new Floating IP using the required values
 				// only.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_floating_ip", res),
 				Check: resource.ComposeTestCheckFunc(

--- a/internal/image/data_source_test.go
+++ b/internal/image/data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-const TestImageName = "ubuntu-20.04"
+const TestImageName = testsupport.TestImage
 const TestImageId = "15512617"
 
 func TestAccHcloudDataSourceImageTest(t *testing.T) {

--- a/internal/loadbalancer/resource_network_test.go
+++ b/internal/loadbalancer/resource_network_test.go
@@ -34,7 +34,7 @@ func TestAccHcloudLoadBalancerNetwork_NetworkID(t *testing.T) {
 	subNetRes.SetRName("test-network-subnet")
 	lbRes := &loadbalancer.RData{
 		Name:        "lb-network-test",
-		Type:        "lb11",
+		Type:        testsupport.TestLoadBalancerType,
 		NetworkZone: "eu-central",
 	}
 
@@ -118,7 +118,7 @@ func TestAccHcloudLoadBalancerNetwork_SubNetID(t *testing.T) {
 	subNetRes.SetRName("test-network-subnet")
 	lbRes := &loadbalancer.RData{
 		Name:        "lb-network-test",
-		Type:        "lb11",
+		Type:        testsupport.TestLoadBalancerType,
 		NetworkZone: "eu-central",
 	}
 

--- a/internal/loadbalancer/resource_target_test.go
+++ b/internal/loadbalancer/resource_target_test.go
@@ -2,6 +2,7 @@ package loadbalancer_test
 
 import (
 	"fmt"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"strconv"
 	"testing"
 
@@ -21,10 +22,13 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget(t *testing.T) {
 	)
 
 	tmplMan := testtemplate.Manager{}
+
+	resSSHKey := sshkey.NewRData(t, "lb-server-target")
 	resServer := &server.RData{
-		Name:  "lb-server-target",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Name:    "lb-server-target",
+		Type:    testsupport.TestServerType,
+		Image:   testsupport.TestImage,
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("lb-server-target")
 	resource.Test(t, resource.TestCase{
@@ -34,10 +38,11 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_load_balancer", &loadbalancer.RData{
 						Name:        "target-test-lb",
-						Type:        "lb11",
+						Type:        testsupport.TestLoadBalancerType,
 						NetworkZone: "eu-central",
 					},
 					"testdata/r/hcloud_load_balancer_target", &loadbalancer.RDataTarget{
@@ -76,10 +81,12 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 
+	resSSHKey := sshkey.NewRData(t, "lb-server-target-pi")
 	resServer := &server.RData{
-		Name:  "lb-server-target",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Name:    "lb-server-target-pi",
+		Type:    testsupport.TestServerType,
+		Image:   testsupport.TestImage,
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("lb-server-target")
 
@@ -102,6 +109,7 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP(t *testing.T) {
 						NetworkZone: "eu-central",
 						IPRange:     "10.0.1.0/24",
 					},
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server_network", &server.RDataNetwork{
 						Name:      "lb-server-network",
@@ -110,7 +118,7 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP(t *testing.T) {
 					},
 					"testdata/r/hcloud_load_balancer", &loadbalancer.RData{
 						Name:        "target-test-lb",
-						Type:        "lb11",
+						Type:        testsupport.TestLoadBalancerType,
 						NetworkZone: "eu-central",
 					},
 					"testdata/r/hcloud_load_balancer_network", &loadbalancer.RDataNetwork{
@@ -152,13 +160,15 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 	selector := fmt.Sprintf("tf-test=tf-test-%d", tmplMan.RandInt)
+	resSSHKey := sshkey.NewRData(t, "lb-label-target")
 	resServer := &server.RData{
 		Name:  "lb-server-target",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("lb-server-target")
 	resource.Test(t, resource.TestCase{
@@ -168,10 +178,11 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_load_balancer", &loadbalancer.RData{
 						Name:        "target-test-lb",
-						Type:        "lb11",
+						Type:        testsupport.TestLoadBalancerType,
 						NetworkZone: "eu-central",
 					},
 					"testdata/r/hcloud_load_balancer_target", &loadbalancer.RDataTarget{
@@ -202,13 +213,16 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget_UsePrivateIP(t *testing
 		srv hcloud.Server
 	)
 	tmplMan := testtemplate.Manager{}
+
+	resSSHKey := sshkey.NewRData(t, "lb-label-target")
 	resServer := &server.RData{
 		Name:  "lb-server-target",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("lb-server-target")
 
@@ -232,6 +246,7 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget_UsePrivateIP(t *testing
 						NetworkZone: "eu-central",
 						IPRange:     "10.0.1.0/24",
 					},
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server_network", &server.RDataNetwork{
 						Name:      "lb-server-network",
@@ -240,7 +255,7 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget_UsePrivateIP(t *testing
 					},
 					"testdata/r/hcloud_load_balancer", &loadbalancer.RData{
 						Name:        "target-test-lb",
-						Type:        "lb11",
+						Type:        testsupport.TestLoadBalancerType,
 						NetworkZone: "eu-central",
 					},
 					"testdata/r/hcloud_load_balancer_network", &loadbalancer.RDataNetwork{
@@ -295,7 +310,7 @@ func TestAccHcloudLoadBalancerTarget_IPTarget(t *testing.T) {
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_load_balancer", &loadbalancer.RData{
 						Name:        "target-test-lb",
-						Type:        "lb11",
+						Type:        testsupport.TestLoadBalancerType,
 						NetworkZone: "eu-central",
 					},
 					"testdata/r/hcloud_load_balancer_target", &loadbalancer.RDataTarget{

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -42,7 +42,7 @@ func TestLoadBalancerResource_Basic(t *testing.T) {
 					testsupport.CheckResourceExists(res.TFID(), loadbalancer.ByID(t, &lb)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
 						fmt.Sprintf("basic-load-balancer--%d", tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(res.TFID(), "load_balancer_type", "lb11"),
+					resource.TestCheckResourceAttr(res.TFID(), "load_balancer_type", testsupport.TestLoadBalancerType),
 					resource.TestCheckResourceAttr(res.TFID(), "location", "nbg1"),
 				),
 			},
@@ -62,7 +62,7 @@ func TestLoadBalancerResource_Basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "name",
 						fmt.Sprintf("basic-load-balancer-renamed--%d", tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(resRenamed.TFID(), "load_balancer_type", "lb11"),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "load_balancer_type", testsupport.TestLoadBalancerType),
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "location", "nbg1"),
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "algorithm.0.type", "least_connections"),
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "labels.key1", "value1"),
@@ -97,7 +97,7 @@ func TestLoadBalancerResource_Resize(t *testing.T) {
 					testsupport.CheckResourceExists(res.TFID(), loadbalancer.ByID(t, &lb)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
 						fmt.Sprintf("basic-load-balancer--%d", tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(res.TFID(), "load_balancer_type", "lb11"),
+					resource.TestCheckResourceAttr(res.TFID(), "load_balancer_type", testsupport.TestLoadBalancerType),
 					resource.TestCheckResourceAttr(res.TFID(), "location", "nbg1"),
 				),
 			},
@@ -124,14 +124,14 @@ func TestLoadBalancerResource_InlineTarget(t *testing.T) {
 	tmplMan := testtemplate.Manager{RandInt: acctest.RandInt()}
 	resServer1 := &server.RData{
 		Name:  "some-server",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 	}
 	resServer1.SetRName("some-server")
 	resServer2 := &server.RData{
 		Name:  "another-server",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 	}
 	resServer2.SetRName("another-server")
 	res := &loadbalancer.RData{

--- a/internal/server/data_source_test.go
+++ b/internal/server/data_source_test.go
@@ -19,8 +19,8 @@ func TestAccHcloudDataSourceServerTest(t *testing.T) {
 
 	res := &server.RData{
 		Name:  "server-ds-test",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"key": strconv.Itoa(acctest.RandInt()),
 		},

--- a/internal/server/resource_network_test.go
+++ b/internal/server/resource_network_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -20,6 +21,7 @@ func TestAccHcloudServerNetwork_NetworkID(t *testing.T) {
 		s  hcloud.Server
 	)
 
+	sk := sshkey.NewRData(t, "server-network-id")
 	netRes := &network.RData{
 		Name:    "test-network",
 		IPRange: "10.0.0.0/16",
@@ -34,9 +36,10 @@ func TestAccHcloudServerNetwork_NetworkID(t *testing.T) {
 	subNetRes.SetRName("test-network-subnet")
 	sRes := &server.RData{
 		Name:         "s-network-test",
-		Type:         "cx11",
+		Type:         testsupport.TestServerType,
 		LocationName: "nbg1",
-		Image:        "ubuntu-20.04",
+		Image:        testsupport.TestImage,
+		SSHKeys:      []string{sk.TFID() + ".id"},
 	}
 	sRes.SetRName("s-network-test")
 	sNRes := &server.RDataNetwork{
@@ -54,6 +57,7 @@ func TestAccHcloudServerNetwork_NetworkID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_network", netRes,
 					"testdata/r/hcloud_network_subnet", subNetRes,
 					"testdata/r/hcloud_server", sRes,
@@ -86,6 +90,7 @@ func TestAccHcloudServerNetwork_SubNetID(t *testing.T) {
 		s  hcloud.Server
 	)
 
+	sk := sshkey.NewRData(t, "server-network-subnetid")
 	netRes := &network.RData{
 		Name:    "test-network",
 		IPRange: "10.0.0.0/16",
@@ -100,9 +105,10 @@ func TestAccHcloudServerNetwork_SubNetID(t *testing.T) {
 	subNetRes.SetRName("test-network-subnet")
 	sRes := &server.RData{
 		Name:         "s-network-test",
-		Type:         "cx11",
+		Type:         testsupport.TestServerType,
 		LocationName: "nbg1",
-		Image:        "ubuntu-20.04",
+		Image:        testsupport.TestImage,
+		SSHKeys:      []string{sk.TFID() + ".id"},
 	}
 	sRes.SetRName("s-network-test")
 
@@ -114,6 +120,7 @@ func TestAccHcloudServerNetwork_SubNetID(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_network", netRes,
 					"testdata/r/hcloud_network_subnet", subNetRes,
 					"testdata/r/hcloud_server", sRes,

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"testing"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
@@ -17,10 +18,12 @@ import (
 func TestServerResource_Basic(t *testing.T) {
 	var s hcloud.Server
 
+	sk := sshkey.NewRData(t, "server-basic")
 	res := &server.RData{
-		Name:  "server-basic",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Name:    "server-basic",
+		Type:    testsupport.TestServerType,
+		Image:   testsupport.TestImage,
+		SSHKeys: []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-basic")
 	resRenamed := &server.RData{Name: res.Name + "-renamed", Type: res.Type, Image: res.Image}
@@ -34,7 +37,10 @@ func TestServerResource_Basic(t *testing.T) {
 			{
 				// Create a new Server using the required values
 				// only.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_server", res),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
@@ -71,10 +77,12 @@ func TestServerResource_Basic(t *testing.T) {
 func TestServerResource_Resize(t *testing.T) {
 	var s hcloud.Server
 
+	sk := sshkey.NewRData(t, "server-resize")
 	res := &server.RData{
-		Name:  "server-resize",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Name:    "server-resize",
+		Type:    testsupport.TestServerType,
+		Image:   testsupport.TestImage,
+		SSHKeys: []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-resize")
 	resResized := &server.RData{Name: res.Name, Type: "cx21", Image: res.Image, KeepDisk: true}
@@ -88,7 +96,10 @@ func TestServerResource_Resize(t *testing.T) {
 			{
 				// Create a new Server using the required values
 				// only.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_server", res),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
@@ -101,6 +112,7 @@ func TestServerResource_Resize(t *testing.T) {
 				// Update the Server created in the previous step by
 				// setting all optional fields and renaming the Server.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resResized,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -117,11 +129,13 @@ func TestServerResource_Resize(t *testing.T) {
 func TestServerResource_ChangeUserData(t *testing.T) {
 	var s, s2 hcloud.Server
 
+	sk := sshkey.NewRData(t, "server-userdata")
 	res := &server.RData{
 		Name:     "server-userdata",
-		Type:     "cx11",
-		Image:    "ubuntu-20.04",
+		Type:     testsupport.TestServerType,
+		Image:    testsupport.TestImage,
 		UserData: "stuff",
+		SSHKeys:  []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-userdata")
 	resChangedUserdata := &server.RData{Name: res.Name, Type: res.Type, Image: res.Image, UserData: "updated stuff"}
@@ -135,7 +149,10 @@ func TestServerResource_ChangeUserData(t *testing.T) {
 			{
 				// Create a new Server using the required values
 				// only.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_server", res),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
@@ -149,6 +166,7 @@ func TestServerResource_ChangeUserData(t *testing.T) {
 				// Update the Server created in the previous step by
 				// setting all optional fields and renaming the Server.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resChangedUserdata,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -168,12 +186,14 @@ func TestServerResource_ChangeUserData(t *testing.T) {
 func TestServerResource_ISO(t *testing.T) {
 	var s hcloud.Server
 
+	sk := sshkey.NewRData(t, "server-iso")
 	res := &server.RData{
 		Name:     "server-iso",
-		Type:     "cx11",
-		Image:    "ubuntu-20.04",
+		Type:     testsupport.TestServerType,
+		Image:    testsupport.TestImage,
 		UserData: "stuff",
 		ISO:      "3500",
+		SSHKeys:  []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-iso")
 	tmplMan := testtemplate.Manager{}
@@ -185,7 +205,10 @@ func TestServerResource_ISO(t *testing.T) {
 			{
 				// Create a new Server using the required values
 				// only.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_server", res),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -14,7 +14,7 @@ func TestAccHcloudDataSourceServerTypeTest(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	stByName := &servertype.DData{
-		ServerTypeName: "cx11",
+		ServerTypeName: testsupport.TestServerType,
 	}
 	stByName.SetRName("st_by_name")
 	stByID := &servertype.DData{

--- a/internal/testsupport/common.go
+++ b/internal/testsupport/common.go
@@ -20,6 +20,17 @@ import (
 	tfhcloud "github.com/hetznercloud/terraform-provider-hcloud/hcloud"
 )
 
+const (
+	// TestImage is the system image that is used in all tests
+	TestImage = "ubuntu-20.04"
+
+	// TestServerType is the default server type used in all tests
+	TestServerType = "cx11"
+
+	// TestLoadBalancerType is the default Load Balancer type used in all tests
+	TestLoadBalancerType = "lb11"
+)
+
 func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }

--- a/internal/volume/resource_attachment_test.go
+++ b/internal/volume/resource_attachment_test.go
@@ -3,6 +3,7 @@ package volume_test
 import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"testing"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
@@ -19,24 +20,28 @@ func TestVolumeAssignmentResource_Basic(t *testing.T) {
 	var s2 hcloud.Server
 	var v hcloud.Volume
 	tmplMan := testtemplate.Manager{}
+
+	resSSHKey := sshkey.NewRData(t, "server-vol")
 	resServer := &server.RData{
 		Name:  "vol-attachment",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-vol-attachment-%d", tmplMan.RandInt),
 		},
+		SSHKeys: []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer.SetRName("server_attachment")
 
 	resServer2 := &server.RData{
 		Name:  "vol-attachment-2",
-		Type:  "cx11",
-		Image: "ubuntu-20.04",
+		Type:  testsupport.TestServerType,
+		Image: testsupport.TestImage,
 		Labels: map[string]string{
 			"tf-test": fmt.Sprintf("tf-test-vol-attachment-%d", tmplMan.RandInt),
 		},
 		LocationName: fmt.Sprintf("${%s.location}", resServer.TFID()),
+		SSHKeys:      []string{resSSHKey.TFID() + ".id"},
 	}
 	resServer2.SetRName("server2_attachment")
 
@@ -65,6 +70,7 @@ func TestVolumeAssignmentResource_Basic(t *testing.T) {
 				// Create a new Volume attachment using the required values
 				// only.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server", resServer2,
 					"testdata/r/hcloud_volume", resVolume,
@@ -88,6 +94,7 @@ func TestVolumeAssignmentResource_Basic(t *testing.T) {
 				// Move the Volume to another server using the
 				// attachment.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,
 					"testdata/r/hcloud_server", resServer2,
 					"testdata/r/hcloud_volume", resVolume,

--- a/internal/volume/resource_test.go
+++ b/internal/volume/resource_test.go
@@ -129,16 +129,16 @@ func TestVolumeResource_WithServer(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 	resServer1 := &server.RData{
 		Name:         "some-server",
-		Type:         "cx11",
-		Image:        "ubuntu-20.04",
+		Type:         testsupport.TestServerType,
+		Image:        testsupport.TestImage,
 		LocationName: "nbg1",
 	}
 	resServer1.SetRName("some-server")
 
 	resServer2 := &server.RData{
 		Name:         "another-server",
-		Type:         "cx11",
-		Image:        "ubuntu-20.04",
+		Type:         testsupport.TestServerType,
+		Image:        testsupport.TestImage,
 		LocationName: "nbg1",
 	}
 	resServer2.SetRName("another-server")


### PR DESCRIPTION
This MR adds an ssh key to every server. With this change, we avoid mailing the password to our test account. 

Also, this adds two constants for the server type and the image which is used on every test. This makes changing the server type or the image easier.