### PR TITLE
chore: Test against Terraform v1.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,14 +6,6 @@ on:
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
-    # These tests use actual resources in a hetzner-owned hcloud project,
-    # depending on the current usage, some quotas are reached and test tests
-    # might fail.
-    strategy:
-      fail-fast: false
-      matrix:
-        terraform_version: [ "1.0.x", "1.1.x", "1.2.x", "1.3.x" ]
-    name: integration-${{ matrix.terraform_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -21,7 +13,7 @@ jobs:
         run: git fetch --prune --unshallow
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: ${{ matrix.terraform_version }}
+          terraform_version: v1.4.x
           terraform_wrapper: false
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
The version was released last week.

Additionally I removed all tests for older versions of terraform, as terraform promises compatibility for the interaction with providers.