### PR TITLE
fix: multiple resources break when parent resource is recreated

### DIFF
--- a/internal/firewall/attachment_resource.go
+++ b/internal/firewall/attachment_resource.go
@@ -29,6 +29,7 @@ func AttachmentResource() *schema.Resource {
 			"firewall_id": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			"server_ids": {
 				Type:     schema.TypeSet,

--- a/internal/loadbalancer/resource_target.go
+++ b/internal/loadbalancer/resource_target.go
@@ -50,6 +50,7 @@ func TargetResource() *schema.Resource {
 			"load_balancer_id": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			"server_id": {
 				Type:         schema.TypeInt,


### PR DESCRIPTION
This PR fixes bugs where deleting a parent resource would not cause child resources to be included in the plan. The orphaned child resources would contain outdated references to their parents IDs. Depending on the resource this would have been fixed by the next apply, or would break the terraform state. The cause for this is a missing `ForceNew: true` on the  `*_id` attributes that reference their parents.

Affected resources:
- `hcloud_load_balancer_target`
- `hcloud_firewall_attachment`