### PR TITLE
Make the image property of hcloud_server optional

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -46,7 +46,7 @@ func Resource() *schema.Resource {
 			},
 			"image": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				ValidateFunc: func(val interface{}, key string) (i []string, errors []error) {
 					image := val.(string)

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -69,7 +69,7 @@ The following arguments are supported:
 
 - `name` - (Required, string) Name of the server to create (must be unique per project and a valid hostname as per RFC 1123).
 - `server_type` - (Required, string) Name of the server type this server should be created with.
-- `image` - (Required, string) Name or ID of the image the server is created from.
+- `image` - (Required, string) Name or ID of the image the server is created from. **Note** the `image` property is only required when using the resource to create servers. As the Hetzner Cloud API may return servers without an image ID set it is not marked as required in the Terraform Provider itself. Thus, users will get an error from the underlying client library if they forget to set the property and try to create a server.
 - `location` - (Optional, string) The location name to create the server in. `nbg1`, `fsn1`, `hel1` or `ash`
 - `datacenter` - (Optional, string) The datacenter name to create the server in.
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation


### PR DESCRIPTION
Users wishing to import existing infrastructure into Terraform may run
into the error described in #490.

In some cases our backend deleted the reference to the image a server
was created from. This leads to the API returning `null` instead of an
image for the server. This is ok according to the API docs for the
object returned by GET /v1/server/{id} resource. In contrast POST
/v1/server requires the image field to be set to a string value.
Therefore the image property of the Terraform hcloud_server resource was
marked as required since the first commit. However, this makes it
impossible to import existing server resources for which we removed the
reference to the image.

This commit makes the image property optional in Terraform and thus
should enable users to import existing infrastructure. However, as soon
as users change any properties of the server that require the server to
be recreated, they will absolutely need to set the image property.
Failing to do so will result in an error.

Closes #490