### PR TITLE
Add network property to hcloud_server resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## unreleased 
+## unreleased
 
 FEATURES:
 * **New Datasource**: `hcloud_server_type`
 * **New Datasource**: `hcloud_server_types`
+* New `network` property for `hcloud_server` resource.
 
 BUG FIXES:
 * `hcloud_volume` resource: A race condition was fixed, that was called when you tried to create multiple volumes for a single server

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -89,6 +89,16 @@ type RData struct {
 	ISO          string
 	Labels       map[string]string
 	UserData     string
+	Network      RDataInlineNetwork
+	DependsOn    []string
+}
+
+// RDataInlineNetwork defines the information required to attach a server
+// to a network directly in the server resource.
+type RDataInlineNetwork struct {
+	NetworkID string
+	IP        string
+	AliasIPs  []string
 }
 
 // TFID returns the resource identifier.

--- a/internal/testdata/r/hcloud_server.tf.tmpl
+++ b/internal/testdata/r/hcloud_server.tf.tmpl
@@ -29,6 +29,18 @@ resource "hcloud_server" "{{ .RName }}" {
   backups     = {{ .Backups }}
   {{ end }}
 
+  {{- if .Network.NetworkID }}{{ with .Network }}
+  network {
+      network_id = {{ .NetworkID }}
+      {{- if .IP }}
+      ip         = "{{ .IP }}"
+      {{ end }}
+      {{- if .AliasIPs }}
+      alias_ips = {{ with DQuoteS .AliasIPs }}[{{ StringsJoin . ", " }}]{{ end }}
+      {{- end }}
+  }
+  {{ end }}{{ end }}
+
   {{- if .Labels }}
   labels = {
   {{- range $k,$v := .Labels }}
@@ -39,5 +51,8 @@ resource "hcloud_server" "{{ .RName }}" {
 
   {{- if .UserData }}
   user_data   = "{{ .UserData }}"
+  {{ end }}
+  {{- if .DependsOn }}
+  depends_on               = [{{ StringsJoin .DependsOn ", " }}]
   {{ end }}
 }

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -12,12 +12,54 @@ Provides an Hetzner Cloud server resource. This can be used to create, modify, a
 
 ## Example Usage
 
+### Basic server creation
+
 ```hcl
 # Create a new server running debian
 resource "hcloud_server" "node1" {
   name = "node1"
   image = "debian-9"
   server_type = "cx11"
+}
+```
+
+### Server creation with network
+
+```
+resource "hcloud_network" "network" {
+  name     = "network"
+  ip_range = "10.0.0.0/16"
+}
+
+resource "hcloud_network_subnet" "network-subnet" {
+  type         = "cloud"
+  network_id   = hcloud_network.network.id
+  network_zone = "eu-central"
+  ip_range     = "10.0.1.0/24"
+}
+
+resource "hcloud_server" "server" {
+  name        = "server"
+  server_type = "cx11"
+  image       = "ubuntu-20.04"
+  location    = "nbg1"
+
+  network {
+      network_id = hcloud_network.network.id
+      ip         = "10.0.1.5"
+      alias_ips  = [
+        "10.0.1.6",
+        "10.0.1.7"
+      ]
+  }
+
+  # **Note**: the depends_on is important when directly attaching the
+  # server to a network. Otherwise Terraform will attempt to create
+  # server and sub-network in parallel. This may result in the server
+  # creation failing randomly.
+  depends_on = [
+    hcloud_network_subnet.network-subnet
+  ]
 }
 ```
 
@@ -56,6 +98,13 @@ The following attributes are exported:
 - `ipv6_network` - (string) The IPv6 network.
 - `status` - (string) The status of the server.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `network` - (map) Private Network the server shall be attached to.
+  The Network that should be attached to the server requires at least
+  one subnetwork. Subnetworks cannot be referenced by Servers in the
+  Hetzner Cloud API. Therefore Terraform attempts to create the
+  subnetwork in parallel to the server. This leads to a concurrency
+  issue. It is therefore necessary to use `depends_on` to link the server
+  to the respective subnetwork. See examples.
 
 ## Import
 


### PR DESCRIPTION
The network property allows to directly attach a server to a network
during creation. However, due to the nature of our API a `depends_on`
clause any subnetworks linked to the server is required.

Closes GH-283