### PR TITLE
fix: wrong required statement

### DIFF
--- a/website/docs/r/server_network.html.md
+++ b/website/docs/r/server_network.html.md
@@ -39,7 +39,7 @@ resource "hcloud_server_network" "srvnetwork" {
 ## Argument Reference
 
 - `server_id` - (Required, int) ID of the server.
-- `alias_ips` - (Required, list[string]) Additional IPs to be assigned
+- `alias_ips` - (Optional, list[string]) Additional IPs to be assigned
   to this server.
 - `network_id` - (Optional, int) ID of the network which should be added
   to the server. Required if `subnet_id` is not set. Successful creation


### PR DESCRIPTION
In the source code the value is flagged as optional (which makes sense):
internal/server/resource_network.go
line 59

The error in the docs have been fixed accordingly.
Closes #543