### PR TITLE
test: fix broken e2e test related to #755

### DIFF
--- a/internal/e2etests/server/resource_test.go
+++ b/internal/e2etests/server/resource_test.go
@@ -66,7 +66,7 @@ func TestServerResource_Basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
-					"ssh_keys", "user_data", "keep_disk", "ignore_remote_firewall_ids", "allow_deprecated_images",
+					"ssh_keys", "user_data", "keep_disk", "ignore_remote_firewall_ids", "allow_deprecated_images", "shutdown_before_deletion",
 				},
 			},
 			{


### PR DESCRIPTION
We do not need to verify the import state on attributes that are terraform internal.

Related to #755 