### PR TITLE
fix(primary_ip): list data source only returned first 25 IPs

### DIFF
--- a/internal/primaryip/data_source.go
+++ b/internal/primaryip/data_source.go
@@ -188,7 +188,7 @@ func dataSourceHcloudPrimaryIPListRead(ctx context.Context, d *schema.ResourceDa
 			LabelSelector: selector,
 		},
 	}
-	allIPs, _, err := client.PrimaryIP.List(ctx, opts)
+	allIPs, err := client.PrimaryIP.AllWithOpts(ctx, opts)
 	if err != nil {
 		return hcclient.ErrorToDiag(err)
 	}


### PR DESCRIPTION
This caused the e2e tests for the primary IPs to fail when the account had more than 25 primary IPs.