### PR TITLE
`hcloud_firewall` resource: plugin normalized CIDRs silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## unreleased
+
+BUG FIXES:
+* `hcloud_firewall` resource: plugin normalized CIDRs silently.
+
 ## 1.25.1 (March 10, 2021)
 
 BUG FIXES:

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -80,30 +80,16 @@ func Resource() *schema.Resource {
 						"source_ips": {
 							Type: schema.TypeSet,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-									sourceIP := i.(string)
-									_, _, err := net.ParseCIDR(sourceIP)
-									if err != nil {
-										return diag.FromErr(err)
-									}
-									return nil
-								},
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateIPDiag,
 							},
 							Optional: true,
 						},
 						"destination_ips": &schema.Schema{
 							Type: schema.TypeSet,
 							Elem: &schema.Schema{
-								Type: schema.TypeString,
-								ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-									sourceIP := i.(string)
-									_, _, err := net.ParseCIDR(sourceIP)
-									if err != nil {
-										return diag.FromErr(err)
-									}
-									return nil
-								},
+								Type:             schema.TypeString,
+								ValidateDiagFunc: validateIPDiag,
 							},
 							Optional: true,
 						},

--- a/internal/firewall/validation.go
+++ b/internal/firewall/validation.go
@@ -1,0 +1,20 @@
+package firewall
+
+import (
+	"net"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+)
+
+func validateIPDiag(i interface{}, path cty.Path) diag.Diagnostics {
+	ipS := i.(string)
+	ip, n, err := net.ParseCIDR(ipS)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if ip.String() != n.IP.String() {
+		return diag.Errorf("%s is not the start of the cidr block %s", ipS, n)
+	}
+	return nil
+}

--- a/internal/firewall/validation_test.go
+++ b/internal/firewall/validation_test.go
@@ -1,0 +1,65 @@
+package firewall
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateIPDiag(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		err  diag.Diagnostics
+	}{
+		{
+			name: "Valid CIDR (IPv4)",
+			ip:   "10.0.0.0/8",
+			err:  nil,
+		},
+		{
+			name: "Valid CIDR (IPv6)",
+			ip:   "fe80::/128",
+			err:  nil,
+		},
+		{
+			name: "Invalid IP",
+			ip:   "test",
+			err:  diag.Diagnostics{diag.Diagnostic{Severity: 0, Summary: "invalid CIDR address: test", Detail: "", AttributePath: cty.Path(nil)}},
+		},
+		{
+			name: "Missing CIDR notation (IPv4)",
+			ip:   "10.0.0.0",
+			err:  diag.Diagnostics{diag.Diagnostic{Severity: 0, Summary: "invalid CIDR address: 10.0.0.0", Detail: "", AttributePath: cty.Path(nil)}},
+		},
+		{
+			name: "Missing CIDR notation (IPv6)",
+			ip:   "fe80::",
+			err:  diag.Diagnostics{diag.Diagnostic{Severity: 0, Summary: "invalid CIDR address: fe80::", Detail: "", AttributePath: cty.Path(nil)}},
+		},
+		{
+			name: "Host bit set (IPv4)",
+			ip:   "10.0.0.5/8",
+			err:  diag.Diagnostics{diag.Diagnostic{Severity: 0, Summary: "10.0.0.5/8 is not the start of the cidr block 10.0.0.0/8", Detail: "", AttributePath: cty.Path(nil)}},
+		},
+		{
+			name: "Host bit set (IPv6)",
+			ip:   "fe80::1337/64",
+			err:  diag.Diagnostics{diag.Diagnostic{Severity: 0, Summary: "fe80::1337/64 is not the start of the cidr block fe80::/64", Detail: "", AttributePath: cty.Path(nil)}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateIPDiag(test.ip, cty.Path{})
+			if test.err == nil {
+				assert.Nil(t, err)
+			}
+
+			if test.err != nil {
+				assert.Equal(t, err, test.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The terraform provider normalized the given CIDRs by default, so when a user entered 10.0.0.1/8 (as a sample) the terraform provider normalized it to 10.0.0.0/8. This lead to a state difference after every apply, so that terraform tries to recreate the firewall rules. After this MR we now validate that the given IP is the start of the CIDR block (e.g. 10.0.0.0/8).

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>