### PR TITLE
Increase create timeout for servers and snapshots

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -31,7 +32,9 @@ func Resource() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(90 * time.Minute),
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/internal/snapshot/resource.go
+++ b/internal/snapshot/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -23,6 +24,9 @@ func Resource() *schema.Resource {
 		DeleteContext: resourceSnapshotDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(90 * time.Minute),
 		},
 		Schema: map[string]*schema.Schema{
 			"description": {


### PR DESCRIPTION
In #312 customers reported that server creation can time out if large
snapshots are used. This commit increases the timeout for server
creation to 90 minutes. Since creating snapshots can also take quite
some time the timeout is increased as well.

 Closes #312