### PR TITLE
refactor: move mux server setup to shared function

### DIFF
--- a/hcloud/mux.go
+++ b/hcloud/mux.go
@@ -1,0 +1,34 @@
+package hcloud
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/providerserver"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
+	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
+)
+
+func GetMuxedProvider(ctx context.Context) (func() tfprotov6.ProviderServer, error) {
+	upgradedSdkServer, err := tf5to6server.UpgradeServer(
+		ctx,
+		Provider().GRPCProvider,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	providers := []func() tfprotov6.ProviderServer{
+		providerserver.NewProtocol6(NewPluginProvider()),
+		func() tfprotov6.ProviderServer {
+			return upgradedSdkServer
+		},
+	}
+
+	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
+	if err != nil {
+		return nil, err
+	}
+
+	return muxServer.ProviderServer, nil
+}

--- a/hcloud/mux_test.go
+++ b/hcloud/mux_test.go
@@ -1,0 +1,23 @@
+package hcloud
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMuxedProviderSchema(t *testing.T) {
+	providerFactory, err := GetMuxedProvider(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := providerFactory().GetProviderSchema(context.Background(), &tfprotov6.GetProviderSchemaRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Len(t, resp.Diagnostics, 0)
+}

--- a/main.go
+++ b/main.go
@@ -5,11 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6/tf6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf5to6server"
-	"github.com/hashicorp/terraform-plugin-mux/tf6muxserver"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/hcloud"
 )
@@ -22,24 +18,7 @@ func main() {
 	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
 	flag.Parse()
 
-	upgradedSdkServer, err := tf5to6server.UpgradeServer(
-		ctx,
-		hcloud.Provider().GRPCProvider,
-	)
-
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	providers := []func() tfprotov6.ProviderServer{
-		providerserver.NewProtocol6(hcloud.NewPluginProvider()),
-		func() tfprotov6.ProviderServer {
-			return upgradedSdkServer
-		},
-	}
-
-	muxServer, err := tf6muxserver.NewMuxServer(ctx, providers...)
-
+	providerFactory, err := hcloud.GetMuxedProvider(ctx)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -52,7 +31,7 @@ func main() {
 
 	err = tf6server.Serve(
 		"registry.terraform.io/hetznercloud/hcloud",
-		muxServer.ProviderServer,
+		providerFactory,
 		serveOpts...,
 	)
 


### PR DESCRIPTION
This refactors the code around #763 and adds a unit test to make sure that the issue does not creep back in. 

We are still not sure why this was not caught in the regular e2e tests.


Co-authored-by: jooola <ljonas@riseup.net>