### PR TITLE
fix: use exponential backoff when retrying actions

### DIFF
--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -51,7 +51,7 @@ func Resource() *schema.Resource {
 				Optional: true,
 				Computed: true,
 				DiffSuppressFunc: func(_, _, _ string, d *schema.ResourceData) bool {
-					// Diff is only valid if "network" resource is set in
+					// Diff is only valid if "apply_to" argument is set in
 					// terraform configuration.
 					_, ok := d.GetOk("apply_to")
 					return !ok // Negate because we do **not** want to suppress the diff.


### PR DESCRIPTION
Exponential backoff is better suited to reduce the average amount of calls needed. We are already using it to wait for running Actions.

Should fix #734 for all but the most extreme situations.