### PR TITLE
style: unify the bool and boolean type in the docs

### DIFF
--- a/website/docs/d/floating_ip.html.md
+++ b/website/docs/d/floating_ip.html.md
@@ -48,4 +48,4 @@ resource "hcloud_floating_ip_assignment" "main" {
 - `ip_address` - (string) IP Address of the Floating IP.
 - `ip_network` - (string) IPv6 subnet. (Only set if `type` is `ipv6`)
 - `labels` - (map) User-defined labels (key-value pairs).
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.

--- a/website/docs/d/load_balancer.html.md
+++ b/website/docs/d/load_balancer.html.md
@@ -41,7 +41,7 @@ data "hcloud_load_balancer" "lb_3" {
 - `target` - (list) List of targets of the Load Balancer.
 - `service` - (list) List of services a Load Balancer provides.
 - `labels` - (map) User-defined labels (key-value pairs) .
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connection`

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -30,4 +30,4 @@ data "hcloud_network" "network_3" {
 - `id` - Unique ID of the Network.
 - `name` - Name of the Network.
 - `ip_range` - IPv4 prefix of the Network.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.

--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -64,9 +64,9 @@ resource "hcloud_server" "server_test" {
 - `type` - (string) Type of the Primary IP.
 - `name` - (string) Name of the Primary IP.
 - `datacenter` - (string) The datacenter name of the Primary IP.
-- `auto_delete` - (boolean) Whether auto delete is enabled.
+- `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (string) Description of the Primary IP.
 - `ip_address` - (string) IP Address of the Primary IP.
 - `assignee_id` - (int) ID of the assigned resource.
 - `assignee_type` - (string) The type of the assigned resource.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -36,7 +36,7 @@ data "hcloud_server" "s_3" {
 - `location` - (string) The location name.
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
-- `backups` - (boolean) Whether backups are enabled.
+- `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.
@@ -45,5 +45,5 @@ data "hcloud_server" "s_3" {
 - `labels` - (map) User-defined labels (key-value pairs)
 - `firewall_ids` - (Optional, list) Firewall IDs the server is attached to.
 - `placement_group_id` - (Optional, string) Placement Group ID the server is assigned to.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
-- `rebuild_protection` - (boolean) Whether rebuild protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
+- `rebuild_protection` - (bool) Whether rebuild protection is enabled.

--- a/website/docs/d/volume.html.md
+++ b/website/docs/d/volume.html.md
@@ -35,4 +35,4 @@ data "hcloud_volume" "volume_3" {
 - `server_id` - (Optional, int) Server ID the volume is attached to
 - `labels` - (map) User-defined labels (key-value pairs).
 - `linux_device` - (string) Device path on the file system for the Volume.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.

--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -33,7 +33,7 @@ resource "hcloud_floating_ip" "master" {
 - `home_location` - (Optional, string) Home location (routing is optimized for that location). Optional if server_id argument is passed.
 - `description` - (Optional, string) Description of the Floating IP.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, boolean) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection.
 
 ## Attributes Reference
 
@@ -46,7 +46,7 @@ resource "hcloud_floating_ip" "master" {
 - `ip_address` - (string) IP Address of the Floating IP.
 - `ip_network` - (string) IPv6 subnet. (Only set if `type` is `ipv6`)
 - `labels` - (map) User-defined labels (key-value pairs)
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 ## Import
 

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -38,7 +38,7 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `network_zone` - (Optional, string) Network Zone of the Load Balancer. Require when no location is set.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, boolean) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection.
 
 `algorithm` support the following fields:
 - `type` - (Required, string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`
@@ -54,7 +54,7 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
 - `service` - (list) List of services a Load Balancer provides.
 - `labels` - (map) User-defined labels (key-value pairs).
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -24,7 +24,7 @@ resource "hcloud_network" "privNet" {
 - `name` - (Required, string) Name of the Network to create (must be unique per project).
 - `ip_range` - (Required, string) IP Range of the whole Network which must span all included subnets and route destinations. Must be one of the private ipv4 ranges of RFC1918.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, boolean) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection.
 
 ## Attributes Reference
 
@@ -32,7 +32,7 @@ resource "hcloud_network" "privNet" {
 - `name` - (string) Name of the network.
 - `ip_range` - (string) IPv4 Prefix of the whole Network.
 - `labels` - (map) User-defined labels (key-value pairs)
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 ## Import
 

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -47,25 +47,25 @@ resource "hcloud_server" "server_test" {
 - `type` - (string) Type of the Primary IP.
 - `name` - (string) Name of the Primary IP.
 - `datacenter` - (string, optional) The datacenter name to create the resource in.
-- `auto_delete` - (boolean) Whether auto delete is enabled.
+- `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (string) Description of the Primary IP.
 - `assignee_id` - (int) ID of the assigned resource
 - `assignee_type` - (string, optional) The type of the assigned resource.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 ## Attributes Reference
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
 - `datacenter` - (string, optional) The datacenter name to create the resource in.
 - `name` - (string) Name of the Primary IP.
-- `auto_delete` - (boolean) Whether auto delete is enabled.
+- `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to a managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (string) Description of the Primary IP.
 - `ip_address` - (string) IP Address of the Primary IP.
 - `assignee_id` - (int) ID of the assigned resource
 - `assignee_type` - (string) The type of the assigned resource.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 ## Import
 

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -148,18 +148,18 @@ The following arguments are supported:
 - `iso` - (Optional, string) ID or Name of an ISO image to mount.
 - `rescue` - (Optional, string) Enable and boot in to the specified rescue system. This enables simple installation of custom operating systems. `linux64` `linux32` or `freebsd64`
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `backups` - (Optional, boolean) Enable or disable backups.
+- `backups` - (Optional, bool) Enable or disable backups.
 - `firewall_ids` - (Optional, list) Firewall IDs the server should be attached to on creation.
-- `ignore_remote_firewall_ids` - (Optional, boolean) Ignores any updates
+- `ignore_remote_firewall_ids` - (Optional, bool) Ignores any updates
   to the `firewall_ids` argument which were received from the server.
   This should not be used in normal cases. See the documentation of the
   `hcloud_firewall_attachment` resource for a reason to use this
   argument.
 - `network` - (Optional)  Network the server should be attached to on creation. (Can be specified multiple times)
 - `placement_group_id` - (Optional, string) Placement Group ID the server added to on creation.
-- `delete_protection` - (Optional, boolean) Enable or disable delete protection (Needs to be the same as `rebuild_protection`).
-- `rebuild_protection` - (Optional, boolean) Enable or disable rebuild protection (Needs to be the same as `delete_protection`).
-- `allow_deprecated_images` - (Optional, boolean) Enable the use of deprecated images (default: false). **Note** Deprecated images will be removed after three months. Using them is then no longer possible.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection (Needs to be the same as `rebuild_protection`).
+- `rebuild_protection` - (Optional, bool) Enable or disable rebuild protection (Needs to be the same as `delete_protection`).
+- `allow_deprecated_images` - (Optional, bool) Enable the use of deprecated images (default: false). **Note** Deprecated images will be removed after three months. Using them is then no longer possible.
 
 `network` support the following fields:
 - `network_id` - (Required, int) ID of the network
@@ -178,7 +178,7 @@ The following attributes are exported:
 - `location` - (string) The location name.
 - `datacenter` - (string) The datacenter name.
 - `backup_window` - (string) The backup window of the server, if enabled.
-- `backups` - (boolean) Whether backups are enabled.
+- `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image.
 - `ipv4_address` - (string) The IPv4 address.
 - `ipv6_address` - (string) The first IPv6 address of the assigned network.
@@ -195,8 +195,8 @@ The following attributes are exported:
 - `firewall_ids` - (Optional, list) Firewall IDs the server is attached to.
 - `network` - (Optional, list)  Network the server should be attached to on creation. (Can be specified multiple times)
 - `placement_group_id` - (Optional, string) Placement Group ID the server is assigned to.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
-- `rebuild_protection` - (boolean) Whether rebuild protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
+- `rebuild_protection` - (bool) Whether rebuild protection is enabled.
 
 a single entry in `network` support the following fields:
 - `network_id` - (Required, int) ID of the network

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -36,7 +36,7 @@ resource "hcloud_volume" "master" {
 - `location` - (Optional, string) Location of the volume to create, not allowed if server_id argument is passed.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).
 - `format` - (Optional, string) Format volume after creation. `xfs` or `ext4`
-- `delete_protection` - (Optional, boolean) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection.
 
 **Note:** When you want to attach multiple volumes to a server, please use the `hcloud_volume_attachment` resource and the `location` argument instead of the `server_id` argument.
 
@@ -49,7 +49,7 @@ resource "hcloud_volume" "master" {
 - `server_id` - (Optional, int) Server ID the volume is attached to
 - `labels` - (map) User-defined labels (key-value pairs).
 - `linux_device` - (string) Device path on the file system for the Volume.
-- `delete_protection` - (boolean) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled.
 
 ## Import
 


### PR DESCRIPTION
Currently the type bool and boolean are used in the documentation for the same type, but due to the change only bool is used.