### PR TITLE
firewall: missing direction

### DIFF
--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -34,7 +34,7 @@ data "hcloud_firewall" "sample_firewall_2" {
 - `labels` - (map) User-defined labels (key-value pairs)
 
 `rule` support the following fields:
-- `direction` - (Required, string) Direction of the Firewall Rule. `in`
+- `direction` - (Required, string) Direction of the Firewall Rule. `in` or `out`
 - `protocol` - (Required, string) Protocol of the Firewall Rule. `tcp`, `icmp`, `udp`
 - `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule


### PR DESCRIPTION
Hey guys - I just missed the direction "out" in the docs. Maybe you`ve just missed it.

Thanks anyways for the awesome provider. 

working example: 
```
...
      + rule {
          + destination_ips = [
              + "0.0.0.0/0",
              + "::/0",
            ]
          + direction       = "out"
          + port            = "any"
          + protocol        = "udp"
          + source_ips      = []
        }
```