### PR TITLE
Docs: Improve documentation for hcloud_firewall

### DIFF
--- a/internal/e2etests/firewall/resource_test.go
+++ b/internal/e2etests/firewall/resource_test.go
@@ -31,6 +31,12 @@ func TestFirewallResource_Basic(t *testing.T) {
 			DestinationIPs: []string{"0.0.0.0/0", "::/0"},
 			Port:           "80",
 		},
+		{
+			Direction:      "in",
+			Protocol:       "udp",
+			DestinationIPs: []string{"0.0.0.0/0", "::/0"},
+			Port:           "any",
+		},
 	})
 
 	updated := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{
@@ -45,6 +51,12 @@ func TestFirewallResource_Basic(t *testing.T) {
 			Protocol:       "tcp",
 			DestinationIPs: []string{"0.0.0.0/0", "::/0"},
 			Port:           "443",
+		},
+		{
+			Direction:      "in",
+			Protocol:       "udp",
+			DestinationIPs: []string{"0.0.0.0/0", "::/0"},
+			Port:           "any",
 		},
 	})
 	updated.SetRName(res.RName())

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -42,7 +42,7 @@ resource "hcloud_server" "node1" {
 `rule` support the following fields:
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`
 - `protocol` - (Required, string) Protocol of the Firewall Rule. `tcp`, `icmp`, `udp`
-- `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`
+- `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`. You can use `any` to allow all ports for the specific protocol. Port ranges are also possible: `80:85` allows all ports between 80 and 85.
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule
 
 ## Attributes Reference


### PR DESCRIPTION
Improve documentation for hcloud_firewall resource to include information about port ranges and the `any` keyword

Fixes https://github.com/hetznercloud/terraform-provider-hcloud/issues/374


Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>