### PR TITLE
Improve provider testing & remove deprecated methods

### DIFF
--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -1,7 +1,9 @@
 package hcloud
 
 import (
+	"context"
 	"errors"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
 
@@ -87,11 +89,11 @@ func Provider() *schema.Provider {
 			sshkey.SSHKeysDataSourceType:         sshkey.SSHKeysDataSource(),
 			volume.DataSourceType:                volume.DataSource(),
 		},
-		ConfigureFunc: providerConfigure,
+		ConfigureContextFunc: providerConfigure,
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(d.Get("token").(string)),
 		hcloud.WithApplication("hcloud-terraform", Version),
@@ -102,7 +104,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	if pollInterval, ok := d.GetOk("poll_interval"); ok {
 		pollInterval, err := time.ParseDuration(pollInterval.(string))
 		if err != nil {
-			return nil, err
+			return nil, diag.FromErr(err)
 		}
 		opts = append(opts, hcloud.WithPollInterval(pollInterval))
 	}

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -3,9 +3,10 @@ package hcloud
 import (
 	"context"
 	"errors"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 

--- a/hcloud/provider_test.go
+++ b/hcloud/provider_test.go
@@ -1,9 +1,20 @@
 package hcloud
 
 import (
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/certificate"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/datacenter"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/image"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/location"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/rdns"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/servertype"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
+	"github.com/stretchr/testify/assert"
 	"testing"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func TestProvider(t *testing.T) {
@@ -12,6 +23,59 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-func TestProvider_impl(t *testing.T) {
-	var _ *schema.Provider = Provider()
+func TestProvider_Resources(t *testing.T) {
+	var provider = Provider()
+	expectedResources := []string{
+		certificate.ResourceType,
+		floatingip.AssignmentResourceType,
+		floatingip.ResourceType,
+		loadbalancer.NetworkResourceType,
+		loadbalancer.ResourceType,
+		loadbalancer.ServiceResourceType,
+		loadbalancer.TargetResourceType,
+		network.ResourceType,
+		network.RouteResourceType,
+		network.SubnetResourceType,
+		rdns.ResourceType,
+		server.NetworkResourceType,
+		server.ResourceType,
+		sshkey.ResourceType,
+		volume.AttachmentResourceType,
+		volume.ResourceType,
+	}
+
+	resources := provider.Resources()
+	assert.Len(t, resources, len(expectedResources))
+
+	for _, datasource := range resources {
+		assert.Contains(t, expectedResources, datasource.Name)
+	}
+}
+
+func TestProvider_DataSources(t *testing.T) {
+	var provider = Provider()
+	expectedDataSources := []string{
+		certificate.DataSourceType,
+		datacenter.DatacentersDataSourceType,
+		datacenter.DataSourceType,
+		floatingip.DataSourceType,
+		image.DataSourceType,
+		loadbalancer.DataSourceType,
+		location.DataSourceType,
+		location.LocationsDataSourceType,
+		network.DataSourceType,
+		server.DataSourceType,
+		servertype.DataSourceType,
+		servertype.ServerTypesDataSourceType,
+		sshkey.DataSourceType,
+		sshkey.SSHKeysDataSourceType,
+		volume.DataSourceType,
+	}
+
+	datasources := provider.DataSources()
+	assert.Len(t, datasources, len(expectedDataSources))
+
+	for _, datasource := range datasources {
+		assert.Contains(t, expectedDataSources, datasource.Name)
+	}
 }


### PR DESCRIPTION
This MR improves the testing of the resource/datacenter registration against Terraform. We also remove the usage of the deprecated `ConfigureFunc` method and replace it with the new `ConfigureContextFunc` Method.