### PR TITLE
feat(server_type): return included traffic

### DIFF
--- a/internal/e2etests/servertype/data_source_test.go
+++ b/internal/e2etests/servertype/data_source_test.go
@@ -38,6 +38,7 @@ func TestAccHcloudDataSourceServerTypeTest(t *testing.T) {
 					resource.TestCheckResourceAttr(stByName.TFID(), "cores", "1"),
 					resource.TestCheckResourceAttr(stByName.TFID(), "memory", "2"),
 					resource.TestCheckResourceAttr(stByName.TFID(), "architecture", "x86"),
+					resource.TestCheckResourceAttr(stByName.TFID(), "included_traffic", "21990232555520"),
 
 					resource.TestCheckResourceAttr(stByID.TFID(), "id", "1"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "name", "cx11"),
@@ -45,6 +46,7 @@ func TestAccHcloudDataSourceServerTypeTest(t *testing.T) {
 					resource.TestCheckResourceAttr(stByID.TFID(), "cores", "1"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "memory", "2"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "architecture", "x86"),
+					resource.TestCheckResourceAttr(stByID.TFID(), "included_traffic", "21990232555520"),
 				),
 			},
 		},

--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -64,6 +64,10 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
+		"included_traffic": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
 	}
 }
 
@@ -152,15 +156,16 @@ func setServerTypeSchema(d *schema.ResourceData, t *hcloud.ServerType) {
 
 func getServerTypeAttributes(t *hcloud.ServerType) map[string]interface{} {
 	return map[string]interface{}{
-		"id":           t.ID,
-		"name":         t.Name,
-		"description":  t.Description,
-		"cores":        t.Cores,
-		"memory":       t.Memory,
-		"disk":         t.Disk,
-		"storage_type": t.StorageType,
-		"cpu_type":     t.CPUType,
-		"architecture": t.Architecture,
+		"id":               t.ID,
+		"name":             t.Name,
+		"description":      t.Description,
+		"cores":            t.Cores,
+		"memory":           t.Memory,
+		"disk":             t.Disk,
+		"storage_type":     t.StorageType,
+		"cpu_type":         t.CPUType,
+		"architecture":     t.Architecture,
+		"included_traffic": t.IncludedTraffic,
 	}
 }
 

--- a/website/docs/d/server_type.html.md
+++ b/website/docs/d/server_type.html.md
@@ -30,3 +30,4 @@ data "hcloud_server_type" "ds_2" {
 - `memory` - (int) Memory a Server of this type will have in GB.
 - `disk` - (int) Disk size a Server of this type will have in GB.
 - `architecture` - (string) Architecture of the server_type.
+- `included_traffic` - (int) Free traffic per month in bytes.


### PR DESCRIPTION
Field was recently added to the API: https://docs.hetzner.cloud/#server-types