### PR TITLE
feat(network): add support for exposing routes to vswitch connection

### DIFF
--- a/internal/e2etests/network/data_source_test.go
+++ b/internal/e2etests/network/data_source_test.go
@@ -24,6 +24,7 @@ func TestAccHcloudDataSourceNetworkTest(t *testing.T) {
 		Labels: map[string]string{
 			"key": strconv.Itoa(acctest.RandInt()),
 		},
+		ExposeRoutesToVSwitch: true,
 	}
 	res.SetRName("network-ds-test")
 	networkByName := &network.DData{
@@ -61,14 +62,17 @@ func TestAccHcloudDataSourceNetworkTest(t *testing.T) {
 					resource.TestCheckResourceAttr(networkByName.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(networkByName.TFID(), "ip_range", res.IPRange),
+					resource.TestCheckResourceAttr(networkByName.TFID(), "expose_routes_to_vswitch", "true"),
 
 					resource.TestCheckResourceAttr(networkByID.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(networkByID.TFID(), "ip_range", res.IPRange),
+					resource.TestCheckResourceAttr(networkByID.TFID(), "expose_routes_to_vswitch", "true"),
 
 					resource.TestCheckResourceAttr(networkBySel.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(networkBySel.TFID(), "ip_range", res.IPRange),
+					resource.TestCheckResourceAttr(networkBySel.TFID(), "expose_routes_to_vswitch", "true"),
 				),
 			},
 		},

--- a/internal/e2etests/network/resource_test.go
+++ b/internal/e2etests/network/resource_test.go
@@ -208,7 +208,7 @@ func TestNetworkResource_ExposeRouteToVSwitch(t *testing.T) {
 					"testdata/r/hcloud_network", updateExposure(res, false),
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(res.TFID(), "delete_protection", fmt.Sprintf("%t", res.ExposeRoutesToVSwitch)),
+					resource.TestCheckResourceAttr(res.TFID(), "expose_routes_to_vswitch", fmt.Sprintf("%t", res.ExposeRoutesToVSwitch)),
 				),
 			},
 			{

--- a/internal/network/data_source.go
+++ b/internal/network/data_source.go
@@ -47,6 +47,11 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
+		"expose_routes_to_vswitch": {
+			Type:        schema.TypeBool,
+			Description: "Indicates if the routes from this network should be exposed to the vSwitch connection. The exposing only takes effect if a vSwitch connection is active.",
+			Computed:    true,
+		},
 	}
 }
 

--- a/internal/network/testing.go
+++ b/internal/network/testing.go
@@ -76,10 +76,11 @@ func (d *DData) TFID() string {
 type RData struct {
 	testtemplate.DataCommon
 
-	Name             string
-	IPRange          string
-	Labels           map[string]string
-	DeleteProtection bool
+	Name                  string
+	IPRange               string
+	Labels                map[string]string
+	DeleteProtection      bool
+	ExposeRoutesToVSwitch bool
 }
 
 // TFID returns the resource identifier.

--- a/internal/testdata/r/hcloud_network.tf.tmpl
+++ b/internal/testdata/r/hcloud_network.tf.tmpl
@@ -17,4 +17,8 @@ resource "hcloud_network" "{{ .RName }}" {
   {{- if .DeleteProtection }}
   delete_protection = {{ .DeleteProtection }}
   {{ end }}
+
+  {{- if .ExposeRoutesToVSwitch }}
+  expose_routes_to_vswitch = {{ .ExposeRoutesToVSwitch }}
+  {{ end }}
 }

--- a/website/docs/d/network.html.md
+++ b/website/docs/d/network.html.md
@@ -31,3 +31,4 @@ data "hcloud_network" "network_3" {
 - `name` - Name of the Network.
 - `ip_range` - IPv4 prefix of the Network.
 - `delete_protection` - (bool) Whether delete protection is enabled.
+- `expose_routes_to_vswitch` - (bool) Indicates if the routes from this network should be exposed to the vSwitch connection. The exposing only takes effect if a vSwitch connection is active.

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -25,6 +25,7 @@ resource "hcloud_network" "privNet" {
 - `ip_range` - (Required, string) IP Range of the whole Network which must span all included subnets and route destinations. Must be one of the private ipv4 ranges of RFC1918.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
 - `delete_protection` - (Optional, bool) Enable or disable delete protection.
+- `expose_routes_to_vswitch` - (Optional, bool) Enable or disable exposing the routes to the vSwitch connection. The exposing only takes effect if a vSwitch connection is active.
 
 ## Attributes Reference
 
@@ -33,6 +34,7 @@ resource "hcloud_network" "privNet" {
 - `ip_range` - (string) IPv4 Prefix of the whole Network.
 - `labels` - (map) User-defined labels (key-value pairs)
 - `delete_protection` - (bool) Whether delete protection is enabled.
+- `expose_routes_to_vswitch` - (bool) Indicates if the routes from this network should be exposed to the vSwitch connection. The exposing only takes effect if a vSwitch connection is active.
 
 ## Import
 


### PR DESCRIPTION
Feature was released today. This adds:

- Setting and returning the field on all `network` resources