### PR TITLE
fix(server): avoid recreate when using official image by ID

### DIFF
--- a/internal/e2etests/server/resource_test.go
+++ b/internal/e2etests/server/resource_test.go
@@ -119,11 +119,6 @@ func TestServerResource_ImageID(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 				),
-
-				// TODO: There is currently a bug that causes a plan when specifying the ID of an official Image. The
-				//       test is still valid to verify that creating servers from image ids work.
-				//       See https://github.com/hetznercloud/terraform-provider-hcloud/issues/657
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -1076,9 +1076,10 @@ func newIPSet(f schema.SchemaSetFunc, ips []net.IP) *schema.Set {
 
 func setServerSchema(d *schema.ResourceData, s *hcloud.Server) {
 	for key, val := range getServerAttributes(d, s) {
-		if key == "id" {
+		switch key {
+		case "id":
 			d.SetId(strconv.Itoa(val.(int)))
-		} else {
+		default:
 			d.Set(key, val)
 		}
 	}
@@ -1109,7 +1110,9 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server) map[string]in
 	}
 
 	if s.Image != nil {
-		if s.Image.Name != "" {
+		if s.Image.Name != "" && strconv.Itoa(s.Image.ID) != d.Get("image") {
+			// Only use the image name if the image is official (Name != "")
+			// AND the user did not explicitly specify the image id
 			res["image"] = s.Image.Name
 		} else {
 			res["image"] = fmt.Sprintf("%d", s.Image.ID)


### PR DESCRIPTION
The hcloud_server resource would always try to use the image name for the image attribute, even if the user explicitly specified the ID. This causes the resource to be recreated on every plan, as the desired image (ID) would be different from the one in the state (name). This only affected images with a name, so the official os images like "ubuntu-22.04".

Fixes #657