### PR TITLE
Network Attachments: Retry on ServiceError and NoSubnetAvailable Error

### DIFF
--- a/internal/loadbalancer/resource_network.go
+++ b/internal/loadbalancer/resource_network.go
@@ -100,7 +100,8 @@ func resourceLoadBalancerNetworkCreate(ctx context.Context, d *schema.ResourceDa
 		action, _, err = c.LoadBalancer.AttachToNetwork(ctx, lb, opts)
 		if hcloud.IsError(err, hcloud.ErrorCodeConflict) ||
 			hcloud.IsError(err, hcloud.ErrorCodeLocked) ||
-			hcloud.IsError(err, hcloud.ErrorCodeServiceError) {
+			hcloud.IsError(err, hcloud.ErrorCodeServiceError) ||
+			hcloud.IsError(err, hcloud.ErrorCodeNoSubnetAvailable) {
 			// Retry on any of the above listed errors
 			return err
 		}
@@ -180,7 +181,9 @@ func resourceLoadBalancerNetworkDelete(ctx context.Context, d *schema.ResourceDa
 		action, _, err = client.LoadBalancer.DetachFromNetwork(ctx, server, hcloud.LoadBalancerDetachFromNetworkOpts{
 			Network: network,
 		})
-		if hcloud.IsError(err, hcloud.ErrorCodeConflict) || hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+		if hcloud.IsError(err, hcloud.ErrorCodeConflict) ||
+			hcloud.IsError(err, hcloud.ErrorCodeLocked) ||
+			hcloud.IsError(err, hcloud.ErrorCodeServiceError) {
 			return err
 		}
 		return control.AbortRetry(err)

--- a/internal/server/resource_network.go
+++ b/internal/server/resource_network.go
@@ -222,7 +222,10 @@ func attachServerToNetwork(ctx context.Context, c *hcloud.Client, srv *hcloud.Se
 		var err error
 
 		a, _, err = c.Server.AttachToNetwork(ctx, srv, opts)
-		if hcloud.IsError(err, hcloud.ErrorCodeConflict) || hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+		if hcloud.IsError(err, hcloud.ErrorCodeConflict) ||
+			hcloud.IsError(err, hcloud.ErrorCodeLocked) ||
+			hcloud.IsError(err, hcloud.ErrorCodeServiceError) ||
+			hcloud.IsError(err, hcloud.ErrorCodeNoSubnetAvailable) {
 			return err
 		}
 		if err != nil {
@@ -331,7 +334,9 @@ func detachServerFromNetwork(ctx context.Context, c *hcloud.Client, s *hcloud.Se
 		var err error
 
 		a, _, err = c.Server.DetachFromNetwork(ctx, s, hcloud.ServerDetachFromNetworkOpts{Network: n})
-		if hcloud.IsError(err, hcloud.ErrorCodeConflict) || hcloud.IsError(err, hcloud.ErrorCodeLocked) {
+		if hcloud.IsError(err, hcloud.ErrorCodeConflict) ||
+			hcloud.IsError(err, hcloud.ErrorCodeLocked) ||
+			hcloud.IsError(err, hcloud.ErrorCodeServiceError) {
 			return err
 		}
 		return control.AbortRetry(err)


### PR DESCRIPTION
In our tests we often run into those timing issues, where a Subnet still has servers; or an LB/Server can not be attached because no subnet is available. This should improve those issues by simply enabling those error codes for retrying.
Sample Test run: https://github.com/hetznercloud/terraform-provider-hcloud/runs/2921946980 
```
    resource_target_test.go:100: Step 1/1 error: Error running apply: exit status 1
        
        Error: no subnet or IP available (no_subnet_available)
        
          with hcloud_load_balancer_network.target-test-lb-network,
          on terraform_plugin_test.tf line 44, in resource "hcloud_load_balancer_network" "target-test-lb-network":
          44: resource "hcloud_load_balancer_network" "target-test-lb-network" {
        
    testing_new.go:70: Error running post-test destroy, there may be dangling resources: exit status 1
        
        Error: cannot remove subnet because servers are attached to it (service_error)
        
--- FAIL: TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP (106.37s)
```

I renamed the server/resource_server_network.go to resource_network.go to be more in line with the same LoadBalancer Resource (filename: resource_network.go)

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>