### PR TITLE
refactor: Make CI Happy Again

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,7 +28,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: latest
+          version: v1.52.2
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,8 @@ issues:
         - exportloopref
         - gosec
         - errcheck
+    - path: testing.go
+      text: unused-parameter
     - linters:
         - gosec
       text: "G401:"

--- a/internal/certificate/resource.go
+++ b/internal/certificate/resource.go
@@ -83,8 +83,8 @@ func UploadedResource() *schema.Resource {
 				Optional: true,
 				Elem:     schema.TypeString,
 				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					if ok, error := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
-						return diag.Errorf(error.Error())
+					if ok, err := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
+						return diag.Errorf(err.Error())
 					}
 					return nil
 				},
@@ -368,7 +368,7 @@ func uploadedAndManagedResourceV0() *schema.Resource {
 }
 
 func upgradeUploadedAndManagedResourceV0(
-	_ context.Context, rawState map[string]interface{}, meta interface{},
+	_ context.Context, rawState map[string]interface{}, _ interface{},
 ) (map[string]interface{}, error) {
 	fields := []string{"created", "not_valid_before", "not_valid_after"}
 	for _, field := range fields {

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -471,10 +471,8 @@ func removeFromResources(ctx context.Context, client *hcloud.Client, d *schema.R
 		}
 		return err
 	}
-	if err := waitForFirewallActions(ctx, client, actions, fw); err != nil {
-		return err
-	}
-	return nil
+
+	return waitForFirewallActions(ctx, client, actions, fw)
 }
 
 func resourceFirewallIsNotFound(err error, d *schema.ResourceData) bool {

--- a/internal/firewall/validation.go
+++ b/internal/firewall/validation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/hcclient"
 )
 
-func validateIPDiag(i interface{}, path cty.Path) diag.Diagnostics {
+func validateIPDiag(i interface{}, _ cty.Path) diag.Diagnostics {
 	ipS := i.(string)
 	ip, n, err := net.ParseCIDR(ipS)
 	if err != nil {

--- a/internal/floatingip/resource.go
+++ b/internal/floatingip/resource.go
@@ -64,8 +64,8 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					if ok, error := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
-						return diag.Errorf(error.Error())
+					if ok, err := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
+						return diag.Errorf(err.Error())
 					}
 					return nil
 				},
@@ -233,8 +233,8 @@ func resourceFloatingIPUpdate(ctx context.Context, d *schema.ResourceData, m int
 	}
 
 	if d.HasChange("delete_protection") {
-		delete := d.Get("delete_protection").(bool)
-		if err := setProtection(ctx, client, floatingIP, delete); err != nil {
+		deletionProtection := d.Get("delete_protection").(bool)
+		if err := setProtection(ctx, client, floatingIP, deletionProtection); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
@@ -315,9 +315,5 @@ func setProtection(ctx context.Context, c *hcloud.Client, f *hcloud.FloatingIP, 
 		return err
 	}
 
-	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-		return err
-	}
-
-	return nil
+	return hcclient.WaitForAction(ctx, &c.Action, action)
 }

--- a/internal/loadbalancer/resource.go
+++ b/internal/loadbalancer/resource.go
@@ -341,8 +341,8 @@ func resourceLoadBalancerUpdate(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	if d.HasChange("delete_protection") {
-		delete := d.Get("delete_protection").(bool)
-		if err := setProtection(ctx, c, loadBalancer, delete); err != nil {
+		deletionProtection := d.Get("delete_protection").(bool)
+		if err := setProtection(ctx, c, loadBalancer, deletionProtection); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
@@ -466,9 +466,5 @@ func setProtection(ctx context.Context, c *hcloud.Client, lb *hcloud.LoadBalance
 		return err
 	}
 
-	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-		return err
-	}
-
-	return nil
+	return hcclient.WaitForAction(ctx, &c.Action, action)
 }

--- a/internal/loadbalancer/resource_network.go
+++ b/internal/loadbalancer/resource_network.go
@@ -272,19 +272,16 @@ func setEnablePublicInterface(ctx context.Context, c *hcloud.Client, loadBalance
 		if err != nil {
 			return err
 		}
-		if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-			return err
-		}
-		return nil
+
+		return hcclient.WaitForAction(ctx, &c.Action, action)
 	}
 	if !loadBalancer.PublicNet.Enabled && enablePublicInterface {
 		action, _, err := c.LoadBalancer.EnablePublicInterface(ctx, loadBalancer)
 		if err != nil {
 			return err
 		}
-		if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-			return err
-		}
+
+		return hcclient.WaitForAction(ctx, &c.Action, action)
 	}
 	return nil
 }

