### PR TITLE
Retry when a create subnetwork fails because the vSwitch is already used

### DIFF
--- a/internal/network/resource_subnet.go
+++ b/internal/network/resource_subnet.go
@@ -104,6 +104,9 @@ func resourceNetworkSubnetCreate(ctx context.Context, d *schema.ResourceData, m 
 		if hcloud.IsError(err, hcloud.ErrorCodeConflict) {
 			return err
 		}
+		if hcloud.IsError(err, hcloud.ErrorCodeVSwitchAlreadyUsed) {
+			return err
+		}
 		return control.AbortRetry(err)
 	})
 	if err != nil {


### PR DESCRIPTION
This behavior can occur mostly only within our testsuite, because we use the same vSwitch for the same tests on different Terraform versions that run at the same time. A normal user shouldn't run into this issue.