### PR TITLE
ci: allow unlimited concurrency on integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   integration_tests:
     runs-on: self-hosted
-    concurrency: integration_tests
+    # These tests use actual resources in a hetzner-owned hcloud project,
+    # depending on the current usage, some quotas are reached and test tests
+    # might fail.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The `concurrency` keyword automatically cancels any pending jobs for the same key, so we can not easily use it to build a queue of pending integration tests and only run one at a time.

For now we decided to allow an unlimited number of concurrent jobs and see if this causes issues.