### PR TITLE
fix(server): unable to create server from image id

### DIFF
--- a/internal/e2etests/testing.go
+++ b/internal/e2etests/testing.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
 	tfhcloud "github.com/hetznercloud/terraform-provider-hcloud/hcloud"
 )
 
@@ -16,6 +17,9 @@ const (
 
 	// TestServerType is the default server type used in all tests
 	TestServerType = "cx11"
+
+	// TestArchitecture is the default architecture used in all tests, should match the architecture of the TestServerType.
+	TestArchitecture = hcloud.ArchitectureX86
 
 	// TestLoadBalancerType is the default Load Balancer type used in all tests
 	TestLoadBalancerType = "lb11"

--- a/internal/image/testing.go
+++ b/internal/image/testing.go
@@ -3,6 +3,7 @@ package image
 import (
 	"fmt"
 
+	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
@@ -14,6 +15,7 @@ type DData struct {
 	ImageID       string
 	ImageName     string
 	LabelSelector string
+	Architecture  hcloud.Architecture
 }
 
 // TFID returns the data source identifier.
@@ -27,6 +29,7 @@ type DDataList struct {
 	testtemplate.DataCommon
 
 	LabelSelector string
+	Architecture  hcloud.Architecture
 }
 
 // TFID returns the data source identifier.

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -276,14 +276,14 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return hcclient.ErrorToDiag(err)
 	}
 
-	imageName := d.Get("image").(string)
-	image, _, err := c.Image.GetByNameAndArchitecture(ctx, imageName, serverType.Architecture)
+	imageNameOrID := d.Get("image").(string)
+	image, _, err := c.Image.GetForArchitecture(ctx, imageNameOrID, serverType.Architecture)
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
 
 	if image == nil {
-		return diag.Errorf("image %s for architecture %s not found", imageName, serverType.Architecture)
+		return diag.Errorf("image %s for architecture %s not found", imageNameOrID, serverType.Architecture)
 	}
 
 	if image.IsDeprecated() {

--- a/internal/testdata/d/hcloud_image.tf.tmpl
+++ b/internal/testdata/d/hcloud_image.tf.tmpl
@@ -4,4 +4,5 @@ data "hcloud_image" "{{ .RName }}" {
   {{ if .ImageID -}}   id            = "{{ .ImageID }}"{{ end -}}
   {{ if .ImageName -}} name          = "{{ .ImageName }}"{{ end -}}
   {{ if .LabelSelector -}}    with_selector = "{{ .LabelSelector }}"{{ end }}
+  {{ if .Architecture -}}    with_architecture = "{{ .Architecture }}"{{ end }}
 }

--- a/internal/testdata/d/hcloud_images.tf.tmpl
+++ b/internal/testdata/d/hcloud_images.tf.tmpl
@@ -2,4 +2,5 @@
 
 data "hcloud_images" "{{ .RName }}" {
   {{ if .LabelSelector -}}    with_selector = "{{ .LabelSelector }}"{{ end }}
+  {{ if .Architecture -}}    with_architecture = ["{{ .Architecture }}"]{{ end }}
 }


### PR DESCRIPTION
Fixes a bug where the server create logic would only consider images by name, instead of id & name. This breaks previously working configurations.

Closes #656