### PR TITLE
feat(rdns): support setting RDNS for Primary IPs

### DIFF
--- a/internal/rdns/testing.go
+++ b/internal/rdns/testing.go
@@ -46,6 +46,7 @@ type RData struct {
 	testtemplate.DataCommon
 
 	ServerID       string
+	PrimaryIPID    string
 	FloatingIPID   string
 	LoadBalancerID string
 	IPAddress      string
@@ -63,6 +64,17 @@ func NewRDataServer(t *testing.T, rName string, serverID string, ipAddress strin
 		ServerID:  serverID,
 		IPAddress: ipAddress,
 		DNSPTR:    dnsPTR,
+	}
+	r.SetRName(rName)
+	return r
+}
+
+// NewRDataPrimaryIP creates data for a new rdns resource with primary_ip_id.
+func NewRDataPrimaryIP(t *testing.T, rName string, primaryIPID string, ipAddress string, dnsPTR string) *RData {
+	r := &RData{
+		PrimaryIPID: primaryIPID,
+		IPAddress:   ipAddress,
+		DNSPTR:      dnsPTR,
 	}
 	r.SetRName(rName)
 	return r

--- a/internal/testdata/r/hcloud_rdns.tf.tmpl
+++ b/internal/testdata/r/hcloud_rdns.tf.tmpl
@@ -4,6 +4,9 @@ resource "hcloud_rdns" "{{ .RName }}" {
   {{- if .ServerID }}
   server_id        = {{ .ServerID }}
   {{ end }}
+  {{- if .PrimaryIPID }}
+  primary_ip_id        = {{ .PrimaryIPID }}
+  {{ end }}
   {{- if .FloatingIPID }}
   floating_ip_id        = {{ .FloatingIPID }}
   {{ end }}

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -3,12 +3,12 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_rdns"
 sidebar_current: "docs-hcloud-resource-rdns"
 description: |-
-  Provides a Hetzner Cloud Reverse DNS Entry to create, modify and reset reverse dns entries for Hetzner Cloud Servers, Floating IPs or Load Balancers.
+  Provides a Hetzner Cloud Reverse DNS Entry to create, modify and reset reverse dns entries for Hetzner Cloud Servers, Primary IPs, Floating IPs or Load Balancers.
 ---
 
 # hcloud_rdns
 
-Provides a Hetzner Cloud Reverse DNS Entry to create, modify and reset reverse dns entries for Hetzner Cloud Servers, Floating IPs or Load Balancers.
+Provides a Hetzner Cloud Reverse DNS Entry to create, modify and reset reverse dns entries for Hetzner Cloud Servers, Primary IPs, Floating IPs or Load Balancers.
 
 ## Example Usage
 
@@ -25,6 +25,21 @@ resource "hcloud_rdns" "master" {
   server_id  = hcloud_server.node1.id
   ip_address = hcloud_server.node1.ipv4_address
   dns_ptr    = "example.com"
+}
+```
+
+For Primary IPs:
+
+```hcl
+resource "hcloud_primary_ip" "primary1" {
+  datacenter = "nbg1-dc3"
+  type       = "ipv4"
+}
+
+resource "hcloud_rdns" "primary1" {
+  primary_ip_id  = hcloud_primary_ip.primary1.id
+  ip_address     = hcloud_primary_ip.primary1.ip_address
+  dns_ptr        = "example.com"
 }
 ```
 
@@ -62,9 +77,10 @@ resource "hcloud_rdns" "load_balancer_master" {
 
 - `dns_ptr` - (Required, string) The DNS address the `ip_address` should resolve to.
 - `ip_address` - (Required, string) The IP address that should point to `dns_ptr`.
-- `server_id` - (Required, int) The server the `ip_address` belongs to. Specify only one of `server_id`, `floating_ip_id` and `load_balancer_id`.
-- `floating_ip_id` - (Required, int) The Floating IP the `ip_address` belongs to. Specify only one of `server_id`, `floating_ip_id` and `load_balancer_id`.
-- `load_balancer_id` - (Required, int) The Load Balancer the `ip_address` belongs to. Specify only one of `server_id`, `floating_ip_id` and `load_balancer_id`.
+- `server_id` - (Required, int) The server the `ip_address` belongs to. - `server_id` - (Required, int) The server the `ip_address` belongs to. Specify only one of `server_id`, `primary_ip_id`, `floating_ip_id` and `load_balancer_id`.
+- `primary_ip_id` - (Required, int) The Primary IP the `ip_address` belongs to. - `server_id` - (Required, int) The server the `ip_address` belongs to. Specify only one of `server_id`, `primary_ip_id`, `floating_ip_id` and `load_balancer_id`.
+- `floating_ip_id` - (Required, int) The Floating IP the `ip_address` belongs to. - `server_id` - (Required, int) The server the `ip_address` belongs to. Specify only one of `server_id`, `primary_ip_id`, `floating_ip_id` and `load_balancer_id`.
+- `load_balancer_id` - (Required, int) The Load Balancer the `ip_address` belongs to. - `server_id` - (Required, int) The server the `ip_address` belongs to. Specify only one of `server_id`, `primary_ip_id`, `floating_ip_id` and `load_balancer_id`.
 
 ## Attributes Reference
 
@@ -72,6 +88,7 @@ resource "hcloud_rdns" "load_balancer_master" {
 - `dns_ptr` - (string) DNS pointer for the IP address.
 - `ip_address` - (string) IP address.
 - `server_id` - (int) The server the IP address belongs to.
+- `primary_ip_id` - (int) The Primary IP the IP address belongs to.
 - `floating_ip_id` - (int) The Floating IP the IP address belongs to.
 - `load_balancer_id` - (int) The Load Balancer the IP address belongs to.
 
@@ -83,6 +100,9 @@ Reverse DNS entries can be imported using a compound ID with the following forma
 ```
 # import reverse dns entry on server with id 123, ip 192.168.100.1
 terraform import hcloud_rdns.myrdns s-123-192.168.100.1
+
+# import reverse dns entry on primary ip with id 123, ip 2001:db8::1
+terraform import hcloud_rdns.myrdns p-123-2001:db8::1
 
 # import reverse dns entry on floating ip with id 123, ip 2001:db8::1
 terraform import hcloud_rdns.myrdns f-123-2001:db8::1


### PR DESCRIPTION
Previously you could only set the RDNS for Primary IPs if they were attached to a server, through the `server_id` attribute. This now also allows setting the RDNS for Primary IPs directly, even if they are not attached to a server.

Closes #668