### PR TITLE
fix: error when deleting hcloud_primary_ip with auto_delete

### DIFF
--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -272,7 +272,10 @@ func resourcePrimaryIPDelete(ctx context.Context, d *schema.ResourceData, m inte
 	}
 	err = control.Retry(2*control.DefaultRetries, func() error {
 		if _, err := client.PrimaryIP.Delete(ctx, &hcloud.PrimaryIP{ID: primaryIPID}); err != nil {
-			return err
+			if !hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+				// Primary IP was already deleted
+				return err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
This error sometimes happened if the `primary_ip` was deleted faster in the API (through auto deletion when the server was deleted) than in Terraform.

This caused a flaky e2e test `TestPrimaryIPResource_with_server` as well as the issue described in https://github.com/hetznercloud/terraform-provider-hcloud/issues/579#issuecomment-1304820391.