### PR TITLE
fix: failed to load plugin schemas

### DIFF
--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -45,7 +45,7 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"token": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("HCLOUD_TOKEN", nil),
 				Description: "The Hetzner Cloud API token, can also be specified with the HCLOUD_TOKEN environment variable.",
 				ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {


### PR DESCRIPTION
The schemas between the Plugin SDK Provider and the Plugin Framework Provider have different values. This is not allowed, as it causes inconstency, and the terraform-provider stops on startup with an error if this is detected.

The "token" is not truly required in the old provider (or the new), because we fallback to the HCLOUD_TOKEN environment variable and have additional validation that verifies it is set.

Closes #763 

Related to #752 