### PR TITLE
feat(primaryip): return IPv6 subnet #600

### DIFF
--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -318,6 +318,11 @@ func getPrimaryIPAttributes(f *hcloud.PrimaryIP) map[string]interface{} {
 		"delete_protection": f.Protection.Delete,
 		"auto_delete":       f.AutoDelete,
 	}
+
+	if f.Type == hcloud.PrimaryIPTypeIPv6 {
+		res["ip_network"] = f.Network.String()
+	}
+
 	return res
 }
 

--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -67,6 +67,7 @@ resource "hcloud_server" "server_test" {
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (string) Description of the Primary IP.
 - `ip_address` - (string) IP Address of the Primary IP.
+- `ip_network` - (string) IPv6 subnet of the Primary IP for IPv6 addresses. (Only set if `type` is `ipv6`)
 - `assignee_id` - (int) ID of the assigned resource.
 - `assignee_type` - (string) The type of the assigned resource.
 - `delete_protection` - (bool) Whether delete protection is enabled.

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -63,6 +63,7 @@ resource "hcloud_server" "server_test" {
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to a managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (string) Description of the Primary IP.
 - `ip_address` - (string) IP Address of the Primary IP.
+- `ip_network` - (string) IPv6 subnet of the Primary IP for IPv6 addresses. (Only set if `type` is `ipv6`)
 - `assignee_id` - (int) ID of the assigned resource
 - `assignee_type` - (string) The type of the assigned resource.
 - `delete_protection` - (bool) Whether delete protection is enabled.


### PR DESCRIPTION
Add attribute `ip_network` on all primary ip resources that contains the IPv6 subnet (if primary IP is IPv6). Implementation is the same as for floating IPs.

Closes #600