### PR TITLE
`hcloud_volume` - fix example in docs not functional

### DIFF
--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -24,6 +24,7 @@ resource "hcloud_volume" "master" {
   size = 50
   server_id = hcloud_server.node1.id
   automount = true
+  format = "ext4"
 }
 ```
 


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Fixes #337 