### PR TITLE
fix(server): Return `nil` instead of  `"<nil>"` with IPv4/IPv6 disabled

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -1109,7 +1109,6 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server) map[string]in
 		"location":           s.Datacenter.Location.Name,
 		"status":             s.Status,
 		"server_type":        s.ServerType.Name,
-		"ipv4_address":       s.PublicNet.IPv4.IP.String(),
 		"ipv6_network":       s.PublicNet.IPv6.Network.String(),
 		"backup_window":      s.BackupWindow,
 		"backups":            s.BackupWindow != "",
@@ -1118,10 +1117,15 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server) map[string]in
 		"rebuild_protection": s.Protection.Rebuild,
 		"firewall_ids":       firewallIDs,
 	}
+	if s.PublicNet.IPv4.IsUnspecified() {
+		res["ipv4_address"] = nil
+	} else {
+		res["ipv4_address"] = s.PublicNet.IPv4.IP.String()
+	}
 
 	if len(s.PublicNet.IPv6.IP) == 0 {
 		// No IPv6 Primary IP assigned
-		res["ipv6_address"] = s.PublicNet.IPv6.IP.String() // Will be just "<nil>"
+		res["ipv6_address"] = nil
 	} else {
 		// Set first IP in assigned subnet range
 		res["ipv6_address"] = s.PublicNet.IPv6.IP.String() + "1"


### PR DESCRIPTION
Why:

`"<nil>"` isn't very easy to work with in terraform. e.g. there are functions to work with null or the empty string (""), like `compact()` or `coalesce()`, but nothing exists to handle `"<nil>"` natively, making it an odd one and requiring specific custom filtering constructs to work with it.

`"<nil>"` is a pretty common thing to return in golang, with tens of usages even in the main repo[1] but HCL is not golang

hcloud-go has a very nice IsUnspecified()[1] function to detect if the API returned an unspecified IP address and a quick check says that the hcloud cli command uses it to provide custom text output.

What:

Switch from using unconditionally the output of net.IP.String() function, which returns `"<nil>"`[2] if the IP has length 0, to a conditional usage of the function, setting the address to nil otherwise.

Setting the entire struct to nil apparently locally appeases unit tests just fine and even works in some, very simple, scenarios just fine, returning the empty string ("") instead of `"<nil>"`

This is an API breaking change. It might not be desirable to merge and/or require some careful handling depending on how widespread the usage of handling `"<nil>"` is. A quick search on my side, did not find any usages[3], but I might have very well failed.

[1] https://github.com/search?q=repo%3Agolang%2Fgo%20%22%3Cnil%3E%22&type=code
[2] https://pkg.go.dev/net#IP.String
[3] https://github.com/search?q=%22%3Cnil%3E%22+language%3AHCL&type=code