### PR TITLE
fix: race-condition when re-creating server with external primary ip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/terraform-plugin-log v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.23.0
-	github.com/hetznercloud/hcloud-go v1.35.3
+	github.com/hetznercloud/hcloud-go v1.36.0
 	github.com/stretchr/testify v1.8.0
 	golang.org/x/crypto v0.0.0-20221005025214-4161e89ecf1b
 	golang.org/x/net v0.0.0-20221004154528-8021a29435af

--- a/go.sum
+++ b/go.sum
@@ -209,8 +209,8 @@ github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734 h1:HKL
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/hetznercloud/hcloud-go v1.35.3 h1:WCmFAhLRooih2QHAsbCbEdpIHnshQQmrPqsr3rHE1Ow=
-github.com/hetznercloud/hcloud-go v1.35.3/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
+github.com/hetznercloud/hcloud-go v1.36.0 h1:T4+XjM/SjrYCYw1UccpQS3WL1dChbHlvuZU9dHUqIIE=
+github.com/hetznercloud/hcloud-go v1.36.0/go.mod h1:mepQwR6va27S3UQthaEPGS86jtzSY9xWL1e9dyxXpgA=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -832,7 +832,13 @@ func resourceServerDelete(ctx context.Context, d *schema.ResourceData, m interfa
 		d.SetId("")
 		return nil
 	}
-	if _, err := client.Server.Delete(ctx, &hcloud.Server{ID: serverID}); err != nil {
+	result, _, err := client.Server.DeleteWithResult(ctx, &hcloud.Server{ID: serverID})
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+
+	err = hcclient.WaitForAction(ctx, &client.Action, result.Action)
+	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
 


### PR DESCRIPTION
When re-creating a server with a primary ip, the replacement server creation failed due to a race condition:

- initial server is deleted through terraform
- API responds to server deletion
- Primary IP is still marked as "attached" in API due to async internal   process
- Terraform tries to create new server
- API call fails because primary API is still marked as "attached" and can not be used for new server

By waiting until the returned action from server delete is completed, we can fix this race condition.

Closes #558