### PR TITLE
Fix hcloud_volume resource: Automount did not work when changing an already existing volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## unreleased
 
 BUG FIXES:
-* `hcloud_volume` datasource: id is now marked as computed to allow more setups where the id is unkown
-* `hcloud_ssh_key` datasource: id is now marked as computed to allow more setups where the id is unkown
-* `hcloud_network` datasource: id is now marked as computed to allow more setups where the id is unkown
-* `hcloud_image` datasource: id is now marked as computed to allow more setups where the id is unkown
-* `hcloud_certificate` datasource: id is now marked as computed to allow more setups where the id is unkown
+* `hcloud_volume` datasource: id is now marked as computed to allow more setups where the id is unknown
+* `hcloud_ssh_key` datasource: id is now marked as computed to allow more setups where the id is unknown
+* `hcloud_network` datasource: id is now marked as computed to allow more setups where the id is unknown
+* `hcloud_image` datasource: id is now marked as computed to allow more setups where the id is unknown
+* `hcloud_certificate` datasource: id is now marked as computed to allow more setups where the id is unknown
+* `hcloud_volume` resource: Automount is now working when you attach an already existing volume to a server.
 
 ## 1.24.0 (January 12, 2021)
 

--- a/internal/volume/resource.go
+++ b/internal/volume/resource.go
@@ -242,7 +242,12 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 				}
 			}
 			err := control.Retry(control.DefaultRetries, func() error {
-				action, _, err := c.Volume.Attach(ctx, volume, &hcloud.Server{ID: serverID})
+				opts := hcloud.VolumeAttachOpts{Server: &hcloud.Server{ID: serverID}}
+				if automount, ok := d.GetOk("automount"); ok {
+					opts.Automount = hcloud.Bool(automount.(bool))
+				}
+
+				action, _, err := c.Volume.AttachWithOpts(ctx, volume, opts)
 				if err != nil {
 					if resourceVolumeIsNotFound(err, d) {
 						return nil

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -31,8 +31,8 @@ resource "hcloud_volume" "master" {
 
 - `name` - (Required, string) Name of the volume to create (must be unique per project).
 - `size` - (Required, int) Size of the volume (in GB).
-- `server_id` - (Optional, int) Server to attach the Volume to, optional if location argument is passed.
-- `location` - (Optional, string) Location of the volume to create, optional if server_id argument is passed.
+- `server_id` - (Optional, int) Server to attach the Volume to, not allowed if location argument is passed.
+- `location` - (Optional, string) Location of the volume to create, not allowed if server_id argument is passed.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).
 - `format` - (Optional, string) Format volume after creation. `xfs` or `ext4`
 


### PR DESCRIPTION
This bug was reported by a customer in Issue #308. He tried to reassign a volume to another server and then expected the volume to be automounted. Within our `hcloud_volume_attachment` this works, only `hcloud_volume` did not "auto mount" it. 

After this MR we use `AttachWithOpts` (with Automount Flag support) when reassigning a volume instead of `Attach` which does not provide this functionality.  

Closes #308


One more thing I noticed:
`hcloud_volume` is now identically powerful as `hcloud_volume_attachment`. Maybe it makes sense to deprecate `hcloud_volume_attachment`? What do you think?
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>