### PR TITLE
docs: replace outdated example OS image

### DIFF
--- a/website/docs/d/datacenters.html.md
+++ b/website/docs/d/datacenters.html.md
@@ -18,7 +18,7 @@ resource "hcloud_server" "workers" {
   count = 3
 
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx31"
   datacenter  = element(data.hcloud_datacenters.ds.names, count.index)
 }

--- a/website/docs/d/locations.html.md
+++ b/website/docs/d/locations.html.md
@@ -18,7 +18,7 @@ resource "hcloud_server" "workers" {
   count = 3
 
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx31"
   location    = element(data.hcloud_locations.ds.names, count.index)
 }

--- a/website/docs/d/server_types.html.md
+++ b/website/docs/d/server_types.html.md
@@ -17,7 +17,7 @@ resource "hcloud_server" "workers" {
   count = 3
 
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = element(data.hcloud_server_types.ds.names, count.index)
 }
 ```

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -37,7 +37,7 @@ resource "hcloud_firewall" "myfirewall" {
 
 resource "hcloud_server" "node1" {
   name         = "node1"
-  image        = "debian-9"
+  image        = "debian-11"
   server_type  = "cx11"
   firewall_ids = [hcloud_firewall.myfirewall.id]
 }

--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -15,7 +15,7 @@ Provides a Hetzner Cloud Floating IP to represent a publicly-accessible static I
 ```hcl
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
 }
 

--- a/website/docs/r/floating_ip_assignment.html.md
+++ b/website/docs/r/floating_ip_assignment.html.md
@@ -20,7 +20,7 @@ resource "hcloud_floating_ip_assignment" "main" {
 
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
   datacenter  = "fsn1-dc8"
 }

--- a/website/docs/r/placement_group.html.md
+++ b/website/docs/r/placement_group.html.md
@@ -23,7 +23,7 @@ resource "hcloud_placement_group" "my-placement-group" {
 
 resource "hcloud_server" "node1" {
   name         = "node1"
-  image        = "debian-9"
+  image        = "debian-11"
   server_type  = "cx11"
   placement_group_id = hcloud_placement_group.my-placement-group.id
 }

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -17,7 +17,7 @@ For servers:
 ```hcl
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
 }
 

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -18,7 +18,7 @@ Provides an Hetzner Cloud server resource. This can be used to create, modify, a
 # Create a new server running debian
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
   public_net {
     ipv4_enabled = true

--- a/website/docs/r/server_network.html.md
+++ b/website/docs/r/server_network.html.md
@@ -15,7 +15,7 @@ description: |-
 ```hcl
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
 }
 resource "hcloud_network" "mynet" {

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -15,7 +15,7 @@ Provides a Hetzner Cloud snapshot to represent an image with type snapshot in th
 ```hcl
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
 }
 

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -15,7 +15,7 @@ Provides a Hetzner Cloud volume resource to manage volumes.
 ```hcl
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
 }
 

--- a/website/docs/r/volume_attachment.html.md
+++ b/website/docs/r/volume_attachment.html.md
@@ -21,7 +21,7 @@ resource "hcloud_volume_attachment" "main" {
 
 resource "hcloud_server" "node1" {
   name        = "node1"
-  image       = "debian-9"
+  image       = "debian-11"
   server_type = "cx11"
   datacenter  = "nbg1-dc3"
 }


### PR DESCRIPTION
The examples in our docs were using "debian-9" as the default image, but that image is not available anymore, so these examples needed to be fixed by the user to get running.

By using an image that is actually available, we can reduce the friction for new users.