### PR TITLE
Remove testing & official support of Terraform < 1.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: [ "0.13.x", "0.14.x", "0.15.x", "1.0.x" ]
+        terraform_version: [ "1.0.x" ]
     name: integration-${{ matrix.terraform_version }}
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Terraform Provider for the Hetzner Cloud
 Requirements
 ------------
 
--	[Terraform](https://www.terraform.io/downloads.html) 0.13.x, 0.14.x, 0.15.x, 1.0.x
+-	[Terraform](https://www.terraform.io/downloads.html) 1.0.x
 -	[Go](https://golang.org/doc/install) 1.17.x (to build the provider plugin)
 
 API Stability


### PR DESCRIPTION
Older Terraform releases might still work, however we do not support them officially anymore. If you encounter an issue with pre Terraform 1.0 and you can not reproduce it on 1.0 we might not fix it.

Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>