### PR TITLE
fix(server): unhandled errors from API calls

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -678,7 +678,11 @@ func updatePublicNet(ctx context.Context, o interface{}, n interface{}, c *hclou
 		}
 	}
 
-	shutdown, _, _ := c.Server.Poweroff(ctx, &hcloud.Server{ID: server.ID})
+	shutdown, _, err := c.Server.Poweroff(ctx, &hcloud.Server{ID: server.ID})
+	if err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+
 	if err := hcclient.WaitForAction(ctx, &c.Action, shutdown); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}

--- a/internal/server/resource_network.go
+++ b/internal/server/resource_network.go
@@ -341,10 +341,14 @@ func detachServerFromNetwork(ctx context.Context, c *hcloud.Client, s *hcloud.Se
 		}
 		return control.AbortRetry(err)
 	})
-	if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
-		// network has already been deleted
-		return nil
+	if err != nil {
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			// network has already been deleted
+			return nil
+		}
+		return fmt.Errorf("%s: %v", op, err)
 	}
+
 	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
 		return fmt.Errorf("%s: %v", op, err)
 	}


### PR DESCRIPTION
When these errors happen, a `nil` Action pointer was passed to `hcclient.WaitForAction`, which caused the error (and other similar):

    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xaf8c56]
    goroutine 63 [running]:
    github.com/hetznercloud/hcloud-go/hcloud.(*ActionClient).WatchOverallProgress.func1(0xc0000c6a80, 0xc000724840, 0xc0008281d0, 0x1, 0x1, 0xc000478178, 0x10fea38, 0xc000716fc0)
        github.com/hetznercloud/hcloud-go@v1.27.0/hcloud/action.go:196 +0x176
    created by github.com/hetznercloud/hcloud-go/hcloud.(*ActionClient).WatchOverallProgress
        github.com/hetznercloud/hcloud-go@v1.27.0/hcloud/action.go:189 +0xde

By properly checking wether we encountered an error in the API call, we can instead return a proper error message to the user.

I checked all usages of `hcclient.WaitForAction` for missing error handlers, but these two were the only ones I found.

Closes #491