### PR TITLE
fix(server): invalid ipv6_address <nil>1 when no IPv6 is used

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -1099,7 +1099,6 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server) map[string]in
 		"status":             s.Status,
 		"server_type":        s.ServerType.Name,
 		"ipv4_address":       s.PublicNet.IPv4.IP.String(),
-		"ipv6_address":       s.PublicNet.IPv6.IP.String() + "1",
 		"ipv6_network":       s.PublicNet.IPv6.Network.String(),
 		"backup_window":      s.BackupWindow,
 		"backups":            s.BackupWindow != "",
@@ -1107,6 +1106,14 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server) map[string]in
 		"delete_protection":  s.Protection.Delete,
 		"rebuild_protection": s.Protection.Rebuild,
 		"firewall_ids":       firewallIDs,
+	}
+
+	if len(s.PublicNet.IPv6.IP) == 0 {
+		// No IPv6 Primary IP assigned
+		res["ipv6_address"] = s.PublicNet.IPv6.IP.String() // Will be just "<nil>"
+	} else {
+		// Set first IP in assigned subnet range
+		res["ipv6_address"] = s.PublicNet.IPv6.IP.String() + "1"
 	}
 
 	if s.Image != nil {


### PR DESCRIPTION
Fixes #687 

I could not add tests for this as they were affected by #688. The tests I added in the description of that issue also verify the fix for this PR.