### PR TITLE
DataSource Network `id` should be an integer

### DIFF
--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -11,7 +11,7 @@ This resource is useful if you want to use a non-terraform managed network.
 ## Example Usage
 ```hcl
 data "hcloud_network" "network_1" {
-  id = "1234"
+  id = 1234
 }
 data "hcloud_network" "network_2" {
   name = "my-network"

--- a/website/docs/d/networks.html.md
+++ b/website/docs/d/networks.html.md
@@ -12,10 +12,10 @@ Provides details about multiple Hetzner Cloud Networks.
 
 ## Example Usage
 ```hcl
-data "hcloud_network" "network_2" {
+data "hcloud_networks" "network_2" {
 
 }
-data "hcloud_network" "network_3" {
+data "hcloud_networks" "network_3" {
   with_selector = "key=value"
 }
 ```
@@ -25,4 +25,4 @@ data "hcloud_network" "network_3" {
 - `with_selector` - (Optional, string) [Label selector](https://docs.hetzner.cloud/#overview-label-selector)
 
 ## Attributes Reference
-- `networks` - (list) List of all matching networks. See `data.hcloud_network` for schema.
+- `networks` - (list) List of all matching networks. See `data.hcloud_networks` for schema.


### PR DESCRIPTION
Hi there!

As per the [schema definition](https://github.com/hetznercloud/terraform-provider-hcloud/blob/main/internal/network/data_source.go#L30), the `id` field in the documentation example should be an integer.

We've run across some doc discrepancies in our downstream Pulumi provider. Thank you so much for considering this pull request.