### PR TITLE
fix: self-reported version not correct

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     flags:
       - -trimpath
     ldflags:
-      - '-s -w -X github.com/terraform-providers/terraform-provider-hcloud/hcloud.Version={{.Version}} -X  github.com/terraform-providers/terraform-provider-hcloud/hcloud.Commit={{.Commit}}'
+      - '-s -w -X github.com/hetznercloud/terraform-provider-hcloud/hcloud.Version={{.Version}} -X github.com/hetznercloud/terraform-provider-hcloud/hcloud.Commit={{.Commit}}'
     goos:
       - freebsd
       - windows


### PR DESCRIPTION
The release process uses ldflags with -X to dynamically set the version in the binary.

This requires the full import path to the module, but the import path we were using was not updated after the repo was migrated from github.com/terraform-providers to github.com/hetznercloud (in 559534f).