### PR TITLE
ci: test against terraform v1.5 series

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         run: git fetch --prune --unshallow
       - uses: hashicorp/setup-terraform@v2
         with:
-          terraform_version: v1.4.x
+          terraform_version: v1.5.x
           terraform_wrapper: false
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Terraform 1.5.0 was released today: https://github.com/hashicorp/terraform/releases/tag/v1.5.0