### PR TITLE
hcloud_firewall resource & datasource: Add apply_to possibility

### DIFF
--- a/internal/e2etests/firewall/data_source_test.go
+++ b/internal/e2etests/firewall/data_source_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
-	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{})
+	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{}, nil)
 	res.SetRName("firewall-ds-test")
 	firewallByName := &firewall.DData{
 		FirewallName: res.TFID() + ".name",
@@ -64,7 +64,7 @@ func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
 }
 
 func TestAccHcloudDataSourceFirewallListTest(t *testing.T) {
-	res := firewall.NewRData(t, "firewall-ds-test", []firewall.RDataRule{})
+	res := firewall.NewRData(t, "firewall-ds-test", []firewall.RDataRule{}, nil)
 
 	firewallBySel := &firewall.DDataList{
 		LabelSelector: fmt.Sprintf("key=${%s.labels[\"key\"]}", res.TFID()),

--- a/internal/e2etests/server/resource_test.go
+++ b/internal/e2etests/server/resource_test.go
@@ -365,7 +365,7 @@ func TestServerResource_Firewalls(t *testing.T) {
 			Protocol:  "icmp",
 			SourceIPs: []string{"0.0.0.0/0", "::/0"},
 		},
-	})
+	}, nil)
 	fw2 := firewall.NewRData(t, "server-test-2", []firewall.RDataRule{
 		{
 			Direction: "in",
@@ -373,7 +373,7 @@ func TestServerResource_Firewalls(t *testing.T) {
 			SourceIPs: []string{"0.0.0.0/0", "::/0"},
 			Port:      "1-65535",
 		},
-	})
+	}, nil)
 	res := &server.RData{
 		Name:        "server-firewall",
 		Type:        e2etests.TestServerType,

--- a/internal/firewall/data_source.go
+++ b/internal/firewall/data_source.go
@@ -40,6 +40,24 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Type:     schema.TypeMap,
 			Optional: true,
 		},
