### PR TITLE
ci: fix not available gpg_private_key in workflow

### DIFF
--- a/.github/workflows/dev_release.yml
+++ b/.github/workflows/dev_release.yml
@@ -31,9 +31,9 @@ jobs:
         name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/dev_release.yml
+++ b/.github/workflows/dev_release.yml
@@ -10,8 +10,10 @@
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: dev_release
+
 on:
   push:
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -43,19 +45,23 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v3
         with:
             name: darwin-amd64
             path: dist/*_darwin_amd64.zip
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v3
         with:
           name: darwin-arm64
           path: dist/*_darwin_arm64.zip
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v3
         with:
             name: linux-amd64
             path: dist/*_linux_amd64.zip
-      - uses: actions/upload-artifact@v3
+      -
+        uses: actions/upload-artifact@v3
         with:
             name: windows-amd64
             path: dist/*_windows_amd64.zip

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,5 @@
 name: golangci-lint
+
 on:
   push:
     tags:
@@ -6,6 +7,7 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@
 # in `goreleaser` to indicate this is being used in a non-interactive mode.
 #
 name: release
+
 on:
   push:
     tags:
       - 'v*'
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
         name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: test
+
 on:
   pull_request:
+
 jobs:
   integration_tests:
     runs-on: self-hosted
@@ -11,36 +13,46 @@ jobs:
         terraform_version: [ "1.0.x", "1.1.x", "1.2.x" ]
     name: integration-${{ matrix.terraform_version }}
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Unshallow
+      -
+        name: Unshallow
         run: git fetch --prune --unshallow
-      - uses: hashicorp/setup-terraform@v2
+      -
+        uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ matrix.terraform_version }}
           terraform_wrapper: false
-      - name: Set up Go
+      -
+        name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - name: Run tests
+      -
+        name: Run tests
         run: |
           export HCLOUD_TOKEN=$(./scripts/get-token.sh)
           cat resp.json
           make testacc
           make
           ./scripts/delete-token.sh $HCLOUD_TOKEN
+
   unit_tests:
     runs-on: self-hosted
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v3
-      - name: Unshallow
+      -
+        name: Unshallow
         run: git fetch --prune --unshallow
-      - name: Set up Go
+      -
+        name: Set up Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19
-      - name: Run tests
+      -
+        name: Run tests
         run: |
           make test


### PR DESCRIPTION
It seems that the import GPG key step does not get to the private key.
See: https://github.com/hetznercloud/terraform-provider-hcloud/actions/runs/2919525089

As long as the key in the repo is set correctly, it should now be able to get the data again.