### PR TITLE
feat: expose deprecation info for server types

### DIFF
--- a/internal/deprecation/deprecation.go
+++ b/internal/deprecation/deprecation.go
@@ -1,0 +1,39 @@
+package deprecation
+
+import (
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hetznercloud/hcloud-go/hcloud"
+)
+
+func AddToSchema(s map[string]*schema.Schema) map[string]*schema.Schema {
+	s["is_deprecated"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Computed: true,
+	}
+	s["deprecation_announced"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+		Optional: true,
+	}
+	s["unavailable_after"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+		Optional: true,
+	}
+
+	return s
+}
+
+func SetData(d *schema.ResourceData, r hcloud.Deprecatable) {
+	if !r.IsDeprecated() {
+		d.Set("is_deprecated", false)
+		d.Set("deprecation_announced", nil)
+		d.Set("unavailable_after", nil)
+	} else {
+		d.Set("is_deprecated", true)
+		d.Set("deprecation_announced", r.DeprecationAnnounced().Format(time.RFC3339))
+		d.Set("unavailable_after", r.UnavailableAfter().Format(time.RFC3339))
+	}
+}

--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/deprecation"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hetznercloud/hcloud-go/hcloud"
@@ -25,7 +27,7 @@ const (
 
 // getCommonDataSchema returns a new common schema used by all server type data sources.
 func getCommonDataSchema() map[string]*schema.Schema {
-	return map[string]*schema.Schema{
+	return deprecation.AddToSchema(map[string]*schema.Schema{
 		"id": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -68,7 +70,7 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Type:     schema.TypeInt,
 			Computed: true,
 		},
-	}
+	})
 }
 
 // DataSource creates a new Terraform schema for the hcloud_server_type data
@@ -152,6 +154,8 @@ func setServerTypeSchema(d *schema.ResourceData, t *hcloud.ServerType) {
 			d.Set(key, val)
 		}
 	}
+
+	deprecation.SetData(d, t)
 }
 
 func getServerTypeAttributes(t *hcloud.ServerType) map[string]interface{} {

--- a/website/docs/d/server_type.html.md
+++ b/website/docs/d/server_type.html.md
@@ -31,3 +31,6 @@ data "hcloud_server_type" "ds_2" {
 - `disk` - (int) Disk size a Server of this type will have in GB.
 - `architecture` - (string) Architecture of the server_type.
 - `included_traffic` - (int) Free traffic per month in bytes.
+- `is_deprecated` - (bool) Deprecation status of server type.
+- `deprecation_announced` (Optional, string) Date when the deprecation of the server type was announced. Only set when the server type is deprecated.
+- `unavailable_after` (Optional, string) Date when the server type will not be available for new servers. Only set when the server type is deprecated.


### PR DESCRIPTION
- Add new fields to `data.hcloud_server_type` & `data.hcloud_server_types` that include the deprecation info
- Log warning when the user creates a server with a deprecated server type