--- a/internal/network/resource.go
+++ b/internal/network/resource.go
@@ -157,8 +157,8 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	if d.HasChange("delete_protection") {
-		delete := d.Get("delete_protection").(bool)
-		if err := setProtection(ctx, client, network, delete); err != nil {
+		deletionProtection := d.Get("delete_protection").(bool)
+		if err := setProtection(ctx, client, network, deletionProtection); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
@@ -228,9 +228,5 @@ func setProtection(ctx context.Context, c *hcloud.Client, n *hcloud.Network, del
 		return err
 	}
 
-	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-		return err
-	}
-
-	return nil
+	return hcclient.WaitForAction(ctx, &c.Action, action)
 }

--- a/internal/placementgroup/resource.go
+++ b/internal/placementgroup/resource.go
@@ -16,10 +16,10 @@ const ResourceType = "hcloud_placement_group"
 
 func Resource() *schema.Resource {
 	return &schema.Resource{
-		CreateContext: create,
-		ReadContext:   read,
-		UpdateContext: update,
-		DeleteContext: delete,
+		CreateContext: resourcePlacementGroupCreate,
+		ReadContext:   resourcePlacementGroupRead,
+		UpdateContext: resourcePlacementGroupUpdate,
+		DeleteContext: resourcePlacementGroupDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -63,7 +63,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePlacementGroupCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*hcloud.Client)
 
 	opts := hcloud.PlacementGroupCreateOpts{
@@ -90,10 +90,10 @@ func create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 		}
 	}
 
-	return read(ctx, d, m)
+	return resourcePlacementGroupRead(ctx, d, m)
 }
 
-func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePlacementGroupRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*hcloud.Client)
 
 	id, err := strconv.Atoi(d.Id())
@@ -117,7 +117,7 @@ func read(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagn
 	return nil
 }
 
-func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePlacementGroupUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*hcloud.Client)
 
 	id, err := strconv.Atoi(d.Id())
@@ -168,10 +168,10 @@ func update(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Dia
 	}
 	d.Partial(false)
 
-	return read(ctx, d, m)
+	return resourcePlacementGroupRead(ctx, d, m)
 }
 
-func delete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func resourcePlacementGroupDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*hcloud.Client)
 
 	id, err := strconv.Atoi(d.Id())

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -234,8 +234,8 @@ func resourcePrimaryIPUpdate(ctx context.Context, d *schema.ResourceData, m inte
 	}
 
 	if d.HasChange("delete_protection") {
-		delete := d.Get("delete_protection").(bool)
-		if err := setProtection(ctx, client, primaryIP, delete); err != nil {
+		deletionProtection := d.Get("delete_protection").(bool)
+		if err := setProtection(ctx, client, primaryIP, deletionProtection); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
@@ -337,11 +337,7 @@ func setProtection(ctx context.Context, c *hcloud.Client, primaryIP *hcloud.Prim
 		return err
 	}
 
-	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-		return err
-	}
-
-	return nil
+	return hcclient.WaitForAction(ctx, &c.Action, action)
 }
 
 func watchProgress(ctx context.Context, action *hcloud.Action, client *hcloud.Client) diag.Diagnostics {

--- a/internal/sshkey/data_source.go
+++ b/internal/sshkey/data_source.go
@@ -171,7 +171,7 @@ func dataSourceHcloudSSHKeyListRead(ctx context.Context, d *schema.ResourceData,
 			LabelSelector: labelSelectorStr,
 		},
 	}
