### PR TITLE
ci: setup release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+on:
+  push:
+    branches:
+      - main
+name: release-please
+
+jobs:
+  release-please:
+    # The secret HCLOUD_BOT_TOKEN is only available on the main repo, not in forks.
+    if: github.repository == 'hetznercloud/terraform-provider-hcloud'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          token: ${{ secrets.HCLOUD_BOT_TOKEN }}
+          release-type: go
+          package-name: terraform-provider-hcloud

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,364 @@
-Every new changelog can be found under the Github Release page: https://github.com/hetznercloud/terraform-provider-hcloud/releases
+# Changelog
+
+## v1.39.0
+
+### What's Changed
+* feat(rdns): support setting RDNS for Primary IPs by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/669
+* feat(server_type): return included traffic by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/680
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.38.2...v1.39.0
+
+## v1.38.2
+
+### What's Changed
+* ci: run e2etests in parallel by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/660
+* fix(server): avoid recreate when using official image by ID by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/661
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.38.1...v1.38.2
+
+## v1.38.1
+
+Affordable, sustainable & powerful! rocketYou can now get one of our Arm64 CAX servers to optimize your operations while minimizing your costs!
+Discover Ampere’s efficient and robust Arm64 architecture and be ready to get blown away with its performance. sunglasses
+
+Learn more: https://www.hetzner.com/news/arm64-cloud
+
+### What's Changed
+* fix(server): crash when non-existent server type is used by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/659
+* fix(server): unable to create server from image id by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/658
+* fix(deps): update module golang.org/x/crypto to v0.8.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/652
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.38.0...v1.38.1
+
+## v1.38.0
+
+Affordable, sustainable & powerful! 🚀You can now get one of our Arm64 CAX servers to optimize your operations while minimizing your costs!
+Discover Ampere’s efficient and robust Arm64 architecture and be ready to get blown away with its performance. 😎
+
+Learn more: https://www.hetzner.com/news/arm64-cloud
+
+### What's Changed
+* fix(deps): update github.com/hashicorp/go-cty digest to 8598007 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/633
+* fix(deps): update module golang.org/x/net to v0.9.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/651
+* feat: add support for ARM APIs by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/654
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.37.0...v1.38.0
+
+## v1.37.0
+
+### What's Changed
+* docs: Add missing location (hil) by @akirak in https://github.com/hetznercloud/terraform-provider-hcloud/pull/606
+* docs: replace outdated example OS image by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/615
+* docs: list available datacenters by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/613
+* docs: explain deprecated attributes by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/614
+* feat(primaryip): return IPv6 subnet #600 by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/620
+* fix: state is missing resources when rate limit is reached #604 by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/621
+* chore(ci): run e2e on public workers by @samcday in https://github.com/hetznercloud/terraform-provider-hcloud/pull/631
+* Configure Renovate by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/629
+* chore: Test against Terraform v1.4 by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/638
+* fix(deps): update module github.com/hashicorp/terraform-plugin-log to v0.8.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/639
+* fix(deps): update module github.com/hetznercloud/hcloud-go to v1.41.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/637
+* fix(deps): update module github.com/hashicorp/terraform-plugin-sdk/v2 to v2.25.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/640
+* chore(deps): update goreleaser/goreleaser-action action to v4 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/642
+* fix: self-reported version not correct by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/630
+* chore(deps): update actions/setup-go action to v4 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/643
+* fix(deps): update module golang.org/x/crypto to v0.7.0 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/641
+* docs: freebsd64 is no longer available as rescue image by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/645
+* refactor: Make CI Happy Again by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/646
+* fix(deps): update module github.com/hashicorp/terraform-plugin-sdk/v2 to v2.26.1 by @renovate in https://github.com/hetznercloud/terraform-provider-hcloud/pull/644
+
+### New Contributors
+* @akirak made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/606
+* @samcday made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/631
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.36.2...v1.37.0
+
+## v1.36.2
+
+### What's Changed
+* test: fix acceptence tests for new location Hillsboro by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/598
+* fix(server): unhandled errors from API calls by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/602
+* fix(lb): lb_target breaks when load-balancer is deleted in API by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/603
+* fix(lb): add missing fields to data source by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/605
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.36.1...v1.36.2
+
+## v1.36.1
+
+### What's Changed
+* chore: update hcloud-go to v1.37.0 by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/591
+* fix(server): make sure that each network block is unique by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/594
+* docs: mention that we only accept the location name as attribute by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/595
+* fix(server): unnecessary updates when using network #556 by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/593
+* fix: multiple resources break when parent resource is recreated by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/596
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.36.0...v1.36.1
+
+## v1.36.0
+
+### What's Changed
+* Update auto delete on primary IP resource change by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/573
+* Update Dependencies by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/575
+* Add tests for Terraform 1.3 by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/576
+* docs: explain how to create a server from snapshot by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/582
+* docs: clarify arguments of hcloud_primary_ip resource by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/584
+* fix: error when deleting hcloud_primary_ip with auto_delete by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/585
+* test: fix flaky test TestServerResource_PrimaryIPNetworkTests by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/587
+* feat: import hcloud_load_balancer_target by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/589
+* fix: race-condition when re-creating server with external primary ip by @apricote in https://github.com/hetznercloud/terraform-provider-hcloud/pull/590
+
+### New Contributors
+* @apricote made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/582
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.35.2...v1.36.0
+
+## v1.35.2
+
+### What's Changed
+* bug: add missing datacenter option at primary_ip & fix file naming by @komandar in https://github.com/hetznercloud/terraform-provider-hcloud/pull/559
+* Fix private only server (attached to network) creation by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/562
+* feature: update workflow & golang to newest stable release 1.19 by @komandar in https://github.com/hetznercloud/terraform-provider-hcloud/pull/560
+* ci: fix not available gpg_private_key in workflow by @komandar in https://github.com/hetznercloud/terraform-provider-hcloud/pull/563
+* Remove < and > signs in import examples by @ekeih in https://github.com/hetznercloud/terraform-provider-hcloud/pull/564
+* fix: wrong required statement by @komandar in https://github.com/hetznercloud/terraform-provider-hcloud/pull/567
+* style: unify the bool and boolean type in the docs by @komandar in https://github.com/hetznercloud/terraform-provider-hcloud/pull/568
+
+### New Contributors
+* @komandar made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/559
+* @ekeih made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/564
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.35.1...v1.35.2
+
+## v1.35.1
+
+### What's Changed
+* Add workaround "fix" for network interface issue by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/552
+* Update hcloud-go to v1.35.2 by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/554
+* Prevent segfault when image nonexistent by @acuteaura in https://github.com/hetznercloud/terraform-provider-hcloud/pull/553
+
+### New Contributors
+* @acuteaura made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/553
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.35.0...v1.35.1
+
+## v1.35.0
+
+### What's Changed
+* Implement Server Create Without primary ip on update behavior by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/548
+* Add support of using deprecated images by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/549
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.34.3...v1.35.0
+
+## v1.34.3
+
+### What's Changed
+* Create server without primary ips: Fix edge case bug + add test by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/546
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.34.2...v1.34.3
+
+## v1.34.2
+
+### What's Changed
+* Server Create without primary IPs via public_net by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/544
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.34.1...v1.34.2
+
+## v1.34.1
+
+### What's Changed
+* Add primary ip documentation by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/540
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.34.0...v1.34.1
+
+## v1.34.0
+
+### What's Changed
+* Update Dependencies (TF SDK 2.7.1 -> 2.14) by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/524
+* DataSource Network `id` should be an integer by @guineveresaenger in https://github.com/hetznercloud/terraform-provider-hcloud/pull/525
+* Improve documentation by @02bensch in https://github.com/hetznercloud/terraform-provider-hcloud/pull/536
+* Add support for primary IPs by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/538
+
+### New Contributors
+* @guineveresaenger made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/525
+* @02bensch made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/536
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.33.2...v1.34.0
+
+## v1.33.2
+
+### What's Changed
+* Implement validation on labels as per spec by @4ND3R50N in https://github.com/hetznercloud/terraform-provider-hcloud/pull/522
+* Add resourceFloatingIPAssignmentUpdate by @CyberShadow in https://github.com/hetznercloud/terraform-provider-hcloud/pull/501
+* Use Go 1.18 for building by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/523
+
+### New Contributors
+* @4ND3R50N made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/522
+* @CyberShadow made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/501
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.33.1...v1.33.2
+
+## v1.33.1
+
+### What's Changed
+* Datasource hcloud_location & hcloud_locations: Add network_zone by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/508
+* hcloud_servcer resource: Retry on enabling rescue (reset call) by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/511
+
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.33.0...v1.33.1
+
+## v1.33.0
+
+### What's Changed
+* Update image.html.md by @FloMaetschke in https://github.com/hetznercloud/terraform-provider-hcloud/pull/494
+* docs: Add missing location (ash) by @dhoppe in https://github.com/hetznercloud/terraform-provider-hcloud/pull/496
+* Add missing argument for resource hcloud_ssh_key by @dhoppe in https://github.com/hetznercloud/terraform-provider-hcloud/pull/498
+* Make the image property of hcloud_server optional by @fhofherr in https://github.com/hetznercloud/terraform-provider-hcloud/pull/499
+* Implement hcloud_firewall_attachment resource by @fhofherr in https://github.com/hetznercloud/terraform-provider-hcloud/pull/500
+
+### New Contributors
+* @FloMaetschke made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/494
+* @dhoppe made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/496
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.32.2...v1.33.0
+
+## v1.32.2
+
+### What's Changed
+* server: resource: fix spelling by @xdevs23 in https://github.com/hetznercloud/terraform-provider-hcloud/pull/480
+* Use our own E2E Test runner by @LKaemmerling in https://github.com/hetznercloud/terraform-provider-hcloud/pull/481
+* Mark the hcloud_token sensitive by @fhofherr in https://github.com/hetznercloud/terraform-provider-hcloud/pull/479
+* Fix nil check for RNDSupporter by @fhofherr in https://github.com/hetznercloud/terraform-provider-hcloud/pull/485
+* fix: typo in docs by @RobertHeim in https://github.com/hetznercloud/terraform-provider-hcloud/pull/486
+* Adjust tests by @fhofherr in https://github.com/hetznercloud/terraform-provider-hcloud/pull/489
+* fix: typo by @RobertHeim in https://github.com/hetznercloud/terraform-provider-hcloud/pull/488
+
+### New Contributors
+* @xdevs23 made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/480
+* @RobertHeim made their first contribution in https://github.com/hetznercloud/terraform-provider-hcloud/pull/486
+
+**Full Changelog**: https://github.com/hetznercloud/terraform-provider-hcloud/compare/v1.32.1...v1.32.2
+
+## v1.32.1
+
+
+
+- ec487e93 Fix failing tests
+- d10e9f0d Fix firewall deletion
+
+## v1.32.0
+
+
+
+- af8300cf Case-insensitive comparison of IPv6 addresses
+- 4adfcfa9 Update hcloud-go to v1.33.0
+- 9e08f76f hcloud_firewall resource: Remove all resources before deleting the firewall
+
+## v1.31.1
+
+
+
+- 545375f9 hcloud_server resource: Add computed to firewall_ids
+
+## v1.31.0
+
+### What's Changed
+
+- 3a6384cc Add delete and rebuild protection (#432)
+- 6eaecafa Add list data source for certificates
+- 07b1b53e Add list data source for firewall (#445)
+- 45843b99 Add list data source for floating ips (#448)
+- 9914e064 Add list data source for images
+- 21267191 Add list data source for load balancers
+- eb3bcc0c Add list data source for networks (#452)
+- a0045237 Add list data source for placement groups (#456)
+- 333e38ca Add list data source for server (#434)
+- 3a33c154 Add list data source for volumes
+- 8de96d9d Allow updating of hcloud_load_balancer_network resource
+- 14c10006 Deprecate hcloud_load_balancer resource `target` property
+- 5a7feae8 Do not fail fast on e2e tests
+- a3023bfc Fix datasources of server and volume (#431)
+- b02858af Fix firewall apply_to if assigned with server resource (#455)
+- b595efa6 Fix race condition on server data source test (#446)
+- ff44ac8e Improve handling of "Error: cannot remove subnet because servers are attached to it"
+- 86f5c990 Refactor list data source for datacenter (#444)
+- 984c2e3b Refactor list data source for locations
+- 32000fcb Refactor list data source for server types
+- 2c8ad4f4 Refactor list data source for ssh keys (#438)
+- b5f5073e Remove testing & official support of Terraform < 1.0
+- 7e4746f1 hcloud_firewall resource & datasource: Add apply_to possibility
+- 54394aea hcloud_rdns: Fix nil pointer when resource does not exist
+
+## v1.30.0
+
+### What's Changed
+
+- 985c1db9 Add dns ptr support for load balancer
+- 13421a6a Update docs
+- ce6982e0 Use go 1.17 for tests & builds
+
+## v1.29.0
+
+### What's Changed
+
+- f0e2e3c1 Fix date format for certificate states
+- e19f2d76 Placement groups (#426)
+- 151a0b6a Update hcloud_firewall documentation on how to define port range
+
+## v1.28.1
+
+### What's Changed
+
+- 93059571 Add missing firewall rule description docs
+- 9abc5d7e Fix firewall rule description
+
+## v1.28.0
+
+### What's Changed
+
+- 92a07cd0 Add description field to firewall rules
+- a0a90b8f Increase amount of retries on firewall deletion
+
+## v1.27.2
+
+### What's Changed
+
+- f397c38d Add a feature request template
+- b4619110 Fix hcloud_snapshot resource documentation
+- 8d204641 Fix spelling and grammar mistakes
+- 219a6355 Update hcloud-go to v1.28.0
+
+## v1.27.1
+
+### What's Changed
+
+- 71f995bf Add issue template
+- ad88a85f Add missing docs about the network attribute/argument on hcloud_server and implement the datatransformation of the network for the attribute
+- 72a5fb48 Add testcase
+- 449710e9 Add tests for terraform 1.0
+- 0cfa7c88 Docs: Add missing firewall_ids to hcloud_server resource and datasource
+- 80ee6fab Docs: Improve documentation for hcloud_firewall resource to include information about port ranges and the `any` keyword (#381)
+- 8f1c5c16 Docs: Mark example "hcloud_token" variable as sensitive
+- b941c699 Fix non iso8601 timestamp in hcloud_image datasource
+- 993b3cd2 Fix tests
+- e775c362 Generate Changelog with goreleaser
+- 1795d377 Improve error messages from hcloud-go
+- 895813eb Improve hcloud_rdns resource documentation and validation of fields `server_id` and `floating_ip_id` that should be mutually exclusive
+- 3cdd11b4 Increase create timeout for servers and snapshots
+- 68a3d6a6 Move logic around to make it more readable
+- faa15532 Network Attachments: Retry on ServiceError and NoSubnetAvailable Error
+- edbddcfe Update dependencies
+- 4027dd6f Update terraform SDK to v2.7.0
+
 
 ## 1.27.0 (June 17, 2021)
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base",
+
+    // Generate commits compatible with release-please changelog
+    // => "deps: update module github.com/prometheus/client_golang to v1.15.1"
+    ":semanticCommitTypeAll(deps)",
+    ":semanticCommitScopeDisabled",
+  ]
+}


### PR DESCRIPTION
Setup release-please to automate creating new tags according to semver rules.

Backfill changelog entries that were only on GitHub Releases.
