### PR TITLE
docs: clarify how delete protection works in TF

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -39,3 +39,11 @@ The following arguments are supported:
 - `token` - (Required, string) This is the Hetzner Cloud API Token, can also be specified with the `HCLOUD_TOKEN` environment variable.
 - `endpoint` - (Optional, string) Hetzner Cloud API endpoint, can be used to override the default API Endpoint `https://api.hetzner.cloud/v1`.
 - `poll_interval` -  (Optional, string) Configures the interval in which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.
+
+## Delete Protection
+
+The Hetzner Cloud API allows to protect resources from deletion by putting a "lock" on them.
+This can also be configured through Terraform through the `delete_protection` argument on resources that support it.
+
+Please note, that this does not protect deletion from Terraform itself, as the Provider will lift the lock in that case.
+If you also want to protect your resources from deletion by Terraform, you can use the [`prevent_destroy` lifecycle attribute](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion).

--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -33,7 +33,7 @@ resource "hcloud_floating_ip" "master" {
 - `home_location` - (Optional, string) Name of home location (routing is optimized for that location). Optional if server_id argument is passed.
 - `description` - (Optional, string) Description of the Floating IP.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, bool) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
 ## Attributes Reference
 

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -38,7 +38,7 @@ resource "hcloud_load_balancer" "load_balancer" {
 - `network_zone` - (Optional, string) The Network Zone of the Load Balancer. Require when no location is set.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, bool) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
 `algorithm` support the following fields:
 - `type` - (Required, string) Type of the Load Balancer Algorithm. `round_robin` or `least_connections`

--- a/website/docs/r/network.html.md
+++ b/website/docs/r/network.html.md
@@ -24,7 +24,7 @@ resource "hcloud_network" "privNet" {
 - `name` - (Required, string) Name of the Network to create (must be unique per project).
 - `ip_range` - (Required, string) IP Range of the whole Network which must span all included subnets and route destinations. Must be one of the private ipv4 ranges of RFC1918.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
-- `delete_protection` - (Optional, bool) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 - `expose_routes_to_vswitch` - (Optional, bool) Enable or disable exposing the routes to the vSwitch connection. The exposing only takes effect if a vSwitch connection is active.
 
 ## Attributes Reference

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -52,7 +52,7 @@ resource "hcloud_server" "server_test" {
 - `labels` - (string) Description of the Primary IP.
 - `assignee_id` - (int) ID of the assigned resource
 - `assignee_type` - (string) The type of the assigned resource. Currently supported: `server`
-- `delete_protection` - (bool) Whether delete protection is enabled.
+- `delete_protection` - (bool) Whether delete protection is enabled. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
 ## Attributes Reference
 

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -178,7 +178,7 @@ The following arguments are supported:
   argument.
 - `network` - (Optional)  Network the server should be attached to on creation. (Can be specified multiple times)
 - `placement_group_id` - (Optional, string) Placement Group ID the server added to on creation.
-- `delete_protection` - (Optional, bool) Enable or disable delete protection (Needs to be the same as `rebuild_protection`).
+- `delete_protection` - (Optional, bool) Enable or disable delete protection (Needs to be the same as `rebuild_protection`). See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 - `rebuild_protection` - (Optional, bool) Enable or disable rebuild protection (Needs to be the same as `delete_protection`).
 - `allow_deprecated_images` - (Optional, bool) Enable the use of deprecated images (default: false). **Note** Deprecated images will be removed after three months. Using them is then no longer possible.
 - `shutdown_before_deletion` - (bool) Whether to try shutting the server down gracefully before deleting it.

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -36,7 +36,7 @@ resource "hcloud_volume" "master" {
 - `location` - (Optional, string) The location name of the volume to create, not allowed if server_id argument is passed.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).
 - `format` - (Optional, string) Format volume after creation. `xfs` or `ext4`
-- `delete_protection` - (Optional, bool) Enable or disable delete protection.
+- `delete_protection` - (Optional, bool) Enable or disable delete protection. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
 **Note:** When you want to attach multiple volumes to a server, please use the `hcloud_volume_attachment` resource and the `location` argument instead of the `server_id` argument.
 


### PR DESCRIPTION
Closes #519

I am not 100% sure that the link will be properly translated when the HTML docs are being built. Unfortunately the `make website` uses deprecated projects from Hashicorp that no longer work. We should revisit this after #752 and evaluate autogenerating the docs from the code schema.