### PR TITLE
Fix non iso8601 timestamp in hcloud_image datasource

### DIFF
--- a/internal/image/data_source.go
+++ b/internal/image/data_source.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"sort"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -157,13 +158,13 @@ func setImageSchema(d *schema.ResourceData, i *hcloud.Image) {
 	d.SetId(strconv.Itoa(i.ID))
 	d.Set("type", i.Type)
 	d.Set("name", i.Name)
-	d.Set("created", i.Created.String())
+	d.Set("created", i.Created.Format(time.RFC3339))
 	d.Set("description", i.Description)
 	d.Set("os_flavor", i.OSFlavor)
 	d.Set("os_version", i.OSVersion)
 	d.Set("rapid_deploy", i.RapidDeploy)
 	if !i.Deprecated.IsZero() {
-		d.Set("deprecated", i.Deprecated.String())
+		d.Set("deprecated", i.Deprecated.Format(time.RFC3339))
 	}
 	d.Set("labels", i.Labels)
 }


### PR DESCRIPTION
The created (& deprecated) dates in the hcloud_image datasource where not iso8601 complaint. Instead they had a strange format: 2020-04-23 17:55:14 +0000 +0000 This fixes the issue now. As those attributes are only in a datasource we should be able to change the format, this shouldn't be an issue as all those values are "computed".

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>

Fixes #368 