### PR TITLE
test: fix flaky test TestServerResource_PrimaryIPNetworkTests

### DIFF
--- a/internal/e2etests/server/resource_test.go
+++ b/internal/e2etests/server/resource_test.go
@@ -384,7 +384,7 @@ func TestServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	snwRes.SetRName("test-network-subnet")
 
 	primaryIPv4Res := &primaryip.RData{
-		Name:         "primaryip-test",
+		Name:         "primaryip-v4-test",
 		Type:         "ipv4",
 		Labels:       nil,
 		Datacenter:   "hel1-dc2",
@@ -394,7 +394,7 @@ func TestServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	primaryIPv4Res.SetRName("primary-ip-v4")
 
 	primaryIPv6Res := &primaryip.RData{
-		Name:         "primaryip-test",
+		Name:         "primaryip-v6-test",
 		Type:         "ipv6",
 		Labels:       nil,
 		Datacenter:   "hel1-dc2",


### PR DESCRIPTION
Test was flaky because two `hcloud_primary_ip` resources used the same name, but name must be unique. Fixed using different names.

Error message:

    resource_test.go:520: Step 6/7 error: Error running apply: exit status 1

    Error: name is already used (uniqueness_error)

      with hcloud_primary_ip.primary-ip-v6,
      on terraform_plugin_test.tf line 21, in resource "hcloud_primary_ip" "primary-ip-v6":
      21: resource "hcloud_primary_ip" "primary-ip-v6" {

    --- FAIL: TestServerResource_PrimaryIPNetworkTests (123.13s)