### PR TITLE
hcloud_load_balancer_target force recreation on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 
 BUG FIXES:
 * `hcloud_server` resource: image had a wrong type (int instead of string) when a server was created from a snapshot
+* `hcloud_load_balancer_target` resource: force recreation when changing a target attribute (server_id, ip or label_selector)
 
 NOTES:
 * The provider is now built with Go 1.16

--- a/internal/loadbalancer/resource_target.go
+++ b/internal/loadbalancer/resource_target.go
@@ -51,17 +51,20 @@ func TargetResource() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ExactlyOneOf: targetProps,
+				ForceNew:     true,
 			},
 			"label_selector": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ExactlyOneOf: targetProps,
+				ForceNew:     true,
 			},
 			"ip": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ExactlyOneOf:  targetProps,
 				ConflictsWith: []string{"use_private_ip"},
+				ForceNew:      true,
 			},
 			"use_private_ip": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
`hcloud_load_balancer_target` resource: force recreation when changing a target attribute (server_id, ip or label_selector)

Fixes #321 

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>