### PR TITLE
Implement hcloud_firewall_attachment resource

### DIFF
--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -71,6 +71,7 @@ func Provider() *schema.Provider {
 			certificate.ResourceType:          certificate.UploadedResource(), // Alias for backwards compatibility.
 			certificate.ManagedResourceType:   certificate.ManagedResource(),
 			firewall.ResourceType:             firewall.Resource(),
+			firewall.AttachmentResourceType:   firewall.AttachmentResource(),
 			floatingip.AssignmentResourceType: floatingip.AssignmentResource(),
 			floatingip.ResourceType:           floatingip.Resource(),
 			loadbalancer.NetworkResourceType:  loadbalancer.NetworkResource(),

--- a/hcloud/provider_test.go
+++ b/hcloud/provider_test.go
@@ -32,6 +32,7 @@ func TestProvider_Resources(t *testing.T) {
 	expectedResources := []string{
 		certificate.ResourceType,
 		firewall.ResourceType,
+		firewall.AttachmentResourceType,
 		certificate.UploadedResourceType,
 		certificate.ManagedResourceType,
 		floatingip.AssignmentResourceType,

--- a/internal/e2etests/firewall/attachment_resource_test.go
+++ b/internal/e2etests/firewall/attachment_resource_test.go
@@ -1,0 +1,100 @@
+package firewall
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/e2etests"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
+)
+
+func TestAttachmentResource_Servers(t *testing.T) {
+	var (
+		srv hcloud.Server
+		fw  hcloud.Firewall
+	)
+
+	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
+	srvRes := &server.RData{
+		Name:  "test-server",
+		Type:  e2etests.TestServerType,
+		Image: e2etests.TestImage,
+	}
+	srvRes.SetRName("test_server")
+
+	fwAttRes := firewall.NewRDataAttachment("fw_ref", fwRes.TFID()+".id")
+	fwAttRes.ServerIDRefs = append(fwAttRes.ServerIDRefs, srvRes.TFID()+".id")
+
+	tmplMan := testtemplate.Manager{}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  e2etests.PreCheck(t),
+		Providers: e2etests.Providers(),
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &srv)),
+			testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &fw)),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", srvRes,
+					"testdata/r/hcloud_firewall", fwRes,
+					"testdata/r/hcloud_firewall_attachment", fwAttRes,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(srvRes.TFID(), server.ByID(t, &srv)),
+					testsupport.CheckResourceExists(fwRes.TFID(), firewall.ByID(t, &fw)),
+					testsupport.LiftTCF(hasServerResource(t, &fw, &srv)),
+				),
+			},
+		},
+	})
+}
+
+func TestAttachmentResource_LabelSelectors(t *testing.T) {
+	var (
+		srv hcloud.Server
+		fw  hcloud.Firewall
+	)
+
+	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
+	srvRes := &server.RData{
+		Name:  "test-server",
+		Type:  e2etests.TestServerType,
+		Image: e2etests.TestImage,
+		Labels: map[string]string{
+			"firewall-attachment": "test-server",
+		},
+	}
+	srvRes.SetRName("test_server")
+
+	fwAttRes := firewall.NewRDataAttachment("fw_ref", fwRes.TFID()+".id")
+	fwAttRes.LabelSelectors = append(fwAttRes.LabelSelectors, "firewall-attachment=test-server")
+
+	tmplMan := testtemplate.Manager{}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  e2etests.PreCheck(t),
+		Providers: e2etests.Providers(),
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &srv)),
+			testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &fw)),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", srvRes,
+					"testdata/r/hcloud_firewall", fwRes,
+					"testdata/r/hcloud_firewall_attachment", fwAttRes,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(srvRes.TFID(), server.ByID(t, &srv)),
+					testsupport.CheckResourceExists(fwRes.TFID(), firewall.ByID(t, &fw)),
+					testsupport.LiftTCF(hasLabelSelectorResource(t, &fw, "firewall-attachment=test-server")),
+				),
+			},
+		},
+	})
+}

--- a/internal/e2etests/firewall/resource_test.go
+++ b/internal/e2etests/firewall/resource_test.go
@@ -281,13 +281,10 @@ func hasFirewallRule(
 	}
 }
 
