### PR TITLE
docs: explain deprecated attributes

### DIFF
--- a/website/docs/d/datacenters.html.md
+++ b/website/docs/d/datacenters.html.md
@@ -15,17 +15,17 @@ data "hcloud_datacenters" "ds" {
 }
 
 resource "hcloud_server" "workers" {
-  count = 3
+  count = 5
 
-  name        = "node1"
+  name        = "node${count.index}"
   image       = "debian-11"
   server_type = "cx31"
-  datacenter  = element(data.hcloud_datacenters.ds.names, count.index)
+  datacenter  = element(data.hcloud_datacenters.ds.datacenters, count.index).name
 }
 ```
 
 ## Attributes Reference
-- `datacenter_ids` - (list) List of unique datacenter identifiers.
-- `names` - (list) List of datacenter names.
-- `descriptions` - (list) List of all datacenter descriptions.
+- `datacenter_ids` - (list) List of unique datacenter identifiers. **Deprecated**: Use `datacenters` attribute instead.
+- `names` - (list) List of datacenter names. **Deprecated**: Use `datacenters` attribute instead.
+- `descriptions` - (list) List of all datacenter descriptions. **Deprecated**: Use `datacenters` attribute instead.
 - `datacenters` - (list) List of all datacenters. See `data.hcloud_datacenter` for schema.

--- a/website/docs/d/locations.html.md
+++ b/website/docs/d/locations.html.md
@@ -15,17 +15,17 @@ data "hcloud_locations" "ds" {
 }
 
 resource "hcloud_server" "workers" {
-  count = 3
+  count = 5
 
-  name        = "node1"
+  name        = "node${count.index}"
   image       = "debian-11"
   server_type = "cx31"
-  location    = element(data.hcloud_locations.ds.names, count.index)
+  location    = element(data.hcloud_locations.ds.locations, count.index).name
 }
 ```
 
 ## Attributes Reference
-- `location_ids` - (list) List of unique location identifiers.
-- `names` - (list) List of location names.
-- `descriptions` - (list) List of all location descriptions.
+- `location_ids` - (list) List of unique location identifiers. **Deprecated**: Use `locations` attribute instead.
+- `names` - (list) List of location names. **Deprecated**: Use `locations` attribute instead.
+- `descriptions` - (list) List of all location descriptions. **Deprecated**: Use `locations` attribute instead.
 - `locations` - (list) List of all locations. See `data.hcloud_location` for schema.


### PR DESCRIPTION
Explain the new usages for the deprecated attributes of the data resources `hcloud_datacenters` and `hcloud_locations`.

Update the examples to use the new attributes instead of the deprecated ones.

Fixes #610 