### PR TITLE
ci: fix outdated golanglint-ci version in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,7 @@ test:acceptance:
 
 test:golangci-lint:
   stage: test
-  image: golangci/golangci-lint:v1.36
+  image: golangci/golangci-lint:latest
   script:
     - golangci-lint run -v
   except:


### PR DESCRIPTION
The GitHub Actions pipeline installs the latest golanglint-ci version by default. To make our internal pipelines as similar as possible, we also switch to using latest in .gitlab-ci.yml.

This also fixes a bug where the step currently fails because the linter `revive` was added to our config, but is not included in golanglint-ci v1.36.