+		"apply_to": {
+			Type:     schema.TypeSet,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"label_selector": {
+						Type:     schema.TypeString,
+						Optional: true,
+						Computed: true,
+					},
+					"server": {
+						Type:     schema.TypeInt,
+						Optional: true,
+						Computed: true,
+					},
+				},
+			},
+		},
 		"rule": {
 			Type:     schema.TypeSet,
 			Optional: true,

--- a/internal/firewall/testing.go
+++ b/internal/firewall/testing.go
@@ -91,9 +91,10 @@ func (d *DDataList) TFID() string {
 type RData struct {
 	testtemplate.DataCommon
 
-	Name   string
-	Rules  []RDataRule
-	Labels map[string]string
+	Name    string
+	Rules   []RDataRule
+	ApplyTo []RDataApplyTo
+	Labels  map[string]string
 }
 
 // RData defines the fields for the "testdata/r/hcloud_firewall"
@@ -107,18 +108,24 @@ type RDataRule struct {
 	Description    string
 }
 
+type RDataApplyTo struct {
+	Server        string
+	LabelSelector string
+}
+
 // TFID returns the resource identifier.
 func (d *RData) TFID() string {
 	return fmt.Sprintf("%s.%s", ResourceType, d.RName())
 }
 
 // NewRData creates data for a new firewall resource.
-func NewRData(t *testing.T, name string, rules []RDataRule) *RData {
+func NewRData(t *testing.T, name string, rules []RDataRule, applyTo []RDataApplyTo) *RData {
 	rInt := acctest.RandInt()
 	r := &RData{
-		Name:   name,
-		Rules:  rules,
-		Labels: map[string]string{"key": strconv.Itoa(rInt)},
+		Name:    name,
+		Rules:   rules,
+		ApplyTo: applyTo,
+		Labels:  map[string]string{"key": strconv.Itoa(rInt)},
 	}
 	r.SetRName(name)
 	return r

--- a/internal/testdata/r/hcloud_firewall.tf.tmpl
+++ b/internal/testdata/r/hcloud_firewall.tf.tmpl
@@ -30,6 +30,18 @@ resource "hcloud_firewall" "{{ .RName }}" {
     }
 {{- end }}
 {{- end }}
+{{- if .ApplyTo }}
+{{- range $v := .ApplyTo }}
+   apply_to {
+{{- if $v.Server }}
+        server = "{{ $v.Server }}"
+{{- end }}
+{{- if $v.LabelSelector }}
+        label_selector = "{{ $v.LabelSelector }}"
+{{- end }}
+   }
+{{- end }}
+{{- end }}
 {{- if .Labels }}
     labels = {
     {{- range $k,$v := .Labels }}

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -33,6 +33,7 @@ data "hcloud_firewall" "sample_firewall_2" {
 - `name` - (string) Name of the Firewall.
 - `rule` - (string)  Configuration of a Rule from this Firewall.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `apply_to` - Configuration of the Applied Resources
 
 `rule` support the following fields:
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`, `out`
@@ -41,3 +42,8 @@ data "hcloud_firewall" "sample_firewall_2" {
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `in`)
 - `destination_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `out`)
 - `description` - (Optional, string) Description of the firewall rule
+
+`apply_to` support the following fields:
+- `label_selector` - (string) Label Selector to select servers the firewall is applied to. Empty if a server is directly
+  referenced
+- `server` - (int) ID of a server where the firewall is applied to. `0` if applied to a label_selector

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -2,8 +2,7 @@
 layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_firewall"
 sidebar_current: "docs-hcloud-resource-firewall"
-description: |-
-Provides a Hetzner Cloud Firewall to represent a Firewall in the Hetzner Cloud.
+description: |- Provides a Hetzner Cloud Firewall to represent a Firewall in the Hetzner Cloud.
 ---
 
 # hcloud_firewall
@@ -49,28 +48,46 @@ resource "hcloud_server" "node1" {
 - `name` - (Optional, string) Name of the Firewall.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `rule` - (Optional) Configuration of a Rule from this Firewall.
+- `apply_to` (Optional) Resources the firewall should be assigned to
 
 `rule` support the following fields:
+
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`
 - `protocol` - (Required, string) Protocol of the Firewall Rule. `tcp`, `icmp`, `udp`, `gre`, `esp`
-- `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`. You can use `any` to allow all ports for the specific protocol. Port ranges are also possible: `80-85` allows all ports between 80 and 85.
+- `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`. You can use `any`
+  to allow all ports for the specific protocol. Port ranges are also possible: `80-85` allows all ports between 80 and
+  85.
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule
 - `description` - (Optional, string) Description of the firewall rule
+
+`apply_to` support the following fields:
+
+- `label_selector` - (Optional, string) Label Selector to select servers the firewall should be applied to (only one
+  of `server` and `label_selector`can be applied in one block)
+- `server` - (Optional, int) ID of the server you want to apply the firewall to (only one of `server`
+  and `label_selector`can be applied in one block)
 
 ## Attributes Reference
 
 - `id` - (int) Unique ID of the Firewall.
 - `name` - (string) Name of the Firewall.
-- `rule` - (string)  Configuration of a Rule from this Firewall.
+- `rule` - Configuration of a Rule from this Firewall.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `apply_to` - Configuration of the Applied Resources
 
 `rule` support the following fields:
 - `direction` - (Required, string) Direction of the Firewall Rule. `in`, `out`
 - `protocol` - (Required, string) Protocol of the Firewall Rule. `tcp`, `icmp`, `udp`, `gre`, `esp`
 - `port` - (Required, string) Port of the Firewall Rule. Required when `protocol` is `tcp` or `udp`
 - `source_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `in`)
-- `destination_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction` is `out`)
+- `destination_ips` - (Required, List) List of CIDRs that are allowed within this Firewall Rule (when `direction`
+  is `out`)
 - `description` - (Optional, string) Description of the firewall rule
+
+`apply_to` support the following fields:
+- `label_selector` - (string) Label Selector to select servers the firewall is applied to. Empty if a server is directly
+  referenced
+- `server` - (int) ID of a server where the firewall is applied to. `0` if applied to a label_selector
 
 ## Import
 


### PR DESCRIPTION
Allow users to specify resources the firewall should be attache to within the hcloud_firewall resource

Fixes #399 
Supersedes #406
Signed-off-by: Lukas Kämmerling <lukas.kaemmerling@hetzner-cloud.de>