-func hasLabelSelectorResource(
-	t *testing.T,
-	f *hcloud.Firewall,
-	labelSelector string,
-) func() error {
+func hasLabelSelectorResource(t *testing.T, f *hcloud.Firewall, labelSelector string) func() error {
 	return func() error {
 		var firewallResource *hcloud.FirewallResource
+
 		for _, r := range f.AppliedTo {
 			if r.Type == hcloud.FirewallResourceTypeLabelSelector && r.LabelSelector.Selector == labelSelector {
 				firewallResource = &r
@@ -297,6 +294,19 @@ func hasLabelSelectorResource(
 		if !assert.NotNil(t, firewallResource, "firewall has no resource for this") {
 			return nil
 		}
+		return nil
+	}
+}
+
+func hasServerResource(t *testing.T, fw *hcloud.Firewall, srv *hcloud.Server) func() error {
+	return func() error {
+		for _, r := range fw.AppliedTo {
+			if r.Type == hcloud.FirewallResourceTypeServer && r.Server.ID == srv.ID {
+				return nil
+			}
+		}
+
+		t.Errorf("Firewall %d has no server resource for server %d", fw.ID, srv.ID)
 		return nil
 	}
 }

--- a/internal/e2etests/server/resource_test.go
+++ b/internal/e2etests/server/resource_test.go
@@ -62,7 +62,8 @@ func TestServerResource_Basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"ssh_keys", "user_data", "keep_disk"},
+					"ssh_keys", "user_data", "keep_disk", "ignore_remote_firewall_ids",
+				},
 			},
 			{
 				// Update the Server created in the previous step by

--- a/internal/firewall/attachment_resource.go
+++ b/internal/firewall/attachment_resource.go
@@ -1,0 +1,345 @@
+package firewall
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/hcclient"
+)
+
+// AttachmentResourceType is the type of the hcloud_firewall_attachment resource.
+const AttachmentResourceType = "hcloud_firewall_attachment"
+
+// AttachmentResource defines the schema for the hcloud_firewall_attachment
+// resource.
+func AttachmentResource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext:   readAttachment,
+		CreateContext: createAttachment,
+		UpdateContext: updateAttachment,
+		DeleteContext: deleteAttachment,
+
+		Schema: map[string]*schema.Schema{
+			"firewall_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"server_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeInt,
+				},
+			},
+			"label_selectors": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func readAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var att attachment
+
+	if err := att.FromResourceData(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := m.(*hcloud.Client)
+	fw, _, err := client.Firewall.GetByID(ctx, att.FirewallID)
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	if fw == nil {
+		log.Printf("[WARN] firewall (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if err := att.FromFirewall(fw); err != nil {
+		return diag.FromErr(err)
+	}
+	att.ToResourceData(d)
+
+	return nil
+}
+
+func createAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
+	var att attachment
+
+	if err := att.FromResourceData(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := m.(*hcloud.Client)
+	action, _, err := client.Firewall.ApplyResources(ctx, &hcloud.Firewall{ID: att.FirewallID}, att.AllResources())
+	if hcloud.IsError(err, hcloud.ErrorCodeFirewallAlreadyApplied) {
+		return readAttachment(ctx, d, m)
+	}
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	if err := hcclient.WaitForActions(ctx, &client.Action, action); err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+
+	return readAttachment(ctx, d, m)
+}
+
+func updateAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	var (
+		tf, hc  attachment
+		actions []*hcloud.Action
+	)
+
+	if err := tf.FromResourceData(d); err != nil {
+		return diag.FromErr(err)
+	}
+
+	client := m.(*hcloud.Client)
+	fw, _, err := client.Firewall.GetByID(ctx, tf.FirewallID)
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	if fw == nil {
+		log.Printf("[WARN] firewall (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+	if err := hc.FromFirewall(fw); err != nil {
+		return diag.FromErr(err)
+	}
+
+	less, more := tf.DiffResources(hc)
+	as, _, err := client.Firewall.RemoveResources(ctx, fw, less)
+	if err != nil && !hcloud.IsError(err, hcloud.ErrorCodeFirewallAlreadyRemoved) {
+		return hcclient.ErrorToDiag(err)
+	}
+	actions = append(actions, as...)
+
+	as, _, err = client.Firewall.ApplyResources(ctx, fw, more)
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	actions = append(actions, as...)
+
+	if err := hcclient.WaitForActions(ctx, &client.Action, actions); err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+
+	return readAttachment(ctx, d, m)
+}
+
+func deleteAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
+	var att attachment
+
+	defer func() {
+		if diags != nil {
+			return
+		}
+		d.SetId("")
+	}()
+
+	if err := att.FromResourceData(d); err != nil {
+		return diag.FromErr(err)
+	}
+	client := m.(*hcloud.Client)
+	action, _, err := client.Firewall.RemoveResources(ctx, &hcloud.Firewall{ID: att.FirewallID}, att.AllResources())
+	if hcloud.IsError(err, hcloud.ErrorCodeFirewallAlreadyRemoved) {
+		return nil
+	}
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	if err := hcclient.WaitForActions(ctx, &client.Action, action); err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+	return nil
+}
+
+type attachment struct {
+	FirewallID     int
+	ServerIDs      []int
+	LabelSelectors []string
+}
+
+// FromResourceData copies the contents of d into a
+func (a *attachment) FromResourceData(d *schema.ResourceData) error {
+	// The terraform schema definition above ensures this is always set and
+	// of the correct type. Thus there is no need to check such things.
+	a.FirewallID = d.Get("firewall_id").(int)
+
+	srvIDs, ok := d.GetOk("server_ids")
+	if ok {
+		for _, v := range srvIDs.(*schema.Set).List() {
+			a.ServerIDs = append(a.ServerIDs, v.(int))
+		}
+		sort.Slice(a.ServerIDs, func(i, j int) bool {
+			return a.ServerIDs[i] < a.ServerIDs[j]
+		})
+	}
+
+	lSels, ok := d.GetOk("label_selectors")
+	if ok {
+		for _, v := range lSels.(*schema.Set).List() {
+			a.LabelSelectors = append(a.LabelSelectors, v.(string))
+		}
+		sort.Slice(a.LabelSelectors, func(i, j int) bool {
+			return a.LabelSelectors[i] < a.LabelSelectors[j]
+		})
+	}
+
+	if len(a.ServerIDs) == 0 && len(a.LabelSelectors) == 0 {
+		return fmt.Errorf("no resources referenced")
+	}
+	return nil
+}
+
+// ToResourceData copies the contents of a into d.
+//
+// Any previously existing values in d are overwritten or removed.
+func (a *attachment) ToResourceData(d *schema.ResourceData) {
+	var srvIDs, lSels *schema.Set
+
+	if len(a.ServerIDs) > 0 {
+		vals := make([]interface{}, len(a.ServerIDs))
+		for i, id := range a.ServerIDs {
+			vals[i] = id
+		}
+		f := d.Get("server_ids").(*schema.Set).F // Returns a default value if server_ids is not present in HCL.
+		srvIDs = schema.NewSet(f, vals)
+	}
+	d.Set("server_ids", srvIDs)
+
+	if len(a.LabelSelectors) > 0 {
+		vals := make([]interface{}, len(a.LabelSelectors))
+		for i, ls := range a.LabelSelectors {
+			vals[i] = ls
+		}
+		f := d.Get("label_selectors").(*schema.Set).F
+		lSels = schema.NewSet(f, vals)
+	}
+	d.Set("label_selectors", lSels)
+
+	d.Set("firewall_id", a.FirewallID)
+	d.SetId(strconv.Itoa(a.FirewallID))
+}
+
+// FromFirewall reads the attachment data from fw into a.
+func (a *attachment) FromFirewall(fw *hcloud.Firewall) error {
+	// We do not need to read the fw.ID. This value is always set in HCL.
+	// Additionally the intended use-case makes sure that we never get data
+	// for the wrong firewall. Therefore comparing fw.ID to a.FirewallID
+	// is not necessary.
+
+	for _, fwr := range fw.AppliedTo {
+		switch fwr.Type {
+		case hcloud.FirewallResourceTypeServer:
+			a.ServerIDs = append(a.ServerIDs, fwr.Server.ID)
+		case hcloud.FirewallResourceTypeLabelSelector:
+			a.LabelSelectors = append(a.LabelSelectors, fwr.LabelSelector.Selector)
+		default:
+			return fmt.Errorf("invalid firewall resource type: %v", fwr.Type)
+		}
+	}
+
+	return nil
+}
+
+// AllResources returns all Hetzner Cloud Firewall that are attached to
+// the Firewall of this attachment.
+func (a *attachment) AllResources() []hcloud.FirewallResource {
+	n := len(a.ServerIDs) + len(a.LabelSelectors)
+	if n == 0 {
+		return nil
+	}
+
+	ress := make([]hcloud.FirewallResource, 0, n)
+	for _, id := range a.ServerIDs {
+		ress = append(ress, serverResource(id))
+	}
+	for _, ls := range a.LabelSelectors {
+		ress = append(ress, labelSelectorResource(ls))
+	}
+
+	return ress
+}
+
+// DiffResources compares the Firewall resources of a to the resources of o.
+//
+// The first return value contains all resources that are present in o but
+// missing in a. The second return value is a slice containing all resources
+// present in a but missing in o.
+func (a *attachment) DiffResources(o attachment) ([]hcloud.FirewallResource, []hcloud.FirewallResource) {
+	var more, less []hcloud.FirewallResource // nolint: prealloc
+
+	aSrvs := make(map[int]bool, len(a.ServerIDs))
+	for _, id := range a.ServerIDs {
+		aSrvs[id] = true
+	}
+	for _, id := range o.ServerIDs {
+		if aSrvs[id] {
+			continue
+		}
+		less = append(less, serverResource(id))
+	}
+
+	aLSels := make(map[string]bool, len(a.LabelSelectors))
+	for _, ls := range a.LabelSelectors {
+		aLSels[ls] = true
+	}
+	for _, ls := range o.LabelSelectors {
+		if aLSels[ls] {
+			continue
+		}
+		less = append(less, labelSelectorResource(ls))
+	}
+
+	oSrvs := make(map[int]bool, len(o.ServerIDs))
+	for _, id := range o.ServerIDs {
+		oSrvs[id] = true
+	}
+	for _, id := range a.ServerIDs {
+		if oSrvs[id] {
+			continue
+		}
+		more = append(more, serverResource(id))
+	}
+
+	oLSels := make(map[string]bool, len(o.LabelSelectors))
+	for _, ls := range o.LabelSelectors {
+		oLSels[ls] = true
+	}
+	for _, ls := range a.LabelSelectors {
+		if oLSels[ls] {
+			continue
+		}
+		more = append(more, labelSelectorResource(ls))
+	}
+
+	return less, more
+}
+
+func serverResource(id int) hcloud.FirewallResource {
+	return hcloud.FirewallResource{
+		Type:   hcloud.FirewallResourceTypeServer,
+		Server: &hcloud.FirewallResourceServer{ID: id},
+	}
+}
+
+func labelSelectorResource(ls string) hcloud.FirewallResource {
+	return hcloud.FirewallResource{
+		Type:          hcloud.FirewallResourceTypeLabelSelector,
+		LabelSelector: &hcloud.FirewallResourceLabelSelector{Selector: ls},
+	}
+}

