### PR TITLE
Remove < and > signs in import examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Terraform Provider for the Hetzner Cloud
 - Website: https://www.terraform.io
 - Documentation: https://www.terraform.io/docs/providers/hcloud/index.html
 
-<img src="https://cdn.rawgit.com/hashicorp/terraform-website/master/content/source/assets/images/logo-hashicorp.svg" width="600px">
-
 Requirements
 ------------
 

--- a/website/docs/d/certificate.html.md
+++ b/website/docs/d/certificate.html.md
@@ -43,5 +43,5 @@ data "hcloud_certificate" "sample_certificate_2" {
 Certificates can be imported using their `id`:
 
 ```hcl
-terraform import hcloud_certificate.sample_certificate_1 <id>
+terraform import hcloud_certificate.sample_certificate_1 id
 ```

--- a/website/docs/d/load_balancer.html.md
+++ b/website/docs/d/load_balancer.html.md
@@ -53,7 +53,7 @@ data "hcloud_load_balancer" "lb_3" {
 
 `service` support the following fields:
 - `protocol` - (string) Protocol of the service. `http`, `https` or `tcp`
-- `listen_port` - (int) Port the service listen on`. Can be everything between `1` and `65535`. Must be unique per Load Balancer. 
+- `listen_port` - (int) Port the service listen on`. Can be everything between `1` and `65535`. Must be unique per Load Balancer.
 - `destination_port` - (int) Port the service connects to the targets on. Can be everything between `1` and `65535`.
 - `proxyprotocol` - (bool) Enable proxyprotocol.
 - `http` - (list) List of http configurations when `protocol` is `http` or `https`.
@@ -87,5 +87,5 @@ data "hcloud_load_balancer" "lb_3" {
 Load Balancers can be imported using its `id`:
 
 ```
-terraform import hcloud_load_balancer.my_load_balancer <id>
+terraform import hcloud_load_balancer.my_load_balancer id
 ```

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -94,5 +94,5 @@ resource "hcloud_server" "node1" {
 Firewalls can be imported using its `id`:
 
 ```
-terraform import hcloud_firewall.myfirewall <id>
+terraform import hcloud_firewall.myfirewall id
 ```

--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -53,5 +53,5 @@ resource "hcloud_floating_ip" "master" {
 Floating IPs can be imported using its `id`:
 
 ```
-terraform import hcloud_floating_ip.myip <id>
+terraform import hcloud_floating_ip.myip id
 ```

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -64,5 +64,5 @@ resource "hcloud_load_balancer" "load_balancer" {
 Load Balancers can be imported using its `id`:
 
 ```
-terraform import hcloud_load_balancer.my_load_balancer <id>
+terraform import hcloud_load_balancer.my_load_balancer id
 ```

--- a/website/docs/r/managed_certificate.html.md
+++ b/website/docs/r/managed_certificate.html.md
@@ -29,7 +29,7 @@ resource "hcloud_managed_certificate" "managed_cert" {
 Managed certificates can be imported using their `id`:
 
 ```hcl
-terraform import hcloud_managed_certificate.sample_certificate <id>
+terraform import hcloud_managed_certificate.sample_certificate id
 ```
 
 ## Argument Reference

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -39,6 +39,6 @@ resource "hcloud_network" "privNet" {
 Networks can be imported using its `id`:
 
 ```
-terraform import hcloud_network.myip <id>
+terraform import hcloud_network.myip id
 ```
 

--- a/website/docs/r/placement_group.html.md
+++ b/website/docs/r/placement_group.html.md
@@ -47,5 +47,5 @@ resource "hcloud_server" "node1" {
 Placement Groups can be imported using its `id`:
 
 ```
-terraform import hcloud_placement_group.my-placement-group <id>
+terraform import hcloud_placement_group.my-placement-group id
 ```

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -72,5 +72,5 @@ resource "hcloud_server" "server_test" {
 Primary IPs can be imported using its `id`:
 
 ```
-terraform import hcloud_primary_ip.myip <id>
+terraform import hcloud_primary_ip.myip id
 ```

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -142,7 +142,7 @@ The following arguments are supported:
 - `datacenter` - (Optional, string) The datacenter name to create the server in.
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation
 - `ssh_keys` - (Optional, list) SSH key IDs or names which should be injected into the server at creation time
-- `public_net` - (Optional, block) In this block you can either enable / disable ipv4 and ipv6 or link existing primary IPs (checkout the examples). 
+- `public_net` - (Optional, block) In this block you can either enable / disable ipv4 and ipv6 or link existing primary IPs (checkout the examples).
   If this block is not defined, two primary (ipv4 & ipv6) ips getting auto generated.
 - `keep_disk` - (Optional, bool) If true, do not upgrade the disk. This allows downgrading the server type later.
 - `iso` - (Optional, string) ID or Name of an ISO image to mount.
@@ -210,5 +210,5 @@ a single entry in `network` support the following fields:
 Servers can be imported using the server `id`:
 
 ```
-terraform import hcloud_server.myserver <id>
+terraform import hcloud_server.myserver id
 ```

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -42,5 +42,5 @@ resource "hcloud_snapshot" "my-snapshot" {
 Snapshots can be imported using its image `id`:
 
 ```
-terraform import hcloud_snapshot.myimage <id>
+terraform import hcloud_snapshot.myimage id
 ```

--- a/website/docs/r/ssh_key.html.md
+++ b/website/docs/r/ssh_key.html.md
@@ -43,5 +43,5 @@ The following attributes are exported:
 SSH keys can be imported using the SSH key `id`:
 
 ```
-terraform import hcloud_ssh_key.mykey <id>
+terraform import hcloud_ssh_key.mykey id
 ```

--- a/website/docs/r/uploaded_certificate.html.md
+++ b/website/docs/r/uploaded_certificate.html.md
@@ -65,5 +65,5 @@ certificate should be created with.
 Uploaded certificates can be imported using their `id`:
 
 ```hcl
-terraform import hcloud_uploaded_certificate.sample_certificate <id>
+terraform import hcloud_uploaded_certificate.sample_certificate id
 ```

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -56,5 +56,5 @@ resource "hcloud_volume" "master" {
 Volumes can be imported using their `id`:
 
 ```
-terraform import hcloud_volume.myvolume <id>
+terraform import hcloud_volume.myvolume id
 ```


### PR DESCRIPTION
The `<id>` in the import examples are not rendered correctly on the Terraform registry website, e.g. at https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs/resources/primary_ip#import

I suspect that the < and > characters are lost during some sanitization process. By removing them we should get rid of the missleading examples.

Also remove a deadlink in the readme.