### PR TITLE
fix(server): crash when non-existent server type is used

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -275,6 +275,9 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}
+	if serverType == nil {
+		return diag.Errorf("server type %s not found", d.Get("server_type"))
+	}
 
 	imageName := d.Get("image").(string)
 	image, _, err := c.Image.GetByNameAndArchitecture(ctx, imageName, serverType.Architecture)


### PR DESCRIPTION
Using a server type that does not exist would crash the plugin with

    Stack trace from the terraform-provider-hcloud_v1.38.0 plugin:
    panic: runtime error: invalid memory address or nil pointer dereference
    [signal SIGSEGV: segmentation violation code=0x2 addr=0x60 pc=0x104b539a0]

    goroutine 98 [running]:
    github.com/hetznercloud/terraform-provider-hcloud/internal/server.resourceServerCreate({0x104e9f9a8, 0x140005d0240}, 0x0?, {0x104de5a80?, 0x140001c5c20?})
    github.com/hetznercloud/terraform-provider-hcloud/internal/server/resource.go:280 +0xe0