### PR TITLE
docs: mention that we only accept the location name as attribute

### DIFF
--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -30,7 +30,7 @@ resource "hcloud_floating_ip" "master" {
 - `type` - (Required, string) Type of the Floating IP. `ipv4` `ipv6`
 - `name` - (Optional, string) Name of the Floating IP.
 - `server_id` - (Optional, int) Server to assign the Floating IP to.
-- `home_location` - (Optional, string) Home location (routing is optimized for that location). Optional if server_id argument is passed.
+- `home_location` - (Optional, string) Name of home location (routing is optimized for that location). Optional if server_id argument is passed.
 - `description` - (Optional, string) Description of the Floating IP.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `delete_protection` - (Optional, bool) Enable or disable delete protection.

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -34,8 +34,8 @@ resource "hcloud_load_balancer" "load_balancer" {
 
 - `name` - (Required, string) Name of the Load Balancer.
 - `load_balancer_type` - (Required, string) Type of the Load Balancer.
-- `location` - (Optional, string) Location of the Load Balancer. Require when no network_zone is set.
-- `network_zone` - (Optional, string) Network Zone of the Load Balancer. Require when no location is set.
+- `location` - (Optional, string) The location name of the Load Balancer. Require when no network_zone is set.
+- `network_zone` - (Optional, string) The Network Zone of the Load Balancer. Require when no location is set.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `delete_protection` - (Optional, bool) Enable or disable delete protection.

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -33,7 +33,7 @@ resource "hcloud_volume" "master" {
 - `name` - (Required, string) Name of the volume to create (must be unique per project).
 - `size` - (Required, int) Size of the volume (in GB).
 - `server_id` - (Optional, int) Server to attach the Volume to, not allowed if location argument is passed.
-- `location` - (Optional, string) Location of the volume to create, not allowed if server_id argument is passed.
+- `location` - (Optional, string) The location name of the volume to create, not allowed if server_id argument is passed.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).
 - `format` - (Optional, string) Format volume after creation. `xfs` or `ext4`
 - `delete_protection` - (Optional, bool) Enable or disable delete protection.


### PR DESCRIPTION
For some resources it was ambigous if the `location` attribute would accept the name or id of the location. In practice the terraform provider only works with the location name, and this was already stated e.g. for `hcloud_server`.

This commit updates all resource docs to explicitly mention that the attribute must be the location name.