### PR TITLE
hcloud_server: Image is wrong type when server created from snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## unreleased
 
+BUG FIXES:
+* `hcloud_server` resource: image had a wrong type (int instead of string) when a server was created from a snapshot
+
 ## 1.24.1 (February 04, 2021)
 
 BUG FIXES:

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -635,7 +635,7 @@ func setServerSchema(d *schema.ResourceData, s *hcloud.Server) {
 		if s.Image.Name != "" {
 			d.Set("image", s.Image.Name)
 		} else {
-			d.Set("image", s.Image.ID)
+			d.Set("image", fmt.Sprintf("%d", s.Image.ID))
 		}
 	}
 }


### PR DESCRIPTION
Bugfix: `hcloud_server` resource: image had a wrong type (int instead of string) when a server was created from a snapshot

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Fixes #315 