### PR TITLE
ci: allow longer timeout for golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,17 +27,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.54.2
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go
-          # skip-go-installation: true
+          version: v1.55.0
+          # In general linting is quite fast with warm caches, but a fresh run might
+          # take some time.
+          args: --timeout 5m

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ test:acceptance:
 
 test:golangci-lint:
   stage: test
-  image: golangci/golangci-lint:v1.54.2
+  image: golangci/golangci-lint:v1.55.0
   script:
     - golangci-lint run -v
   except:


### PR DESCRIPTION
Was failing on all PRs today with a timeout error. Also update to newest version (replacing #778)