### PR TITLE
Increase amount of retries on firewall deletion

### DIFF
--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -292,7 +292,9 @@ func resourceFirewallDelete(ctx context.Context, d *schema.ResourceData, m inter
 		return hcclient.ErrorToDiag(err)
 	}
 
-	err = control.Retry(control.DefaultRetries, func() error {
+	// Removing resources from the firewall can sometimes take longer. We
+	// thus retry two times the number of DefaultRetries.
+	err = control.Retry(2*control.DefaultRetries, func() error {
 		var hcerr hcloud.Error
 		_, err := client.Firewall.Delete(ctx, firewall)
 		if errors.As(err, &hcerr) {


### PR DESCRIPTION
Depending on how fast any attached resources get removed from a firewall
it can sometimes take a while longer. Therefore we increase the amount
of retries and thus also the total timeout.