### PR TITLE
Docs: Mark example "hcloud_token" variable as sensitive

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -17,7 +17,9 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Set the variable value in *.tfvars file
 # or using the -var="hcloud_token=..." CLI option
-variable "hcloud_token" {}
+variable "hcloud_token" {
+  sensitive = true # Requires terraform >= 0.14
+}
 
 # Configure the Hetzner Cloud Provider
 provider "hcloud" {


### PR DESCRIPTION
Prevents the field's values from showing up in CLI output and in Terraform Cloud.

See [Terraform Docs](https://www.terraform.io/docs/extend/best-practices/sensitive-state.html#using-the-sensitive-flag)

Signed-off-by: Alex Andrews <alias-dev@protonmail.com>