### PR TITLE
fix: state is missing resources when rate limit is reached #604

### DIFF
--- a/internal/certificate/resource.go
+++ b/internal/certificate/resource.go
@@ -230,10 +230,10 @@ func createManagedResource(ctx context.Context, d *schema.ResourceData, m interf
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(strconv.Itoa(res.Certificate.ID))
 	if err := hcclient.WaitForAction(ctx, &c.Action, res.Action); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	d.SetId(strconv.Itoa(res.Certificate.ID))
 
 	return readResource(ctx, d, m)
 }

--- a/internal/loadbalancer/resource_network.go
+++ b/internal/loadbalancer/resource_network.go
@@ -115,6 +115,7 @@ func resourceLoadBalancerNetworkCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(generateLoadBalancerNetworkID(lb, nw))
 
 	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
 		return hcclient.ErrorToDiag(err)
@@ -125,7 +126,6 @@ func resourceLoadBalancerNetworkCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	d.SetId(generateLoadBalancerNetworkID(lb, nw))
 
 	return resourceLoadBalancerNetworkRead(ctx, d, m)
 }

--- a/internal/loadbalancer/resource_service.go
+++ b/internal/loadbalancer/resource_service.go
@@ -238,12 +238,13 @@ func resourceLoadBalancerServiceCreate(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+
+	svcID := fmt.Sprintf("%d__%d", lb.ID, listenPort)
+	d.SetId(svcID)
+
 	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	svcID := fmt.Sprintf("%d__%d", lb.ID, listenPort)
-
-	d.SetId(svcID)
 
 	return resourceLoadBalancerServiceRead(ctx, d, m)
 }

--- a/internal/network/resource_route.go
+++ b/internal/network/resource_route.go
@@ -87,10 +87,10 @@ func resourceNetworkRouteCreate(ctx context.Context, d *schema.ResourceData, m i
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(generateNetworkRouteID(network, destination.String()))
 	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	d.SetId(generateNetworkRouteID(network, destination.String()))
 
 	return resourceNetworkRouteRead(ctx, d, m)
 }

--- a/internal/network/resource_subnet.go
+++ b/internal/network/resource_subnet.go
@@ -112,11 +112,11 @@ func resourceNetworkSubnetCreate(ctx context.Context, d *schema.ResourceData, m 
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(generateNetworkSubnetID(network, ipRange.String()))
 
 	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	d.SetId(generateNetworkSubnetID(network, ipRange.String()))
 
 	return resourceNetworkSubnetRead(ctx, d, m)
 }

--- a/internal/placementgroup/resource.go
+++ b/internal/placementgroup/resource.go
@@ -82,13 +82,13 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(strconv.Itoa(res.PlacementGroup.ID))
+
 	if res.Action != nil {
 		if err := hcclient.WaitForAction(ctx, &client.Action, res.Action); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
-
-	d.SetId(strconv.Itoa(res.PlacementGroup.ID))
 
 	return read(ctx, d, m)
 }

--- a/internal/volume/resource.go
+++ b/internal/volume/resource.go
@@ -116,6 +116,8 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		}
 		return hcclient.ErrorToDiag(err)
 	}
+	d.SetId(strconv.Itoa(result.Volume.ID))
+
 	if err := hcclient.WaitForAction(ctx, &c.Action, result.Action); err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
@@ -160,7 +162,6 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 		}
 	}
-	d.SetId(strconv.Itoa(result.Volume.ID))
 
 	deleteProtection := d.Get("delete_protection").(bool)
 	if deleteProtection {

--- a/internal/volume/resource_attachment.go
+++ b/internal/volume/resource_attachment.go
@@ -78,12 +78,14 @@ func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
-	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
-		return hcclient.ErrorToDiag(err)
-	}
 	// Since a volume can only be attached to one server
 	// we can use the volume id as volume attachment id.
 	d.SetId(strconv.Itoa(volume.ID))
+
+	if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
+		return hcclient.ErrorToDiag(err)
+	}
+
 	return resourceVolumeAttachmentRead(ctx, d, m)
 }
 


### PR DESCRIPTION
If the rate limit is reached we return an error and exit the reconciliation. This can lead to resources that are actually created, but were not added to the terraform state based on this process:

1. Resource is created, rate limit was not reached
2. Further API requests are made, usually to wait for async actions
3. Resource is persisted to the state by calling `resource.SetID()`

If any of the calls in (2) fail, the resource will never be added to the state, but will be created and incur costs in the cloud. This could either lead to orphaned resources, or to failures in subsequent runs if e.g. a server with the same name is created again.

We can fix this by calling `resource.SetID()` before making any further API calls. This way, terraform knows that the resource exists and can retry any actions on the next run if necessary.

Closes #604 