### PR TITLE
fix(server): unnecessary updates when using network #556

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -205,6 +205,7 @@ func Resource() *schema.Resource {
 						"alias_ips": {
 							Type:     schema.TypeSet,
 							Elem:     &schema.Schema{Type: schema.TypeString},
+							Computed: true,
 							Optional: true,
 						},
 						"mac_address": {


### PR DESCRIPTION
When using the `network` parameter of `hcloud_server` resource, the plan would always contain a diff, because the field `alias_ip` is not set by the user, but has a value in the plan. The field is automatically set to an empty set by the API -> it is computed and should be marked as such.

Fixes #556