### PR TITLE
Deprecate hcloud_load_balancer resource `target` property

### DIFF
--- a/internal/loadbalancer/resource.go
+++ b/internal/loadbalancer/resource.go
@@ -89,9 +89,10 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"target": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Computed:   true,
+				Deprecated: "Use hcloud_load_balancer_target resource instead. This allows the full control over the selected targets.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {

--- a/internal/loadbalancer/resource_target.go
+++ b/internal/loadbalancer/resource_target.go
@@ -257,6 +257,10 @@ func resourceLoadBalancerTargetRead(ctx context.Context, d *schema.ResourceData,
 	tgtType := hcloud.LoadBalancerTargetType(d.Get("type").(string))
 
 	_, tgt, err := findLoadBalancerTarget(ctx, client, lbID, tgtType, d)
+	if errors.Is(err, errLoadBalancerTargetNotFound) {
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
@@ -272,7 +276,8 @@ func resourceLoadBalancerTargetUpdate(ctx context.Context, d *schema.ResourceDat
 
 	lb, tgt, err := findLoadBalancerTarget(ctx, client, lbID, tgtType, d)
 	if errors.Is(err, errLoadBalancerTargetNotFound) {
-		return resourceLoadBalancerTargetCreate(ctx, d, m)
+		d.SetId("")
+		return nil
 	}
 	if err != nil {
 		return hcclient.ErrorToDiag(err)

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -37,17 +37,11 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `location` - (Optional, string) Location of the Load Balancer. Require when no network_zone is set.
 - `network_zone` - (Optional, string) Network Zone of the Load Balancer. Require when no location is set.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
-- `target` - (Optional, list) List of targets of the Load Balancer.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `delete_protection` - (Optional, boolean) Enable or disable delete protection.
 
 `algorithm` support the following fields:
 - `type` - (Required, string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`
-
-`target` support the following fields:
-- `type` - (Required, string) Type of the target. `server`
-- `server_id` - (Optional, int) ID of the server which should be a target for this Load Balancer. Required if `type` is `server`
-
 
 ## Attributes Reference
 
@@ -58,18 +52,12 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `ipv4` - (string) IPv4 Address of the Load Balancer.
 - `ipv6` - (string) IPv4 Address of the Load Balancer.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
-- `target` - (list) List of targets of the Load Balancer.
 - `service` - (list) List of services a Load Balancer provides.
 - `labels` - (map) User-defined labels (key-value pairs).
 - `delete_protection` - (boolean) Whether delete protection is enabled.
 
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`
-
-`target` supports the following fields, which are a restricted sub-set
-of the fields supported by `hcloud_load_balancer_target`:
-- `type` - (string) Type of the target. `server`
-- `server_id` - (int) ID of the server which should be a target for this Load Balancer.
 
 ## Import
 


### PR DESCRIPTION
Additionally this fixes a few smaller inconsistencies with the provider spec for `load_balancer_target`

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>