### PR TITLE
Fix date format for certificate states

### DIFF
--- a/internal/util/timeutil/format.go
+++ b/internal/util/timeutil/format.go
@@ -1,0 +1,23 @@
+package timeutil
+
+import "time"
+
+// TimeStringLayout is the layout used by time/Time.String() to create a string
+// representation of a Time value.
+const TimeStringLayout = "2006-01-02 15:04:05.999999999 -0700 MST"
+
+// ConvertFormat converts the time format of cur from curLayout to newLayout.
+//
+// This is achieved by first attempting to parse cur using old layout. If
+// parsing fails the error is returned verbatim. Usually this indicates that
+// cur did not match curLayout and the caller may act accordingly.
+//
+// If parsing cur was successful it is converted to newLayout using
+// time/Time.Format().
+func ConvertFormat(cur, curLayout, newLayout string) (string, error) {
+	t, err := time.Parse(curLayout, cur)
+	if err != nil {
+		return cur, err
+	}
+	return t.Format(newLayout), nil
+}

--- a/internal/util/timeutil/format_test.go
+++ b/internal/util/timeutil/format_test.go
@@ -1,0 +1,78 @@
+package timeutil_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/timeutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertFormat(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name      string
+		curVal    string
+		curLayout string
+		newVal    string
+		newLayout string
+		expectErr bool
+	}{
+		{
+			name:      "layout is the same",
+			curVal:    now.Format(time.RFC3339),
+			curLayout: time.RFC3339,
+			newVal:    now.Format(time.RFC3339),
+			newLayout: time.RFC3339,
+		},
+		{
+			name:      "curLayout does not match curVal",
+			curVal:    now.Format(time.RFC3339),
+			curLayout: time.RFC1123Z,
+			newLayout: time.RFC822,
+			expectErr: true,
+		},
+		{
+			name:      "successful conversion from cur to new",
+			curVal:    now.Format(time.RFC3339),
+			curLayout: time.RFC3339,
+			newVal:    now.Format(time.RFC822),
+			newLayout: time.RFC822,
+		},
+		{
+			name:      "convert from TimeStringLayout",
+			curVal:    now.UTC().String(),
+			curLayout: timeutil.TimeStringLayout,
+			newVal:    now.UTC().Format(time.RFC3339),
+			newLayout: time.RFC3339,
+		},
+		{
+			name:      "convert from TimeStringLayout",
+			curVal:    "2021-05-27 14:39:46.877103 +0000 +0000",
+			curLayout: timeutil.TimeStringLayout,
+			newVal:    "2021-05-27T14:39:46Z",
+			newLayout: time.RFC3339,
+		},
+		{
+			name:      "convert from TimeStringLayout",
+			curVal:    "2021-05-27 14:39:46.877103 +0000 UTC",
+			curLayout: timeutil.TimeStringLayout,
+			newVal:    "2021-05-27T14:39:46Z",
+			newLayout: time.RFC3339,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := timeutil.ConvertFormat(tt.curVal, tt.curLayout, tt.newLayout)
+			if tt.expectErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.newVal, v)
+		})
+	}
+}


### PR DESCRIPTION
Previously the created date of a certificate was stored as the Go string
representation of a time.Time value. If the time was in UTC this lead to
issues because the time was stored in an invalid format. This behavior
of the time/Time.String function is known and intended:
https://github.com/golang/go/issues/11712

This commit fixes the created date by storing it in RFC3339 format.
Additionally it adds a migration for states containing the invalid
format to the new format.

We had a similar issue for image time stamps. This was fixed in PR #385.
However, PR #385 does not add a migration for the state. In order to
keep the changes isolated this commit does add the migration
retroactively. This will be done in a separate commit.

Closes #421