### PR TITLE
fix(lb): add missing fields to data source

### DIFF
--- a/internal/loadbalancer/data_source.go
+++ b/internal/loadbalancer/data_source.go
@@ -57,6 +57,14 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			ForceNew: true,
 			Computed: true,
 		},
+		"network_id": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"network_ip": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 		"algorithm": {
 			Type:     schema.TypeList,
 			Computed: true,

--- a/website/docs/d/load_balancer.html.md
+++ b/website/docs/d/load_balancer.html.md
@@ -42,6 +42,8 @@ data "hcloud_load_balancer" "lb_3" {
 - `service` - (list) List of services a Load Balancer provides.
 - `labels` - (map) User-defined labels (key-value pairs) .
 - `delete_protection` - (bool) Whether delete protection is enabled.
+- `network_id` - (int) ID of the first private network that this Load Balancer is connected to.
+- `network_ip` - (string) IP of the Load Balancer in the first private network that it is connected to.
 
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connection`

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -55,6 +55,8 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `service` - (list) List of services a Load Balancer provides.
 - `labels` - (map) User-defined labels (key-value pairs).
 - `delete_protection` - (bool) Whether delete protection is enabled.
+- `network_id` - (int) ID of the first private network that this Load Balancer is connected to.
+- `network_ip` - (string) IP of the Load Balancer in the first private network that it is connected to.
 
 `algorithm` support the following fields:
 - `type` - (string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`


### PR DESCRIPTION
The fields `network_id` and `network_ip` are missing from the fields of the datasources `hcloud_load_balancer` and `hcloud_load_balancers`.

This problem caused our integration test
`TestAccHcloudDataSourceLoadBalancerListTest` to be flaky with following error:

    panic: Invalid address to set: []string{"load_balancers", "0", "network_id"}