### PR TITLE
Docs: Add missing firewall_ids to hcloud_server resource and datasource

### DIFF
--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -43,3 +43,4 @@ data "hcloud_server" "s_3" {
 - `ipv6_network` - (string) The IPv6 network.
 - `status` - (string) The status of the server.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `firewall_ids` - (Optional, list) Firewall IDs the server is attached to.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -79,6 +79,7 @@ The following arguments are supported:
 - `rescue` - (Optional, string) Enable and boot in to the specified rescue system. This enables simple installation of custom operating systems. `linux64` `linux32` or `freebsd64`
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `backups` - (Optional, boolean) Enable or disable backups.
+- `firewall_ids` - (Optional, list) Firewall IDs the server should be attached to on creation.
 
 ## Attributes Reference
 
@@ -105,6 +106,7 @@ The following attributes are exported:
   subnetwork in parallel to the server. This leads to a concurrency
   issue. It is therefore necessary to use `depends_on` to link the server
   to the respective subnetwork. See examples.
+- `firewall_ids` - (Optional, list) Firewall IDs the server is attached to.
 
 ## Import
 


### PR DESCRIPTION
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Fixes https://github.com/hetznercloud/terraform-provider-hcloud/issues/370