### PR TITLE
Fix wrong sticky session value

### DIFF
--- a/internal/loadbalancer/testing.go
+++ b/internal/loadbalancer/testing.go
@@ -139,6 +139,7 @@ type RDataServiceHTTP struct {
 	CookieLifeTime int
 	Certificates   []string
 	RedirectHTTP   bool
+	StickySessions bool
 }
 
 // RDataServiceHealthCheck contains data for a load balancer service

--- a/internal/testdata/r/hcloud_load_balancer_service.tf.tmpl
+++ b/internal/testdata/r/hcloud_load_balancer_service.tf.tmpl
@@ -15,10 +15,11 @@ resource "hcloud_load_balancer_service" "{{ .Name }}" {
   proxyprotocol    = {{ .Proxyprotocol }}
   {{- if .AddHTTP }}
   http {
-    {{ if .HTTP.CookieName -}}    cookie_name     = "{{ .HTTP.CookieName }}"{{ end }}
-    {{ if .HTTP.CookieLifeTime -}}cookie_lifetime = "{{ .HTTP.CookieLifeTime }}"{{ end }}
-    {{ if .HTTP.RedirectHTTP -}}  redirect_http   = {{ .HTTP.RedirectHTTP }}{{ end }}
-    {{ if .HTTP.Certificates -}}  certificates    = [{{ StringsJoin .HTTP.Certificates ", " }}]{{ end }}
+    {{ if .HTTP.CookieName -}}    cookie_name      = "{{ .HTTP.CookieName }}"{{ end }}
+    {{ if .HTTP.CookieLifeTime -}}cookie_lifetime  = "{{ .HTTP.CookieLifeTime }}"{{ end }}
+    {{ if .HTTP.RedirectHTTP -}}  redirect_http    = {{ .HTTP.RedirectHTTP }}{{ end }}
+    {{ if .HTTP.Certificates -}}  certificates     = [{{ StringsJoin .HTTP.Certificates ", " }}]{{ end }}
+    {{ if .HTTP.StickySessions -}} sticky_sessions = "{{ .HTTP.StickySessions }}"{{ end }}
   }
   {{ end }}
   {{- if .AddHealthCheck }}


### PR DESCRIPTION
We did not add the "sticky_sessions" attribute to the httpMap but
instead set it directly on the resource data.

In addition we had a weird way to identify a service belonging to a load
balancer. First we correctly identifed the affected load balancer service
using our faux service ID. Then we then additionally tried to identify the
same service again. This commit removes this strange behavior and uses
the initially found service in the first place.

Closes #366