### PR TITLE
test: avoid 500 in api by running firewall tests in parallel

### DIFF
--- a/internal/e2etests/firewall/data_source_test.go
+++ b/internal/e2etests/firewall/data_source_test.go
@@ -30,7 +30,8 @@ func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
 	}
 	firewallBySel.SetRName("firewall_by_sel")
 
-	resource.ParallelTest(t, resource.TestCase{
+	// TODO: Move to parallel test once API endpoint is fixed
+	resource.Test(t, resource.TestCase{
 		PreCheck:     e2etests.PreCheck(t),
 		Providers:    e2etests.Providers(),
 		CheckDestroy: testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, nil)),
@@ -75,7 +76,8 @@ func TestAccHcloudDataSourceFirewallListTest(t *testing.T) {
 	allFirewallsSel.SetRName("all_firewalls_sel")
 
 	tmplMan := testtemplate.Manager{}
-	resource.ParallelTest(t, resource.TestCase{
+	// TODO: Move to parallel test once API endpoint is fixed
+	resource.Test(t, resource.TestCase{
 		PreCheck:     e2etests.PreCheck(t),
 		Providers:    e2etests.Providers(),
 		CheckDestroy: testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, nil)),


### PR DESCRIPTION
Follow up to #681, which already moved the resource tests to serial. This commit changes the data source tests.