--- a/internal/firewall/attachment_resource_internal_test.go
+++ b/internal/firewall/attachment_resource_internal_test.go
@@ -1,0 +1,344 @@
+package firewall
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttachment_FromResourceData(t *testing.T) {
+	tests := []struct {
+		name      string
+		rawData   map[string]interface{}
+		att       attachment
+		assertErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "server_ids and label_selectors present",
+			rawData: map[string]interface{}{
+				"firewall_id":     4711,
+				"server_ids":      []interface{}{1, 2, 3},
+				"label_selectors": []interface{}{"key1=value1", "key2=value2"},
+			},
+			att: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+		},
+		{
+			name: "only server_ids present",
+			rawData: map[string]interface{}{
+				"firewall_id": 4712,
+				"server_ids":  []interface{}{4, 5, 6},
+			},
+			att: attachment{
+				FirewallID: 4712,
+				ServerIDs:  []int{4, 5, 6},
+			},
+		},
+		{
+			name: "only label_selectors present",
+			rawData: map[string]interface{}{
+				"firewall_id":     4713,
+				"label_selectors": []interface{}{"key3=value3", "key4=value4"},
+			},
+			att: attachment{
+				FirewallID:     4713,
+				LabelSelectors: []string{"key3=value3", "key4=value4"},
+			},
+		},
+		{
+			name: "only firewall id present",
+			rawData: map[string]interface{}{
+				"firewall_id": 4714,
+			},
+			att: attachment{
+				FirewallID: 4714,
+			},
+			assertErr: func(t assert.TestingT, err error, args ...interface{}) bool {
+				return assert.EqualError(t, err, "no resources referenced", args...)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var actual attachment
+
+			data := schema.TestResourceDataRaw(t, AttachmentResource().Schema, tt.rawData)
+			err := actual.FromResourceData(data)
+			if tt.assertErr != nil {
+				tt.assertErr(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.att, actual)
+		})
+	}
+}
+
+func TestAttachment_ToResourceData(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawData map[string]interface{}
+		att     attachment
+	}{
+		{
+			name: "server_ids and label_selectors present",
+			att: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+		},
+		{
+			name: "only server_ids present",
+			att: attachment{
+				FirewallID: 4712,
+				ServerIDs:  []int{4, 5, 6},
+			},
+		},
+		{
+			name: "only label_selectors present",
+			att: attachment{
+				FirewallID:     4713,
+				LabelSelectors: []string{"key3=value3", "key4=value4"},
+			},
+		},
+		{
+			name: "remove pre-existing server_ids",
+			rawData: map[string]interface{}{
+				"firewall_id": 4714,
+				"server_ids":  []interface{}{1, 2, 3},
+			},
+			att: attachment{
+				FirewallID:     4714,
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+		},
+		{
+			name: "remove pre-existing label_selectors",
+			rawData: map[string]interface{}{
+				"firewall_id":     4714,
+				"label_selectors": []interface{}{"key1=value1", "key2=value2"},
+			},
+			att: attachment{
+				FirewallID: 4714,
+				ServerIDs:  []int{1, 2, 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			data := schema.TestResourceDataRaw(t, AttachmentResource().Schema, tt.rawData)
+
+			tt.att.ToResourceData(data)
+
+			assert.Equal(t, data.Id(), strconv.Itoa(tt.att.FirewallID))
+			assert.Equal(t, data.Get("firewall_id"), tt.att.FirewallID)
+
+			srvIDdata, ok := data.GetOk("server_ids")
+			if len(tt.att.ServerIDs) > 0 {
+				assert.True(t, ok, "expected data to contain server_ids")
+
+				// Need to iterate as the types of the slices don't match: []int vs []interface{}
+				for _, id := range tt.att.ServerIDs {
+					assert.Contains(t, srvIDdata.(*schema.Set).List(), id)
+				}
+			} else {
+				assert.False(t, ok, "expected no server_ids in data")
+			}
+
+			labelSelData, ok := data.GetOk("label_selectors")
+			if len(tt.att.LabelSelectors) > 0 {
+				assert.True(t, ok, "expected data to contain label_selectors")
+
+				for _, ls := range tt.att.LabelSelectors {
+					assert.Contains(t, labelSelData.(*schema.Set).List(), ls)
+				}
+			} else {
+				assert.False(t, ok, "expected no label_selectors in data")
+			}
+		})
+	}
+}
+
+func TestAttachment_FromFirewall(t *testing.T) {
+	tests := []struct {
+		name        string
+		fw          *hcloud.Firewall // partial data is enough for this test.
+		att         attachment
+		assertError assert.ErrorAssertionFunc
+	}{
+		{
+			name: "nothing attached to firewall",
+			fw:   &hcloud.Firewall{ID: 4711},
+			att:  attachment{FirewallID: 4711},
+		},
+		{
+			name: "only servers attached to firewall",
+			fw: &hcloud.Firewall{
+				ID: 4712,
+				AppliedTo: []hcloud.FirewallResource{
+					serverResource(1),
+					serverResource(2),
+				},
+			},
+			att: attachment{
+				FirewallID: 4712,
+				ServerIDs:  []int{1, 2},
+			},
+		},
+		{
+			name: "only label selectors attached to firewall",
+			fw: &hcloud.Firewall{
+				ID: 4713,
+				AppliedTo: []hcloud.FirewallResource{
+					labelSelectorResource("key1=value1"),
+					labelSelectorResource("key2=value2"),
+				},
+			},
+			att: attachment{
+				FirewallID:     4713,
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+		},
+		{
+			name: "invalid attachment type",
+			fw: &hcloud.Firewall{
+				ID: 4714,
+				AppliedTo: []hcloud.FirewallResource{
+					{
+						Type: hcloud.FirewallResourceType("invalid"),
+					},
+				},
+			},
+			assertError: func(t assert.TestingT, err error, args ...interface{}) bool {
+				return assert.EqualError(t, err, "invalid firewall resource type: invalid", args...)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			att := attachment{FirewallID: tt.fw.ID}
+			err := att.FromFirewall(tt.fw)
+			if tt.assertError != nil {
+				tt.assertError(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.att, att)
+		})
+	}
+}
+
+func TestAttachment_AllResources(t *testing.T) {
+	tests := []struct {
+		name string
+		att  attachment
+		res  []hcloud.FirewallResource
+	}{
+		{
+			name: "no resources attached",
+			att:  attachment{FirewallID: 4711},
+		},
+		{
+			name: "servers and label selectors attached",
+			att: attachment{
+				FirewallID:     4712,
+				ServerIDs:      []int{1, 2},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+			res: []hcloud.FirewallResource{
+				serverResource(1),
+				serverResource(2),
+				labelSelectorResource("key1=value1"),
+				labelSelectorResource("key2=value2"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			actual := tt.att.AllResources()
+			assert.ElementsMatch(t, tt.res, actual)
+		})
+	}
+}
+
+func TestAttachment_DiffResources(t *testing.T) {
+	tests := []struct {
+		name  string
+		att   attachment
+		other attachment
+		more  []hcloud.FirewallResource
+		less  []hcloud.FirewallResource
+	}{
+		{
+			name: "nothing changed",
+			att: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+			other: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+		},
+		{
+			name: "resources in att but not in other",
+			att: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+			other: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2},
+				LabelSelectors: []string{"key1=value1"},
+			},
+			more: []hcloud.FirewallResource{
+				serverResource(3),
+				labelSelectorResource("key2=value2"),
+			},
+		},
+		{
+			name: "resources in other but not in att",
+			att: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2},
+				LabelSelectors: []string{"key1=value1"},
+			},
+			other: attachment{
+				FirewallID:     4711,
+				ServerIDs:      []int{1, 2, 3},
+				LabelSelectors: []string{"key1=value1", "key2=value2"},
+			},
+			less: []hcloud.FirewallResource{
+				serverResource(3),
+				labelSelectorResource("key2=value2"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			less, more := tt.att.DiffResources(tt.other)
+			assert.ElementsMatch(t, tt.less, less)
+			assert.ElementsMatch(t, tt.more, more)
+		})
+	}
+}

--- a/internal/firewall/testing.go
+++ b/internal/firewall/testing.go
@@ -97,8 +97,25 @@ type RData struct {
 	Labels  map[string]string
 }
 
-// RData defines the fields for the "testdata/r/hcloud_firewall"
-// template.
+// NewRData creates data for a new firewall resource.
+func NewRData(t *testing.T, name string, rules []RDataRule, applyTo []RDataApplyTo) *RData {
+	rInt := acctest.RandInt()
+	r := &RData{
+		Name:    name,
+		Rules:   rules,
+		ApplyTo: applyTo,
+		Labels:  map[string]string{"key": strconv.Itoa(rInt)},
+	}
+	r.SetRName(name)
+	return r
+}
+
+// TFID returns the resource identifier.
+func (d *RData) TFID() string {
+	return fmt.Sprintf("%s.%s", ResourceType, d.RName())
+}
+
+// RDataRule defines the fields for the "testdata/r/hcloud_firewall" template.
 type RDataRule struct {
 	Direction      string
 	Port           string
@@ -113,20 +130,28 @@ type RDataApplyTo struct {
 	LabelSelector string
 }
 
-// TFID returns the resource identifier.
-func (d *RData) TFID() string {
-	return fmt.Sprintf("%s.%s", ResourceType, d.RName())
+// RDataAttachment defines the fields for the
+// "testdata/r/hcloud_firewall_attachment" template.
+//
+// Fields ending in Ref are meant to contain a string referencing a Terraform
+// value.
+type RDataAttachment struct {
+	testtemplate.DataCommon
+
+	FirewallIDRef  string
+	ServerIDRefs   []string
+	LabelSelectors []string
 }
 
-// NewRData creates data for a new firewall resource.
-func NewRData(t *testing.T, name string, rules []RDataRule, applyTo []RDataApplyTo) *RData {
-	rInt := acctest.RandInt()
-	r := &RData{
-		Name:    name,
-		Rules:   rules,
-		ApplyTo: applyTo,
-		Labels:  map[string]string{"key": strconv.Itoa(rInt)},
-	}
-	r.SetRName(name)
-	return r
+// NewRDataAttachment creates a new RDataAttachment with the passed
+// terraform resource name. It references a firewall using fwIDRef.
+func NewRDataAttachment(resName, fwIDRef string) *RDataAttachment {
+	d := RDataAttachment{FirewallIDRef: fwIDRef}
+	d.SetRName(resName)
+	return &d
+}
+
+// TFID returns the resource identifier.
+func (d *RDataAttachment) TFID() string {
+	return fmt.Sprintf("%s.%s", AttachmentResourceType, d.RName())
 }

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -29,12 +29,14 @@ func Resource() *schema.Resource {
 		ReadContext:   resourceServerRead,
 		UpdateContext: resourceServerUpdate,
 		DeleteContext: resourceServerDelete,
+
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(90 * time.Minute),
 		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -163,11 +165,23 @@ func Resource() *schema.Resource {
 					},
 				},
 			},
+			"ignore_remote_firewall_ids": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"firewall_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					sup := d.Get("ignore_remote_firewall_ids").(bool)
+					if sup && old != "" && new != "" {
+						return true
+					}
+					return false
+				},
 			},
 			"placement_group_id": {
 				Type:     schema.TypeInt,

--- a/internal/testdata/r/hcloud_firewall_attachment.tf.tmpl
+++ b/internal/testdata/r/hcloud_firewall_attachment.tf.tmpl
@@ -1,0 +1,11 @@
+{{- /* vim: set ft=terraform: */ -}}
+
+resource "hcloud_firewall_attachment" "{{ .RName }}" {
+    firewall_id = {{ .FirewallIDRef }}
+    {{- if .ServerIDRefs }}
+    server_ids = [{{ StringsJoin .ServerIDRefs ", " }}]
+    {{- end }}
+    {{- if .LabelSelectors }}
+    label_selectors = [{{ with DQuoteS .LabelSelectors }}{{ StringsJoin . ", " }}{{ end }}]
+    {{- end }}
+}

--- a/website/docs/r/firewall_attachment.html.md
+++ b/website/docs/r/firewall_attachment.html.md
@@ -1,0 +1,143 @@
+---
+layout: "hcloud"
+page_title: "Hetzner Cloud: hcloud_firewall_attachment"
+sidebar_current: "docs-hcloud-resource-firewall-attachment"
+description: |-
+  Attaches resources to a Hetzner Cloud Firewall.
+---
+
+# hcloud_firewall_attachment
+
+Attaches resource to a Hetzner Cloud Firewall.
+
+*Note*: only one `hcloud_firewall_attachment` per Firewall is allowed.
+Any resources that should be attached to that Firewall need to be
+specified in that `hcloud_firewall_attachment`.
+
+## Example Usage
+
+### Attach Servers
+
+```hcl
+resource "hcloud_server" "test_server" {
+    name        = "test-server"
+    server_type = "cx11"
+    image       = "ubuntu-20.04"
+}
+
+resource "hcloud_firewall" "basic_firewall" {
+    name   = "basic_firewall"
+}
+
+resource "hcloud_firewall_attachment" "fw_ref" {
+    firewall_id = hcloud_firewall.basic_firewall.id
+    server_ids  = [hcloud_server.test_server.id]
+}
+```
+
+### Attach Label Selectors
+
+```hcl
+resource "hcloud_server" "test_server" {
+    name        = "test-server"
+    server_type = "cx11"
+    image       = "ubuntu-20.04"
+
+    labels = {
+      firewall-attachment = "test-server"
+    }
+}
+
+resource "hcloud_firewall" "basic_firewall" {
+    name = "basic_firewall"
+}
+
+resource "hcloud_firewall_attachment" "fw_ref" {
+    firewall_id     = hcloud_firewall.basic_firewall.id
+    label_selectors = ["firewall-attachment=test-server"]
+}
+```
+
+### Ensure a server is attached to a Firewall on first boot
+
+The `firewall_ids` property of the `hcloud_server` resource ensures that
+a server is attached to the specified Firewalls before its first boot.
+This is **not** the case when using the `hcloud_firewall_attachment`
+resource to attach servers to a Firewall. In some scenarios this may
+pose a security risk.
+
+The following workaround ensures that a server is attached to a Firewall
+*before* it first boots. However, the workaround requires two Firewalls.
+Additionally the server resource definition needs to ignore any remote
+changes to the `hcloud_server.firewall_ids` property. This is done using
+the `ignore_remote_firewall_ids` property of `hcloud_server`.
+
+```hcl
+terraform {
+  required_providers {
+    hcloud = {
+      source     = "hetznercloud/hcloud"
+      version    = "1.32.2"
+    }
+  }
+}
+
+resource "hcloud_firewall" "deny_all" {
+    name   = "deny_all"
+}
+
+resource "hcloud_server" "test_server" {
+    name                       = "test-server"
+    server_type                = "cx11"
+    image                      = "ubuntu-20.04"
+    ignore_remote_firewall_ids = true
+    firewall_ids               = [
+        hcloud_firewall.deny_all.id
+    ]
+}
+
+resource "hcloud_firewall" "allow_rules" {
+    name   = "allow_rules"
+
+    rule {
+        direction       = "in"
+        protocol        = "tcp"
+        port            = "22"
+        source_ips      = [
+            "0.0.0.0/0",
+            "::/0",
+        ]
+        destination_ips = [
+            format("%s/32", hcloud_server.test_server.ipv4_address)
+        ]
+    }
+}
+
+resource "hcloud_firewall_attachment" "deny_all_att" {
+    firewall_id = hcloud_firewall.deny_all.id
+    server_ids  = [hcloud_server.test_server.id]
+}
+
+resource "hcloud_firewall_attachment" "allow_rules_att" {
+    firewall_id = hcloud_firewall.allow_rules.id
+    server_ids  = [hcloud_server.test_server.id]
+}
+```
+
+## Argument Reference
+
+- `firewall_id` - (Required, int) ID of the firewall the resources
+  should be attached to.
+- `server_ids` - (Optional, List) List of Server IDs to attach to the
+  firewall.
+- `label_selectors` - (Optional, List) List of label selectors used to
+  select resources to attach to the firewall.
+
+## Attribute Reference
+
+- `id` (int) - Unique ID representing this `hcloud_firewall_attachment`.
+- `firewall_id` (int) - ID of the Firewall the resourced referenced by
+  this attachment are attached to.
+- `server_ids` (List) - List of Server IDs attached to the Firewall.
+- `label_selectors` (List) - List of label selectors attached to the
+  Firewall.

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -80,6 +80,11 @@ The following arguments are supported:
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `backups` - (Optional, boolean) Enable or disable backups.
 - `firewall_ids` - (Optional, list) Firewall IDs the server should be attached to on creation.
+- `ignore_remote_firewall_ids` - (Optional, boolean) Ingores any updates
+  to the `firewall_ids` argument which were received from the server.
+  This should not be used in normal cases. See the documentation of the
+  `hcloud_firewall_attachment` resouce for a reason to use this
+  argument.
 - `network` - (Optional)  Network the server should be attached to on creation. (Can be specified multiple times)
 - `placement_group_id` - (Optional, string) Placement Group ID the server added to on creation.
 - `delete_protection` - (Optional, boolean) Enable or disable delete protection (Needs to be the same as `rebuild_protection`).


### PR DESCRIPTION
The hcloud_firewall_attachment resource allows to work around the issue
described in #336. Using this resource it is possible to first create a
server and a firewall before attaching the server to the firewall. This
in turn allows the server's public IP addresses to be used in the
firewall rules.

The drawback of this resource is that it requires a workaround to ensure
a server is protected by a firewall right from the beginning. Without
using the workaround there is a small amount of time where the server is
reachable directly from the internet. The workaround is documented
along with the `hcloud_firewall_attachment` resource.

Closes #336