### PR TITLE
#399 apply to for firewall resource

### DIFF
--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -44,13 +44,15 @@ func Resource() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"servers": {
-							Type: schema.TypeList,
+							Type:     schema.TypeList,
+							Optional: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},
 						},
 						"labelSelectors": {
-							Type: schema.TypeList,
+							Type:     schema.TypeList,
+							Optional: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeString,
 							},

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -37,6 +37,27 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 			},
+			"apply_to": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"servers": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeInt,
+							},
+						},
+						"labelSelectors": {
+							Type: schema.TypeList,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+						},
+					},
+				},
+			},
 			"rule": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -114,6 +135,12 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m inter
 			opts.Rules = append(opts.Rules, rule)
 		}
 	}
+	if applyTo, ok := d.GetOk("apply_to"); ok {
+		for _, tfRawApplyTo := range applyTo.(*schema.Set).List() {
+			tmpApplyTo := toHcloudApplyTo(tfRawApplyTo)
+			opts.ApplyTo = append(opts.ApplyTo, tmpApplyTo...)
+		}
+	}
 	if labels, ok := d.GetOk("labels"); ok {
 		tmpLabels := make(map[string]string)
 		for k, v := range labels.(map[string]interface{}) {
@@ -135,6 +162,36 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m inter
 	d.SetId(strconv.Itoa(res.Firewall.ID))
 
 	return resourceFirewallRead(ctx, d, m)
+}
+
+func toHcloudApplyTo(tfRawApplyTo interface{}) []hcloud.FirewallResource {
+	tfApplyTo := tfRawApplyTo.(map[string]interface{})
+	var applyTo []hcloud.FirewallResource
+	for _, server := range tfApplyTo["servers"].(*schema.Set).List() {
+		applyTo = append(applyTo, hcloud.FirewallResource{
+			Type:   hcloud.FirewallResourceTypeServer,
+			Server: &hcloud.FirewallResourceServer{ID: server.(int)},
+		})
+	}
+	for _, label := range tfApplyTo["labelSelectors"].(*schema.Set).List() {
+		applyTo = append(applyTo, hcloud.FirewallResource{
+			Type:          hcloud.FirewallResourceTypeLabelSelector,
+			LabelSelector: &hcloud.FirewallResourceLabelSelector{Selector: label.(string)},
+		})
+	}
+	return applyTo
+}
+
+func toTFApplyTo(hcloudApplyTo hcloud.FirewallResource) map[string]interface{} {
+	tfApplyTo := make(map[string]interface{})
+
+	if hcloudApplyTo.Type == hcloud.FirewallResourceTypeServer {
+		tfApplyTo["server"] = []int{hcloudApplyTo.Server.ID}
+	} else {
+		tfApplyTo["labelSelectors"] = []string{hcloudApplyTo.LabelSelector.Selector}
+	}
+
+	return tfApplyTo
 }
 
 func toHcloudRule(tfRawRule interface{}) hcloud.FirewallRule {
@@ -332,8 +389,13 @@ func setFirewallSchema(d *schema.ResourceData, v *hcloud.Firewall) {
 	for i, rule := range v.Rules {
 		rules[i] = toTFRule(rule)
 	}
+	applyTo := make([]map[string]interface{}, len(v.AppliedTo))
+	for i, appliedTo := range v.AppliedTo {
+		applyTo[i] = toTFApplyTo(appliedTo)
+	}
 	d.Set("rule", rules)
 	d.Set("labels", v.Labels)
+	d.Set("apply_to", applyTo)
 }
 
 func waitForFirewallActions(ctx context.Context, client *hcloud.Client, actions []*hcloud.Action, firewall *hcloud.Firewall) error {

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -165,8 +165,8 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func validateApplyTo(tfRawApplyTo interface{}) diag.Diagnostics {
 	tfApplyTo := tfRawApplyTo.(map[string]interface{})
-	if _, ok := tfApplyTo["server"]; ok {
-		if _, ok2 := tfApplyTo["label_selector"]; ok2 {
+	if server, ok := tfApplyTo["server"]; ok && len(server.(string)) > 0 {
+		if labelSelector, ok2 := tfApplyTo["label_selector"]; ok2 && len(labelSelector.(string)) > 0 {
 			return diag.Errorf("It is not allowed to combine 'server' and 'label_selector' in one 'apply_to'. Create 'apply_to' for each 'server' and 'label_selector'.")
 		}
 	}
@@ -176,11 +176,11 @@ func validateApplyTo(tfRawApplyTo interface{}) diag.Diagnostics {
 func toHcloudApplyTo(tfRawApplyTo interface{}) hcloud.FirewallResource {
 	tfApplyTo := tfRawApplyTo.(map[string]interface{})
 	applyTo := hcloud.FirewallResource{}
-	if server, ok := tfApplyTo["server"]; ok {
+	if server, ok := tfApplyTo["server"]; ok && len(server.(string)) > 0 {
 		applyTo.Type = hcloud.FirewallResourceTypeServer
 		applyTo.Server = &hcloud.FirewallResourceServer{ID: server.(int)}
 	}
-	if labelSelector, ok := tfApplyTo["label_selector"]; ok {
+	if labelSelector, ok := tfApplyTo["label_selector"]; ok && len(labelSelector.(string)) > 0 {
 		applyTo.Type = hcloud.FirewallResourceTypeLabelSelector
 		applyTo.LabelSelector = &hcloud.FirewallResourceLabelSelector{Selector: labelSelector.(string)}
 	}

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -165,7 +165,7 @@ func resourceFirewallCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 func validateApplyTo(tfRawApplyTo interface{}) diag.Diagnostics {
 	tfApplyTo := tfRawApplyTo.(map[string]interface{})
-	if server, ok := tfApplyTo["server"]; ok && len(server.(string)) > 0 {
+	if server, ok := tfApplyTo["server"]; ok && server.(int) > 0 {
 		if labelSelector, ok2 := tfApplyTo["label_selector"]; ok2 && len(labelSelector.(string)) > 0 {
 			return diag.Errorf("It is not allowed to combine 'server' and 'label_selector' in one 'apply_to'. Create 'apply_to' for each 'server' and 'label_selector'.")
 		}
@@ -176,7 +176,7 @@ func validateApplyTo(tfRawApplyTo interface{}) diag.Diagnostics {
 func toHcloudApplyTo(tfRawApplyTo interface{}) hcloud.FirewallResource {
 	tfApplyTo := tfRawApplyTo.(map[string]interface{})
 	applyTo := hcloud.FirewallResource{}
-	if server, ok := tfApplyTo["server"]; ok && len(server.(string)) > 0 {
+	if server, ok := tfApplyTo["server"]; ok && server.(int) > 0 {
 		applyTo.Type = hcloud.FirewallResourceTypeServer
 		applyTo.Server = &hcloud.FirewallResourceServer{ID: server.(int)}
 	}

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -43,4 +43,4 @@ data "hcloud_firewall" "sample_firewall_2" {
 
 `apply_to` support the following fields:
 - `server` - (Optional, int) ID of the server to apply firewall to
-- `labelSelectors` - (Optional, string) Label selector of the firewall
+- `labelSelector` - (Optional, string) Label selector of the firewall

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -31,6 +31,7 @@ data "hcloud_firewall" "sample_firewall_2" {
 - `id` - (int) Unique ID of the Firewall.
 - `name` - (string) Name of the Firewall.
 - `rule` - (string)  Configuration of a Rule from this Firewall.
+- `apply_to` - (map)  Configuration of an ApplyTo from this Firewall.
 - `labels` - (map) User-defined labels (key-value pairs)
 
 `rule` support the following fields:
@@ -39,3 +40,7 @@ data "hcloud_firewall" "sample_firewall_2" {
 - `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `in`)
 - `destination_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `out`)
+
+`apply_to` support the following fields:
+- `server` - (Optional, int) ID of the server to apply firewall to
+- `labelSelectors` - (Optional, string) Label selector of the firewall

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -23,6 +23,12 @@ resource "hcloud_firewall" "myfirewall" {
       "::/0"
    ]
   }
+  apply_to {
+    server = 22
+  }
+  apply_to {
+    labelSelector = "security=production"
+  }
 }
 
 resource "hcloud_server" "node1" {
@@ -38,6 +44,7 @@ resource "hcloud_server" "node1" {
 - `name` - (Optional, string) Name of the Firewall.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `rule` - (Optional) Configuration of a Rule from this Firewall.
+- `apply_to` - (Optional) Configuration of an ApplyTo from this Firewall.
 
 `rule` support the following fields:
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`
@@ -45,12 +52,17 @@ resource "hcloud_server" "node1" {
 - `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`. You can use `any` to allow all ports for the specific protocol. Port ranges are also possible: `80:85` allows all ports between 80 and 85.
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule
 
+`apply_to` support the following fields:
+- `server` - (Optional, int) ID of the server to apply firewall to
+- `labelSelectors` - (Optional, string) Label selector of the firewall
+
 ## Attributes Reference
 
 - `id` - (int) Unique ID of the Firewall.
 - `name` - (string) Name of the Firewall.
 - `rule` - (string)  Configuration of a Rule from this Firewall.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `apply_to` - (map) Configuration of an ApplyTo from this Firewall.
 
 `rule` support the following fields:
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`, `out`
@@ -58,6 +70,10 @@ resource "hcloud_server" "node1" {
 - `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `in`)
 - `destination_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `out`)
+
+`apply_to` support the following fields:
+- `server` - (Optional, int) ID of the server to apply firewall to
+- `labelSelectors` - (Optional, string) Label selector of the firewall
 
 ## Import
 


### PR DESCRIPTION
Implemented argument 'apply_to' for resource 'firewall'. Thanks to this there is finally a way to apply firewall also to 'labelSelector' rather to only set it to specific server id's.