-	allKeys, err := client.SSHKey.AllWithOpts(context.Background(), opts)
+	allKeys, err := client.SSHKey.AllWithOpts(ctx, opts)
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}

--- a/internal/sshkey/resource.go
+++ b/internal/sshkey/resource.go
@@ -48,8 +48,8 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					if ok, error := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
-						return diag.Errorf(error.Error())
+					if ok, err := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
+						return diag.Errorf(err.Error())
 					}
 					return nil
 				},
@@ -58,7 +58,7 @@ func Resource() *schema.Resource {
 	}
 }
 
-func resourceSSHKeyPublicKeyDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+func resourceSSHKeyPublicKeyDiffSuppress(_, old, new string, d *schema.ResourceData) bool {
 	fingerprint := d.Get("fingerprint").(string)
 	if new != "" && fingerprint != "" {
 		publicKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(new))

--- a/internal/volume/resource.go
+++ b/internal/volume/resource.go
@@ -54,8 +54,8 @@ func Resource() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				ValidateDiagFunc: func(i interface{}, path cty.Path) diag.Diagnostics {
-					if ok, error := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
-						return diag.Errorf(error.Error())
+					if ok, err := hcloud.ValidateResourceLabels(i.(map[string]interface{})); !ok {
+						return diag.Errorf(err.Error())
 					}
 					return nil
 				},
@@ -241,10 +241,7 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 					return err
 				}
 
-				if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
-					return err
-				}
-				return nil
+				return hcclient.WaitForAction(ctx, &c.Action, a)
 			})
 			if err != nil {
 				return hcclient.ErrorToDiag(err)
@@ -259,10 +256,8 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 						}
 						return err
 					}
-					if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-						return err
-					}
-					return nil
+
+					return hcclient.WaitForAction(ctx, &c.Action, action)
 				})
 				if err != nil {
 					return hcclient.ErrorToDiag(err)
@@ -281,10 +276,8 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 					}
 					return err
 				}
-				if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-					return err
-				}
-				return nil
+
+				return hcclient.WaitForAction(ctx, &c.Action, action)
 			})
 			if err != nil {
 				return hcclient.ErrorToDiag(err)
@@ -301,6 +294,7 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			}
 			return hcclient.ErrorToDiag(err)
 		}
+
 		if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
@@ -324,8 +318,8 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	if d.HasChange("delete_protection") {
-		delete := d.Get("delete_protection").(bool)
-		if err := setProtection(ctx, c, volume, delete); err != nil {
+		deletionProtection := d.Get("delete_protection").(bool)
+		if err := setProtection(ctx, c, volume, deletionProtection); err != nil {
 			return hcclient.ErrorToDiag(err)
 		}
 	}
@@ -358,10 +352,7 @@ func resourceVolumeDelete(ctx context.Context, d *schema.ResourceData, m interfa
 				return err
 			}
 
-			if err := hcclient.WaitForAction(ctx, &c.Action, a); err != nil {
-				return err
-			}
-			return nil
+			return hcclient.WaitForAction(ctx, &c.Action, a)
 		})
 		if err != nil {
 			return hcclient.ErrorToDiag(err)
@@ -430,9 +421,5 @@ func setProtection(ctx context.Context, c *hcloud.Client, v *hcloud.Volume, dele
 		return err
 	}
 
-	if err := hcclient.WaitForAction(ctx, &c.Action, action); err != nil {
-		return err
-	}
-
-	return nil
+	return hcclient.WaitForAction(ctx, &c.Action, action)
 }


### PR DESCRIPTION
The linting step in our CI started failing for new PRs. This fixes all open issues and pins the golangci-lint version to avoid accidental regressions.