### PR TITLE
refactor: embed markdown descriptions for datacenter

### DIFF
--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -147,12 +147,12 @@ func (d *dataSource) Configure(_ context.Context, req datasource.ConfigureReques
 }
 
 //go:embed data_source.md
-var datacenterDataSourceMarkdownDescription string
+var dataSourceMarkdownDescription string
 
 // Schema should return the schema for this data source.
 func (d *dataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema.Attributes = getCommonDataSchema()
-	resp.Schema.MarkdownDescription = datacenterDataSourceMarkdownDescription
+	resp.Schema.MarkdownDescription = dataSourceMarkdownDescription
 }
 
 // ConfigValidators returns a list of ConfigValidators. Each ConfigValidator's Validate method will be called when validating the data source.
@@ -248,7 +248,7 @@ func (d *dataSourceList) Configure(_ context.Context, req datasource.ConfigureRe
 }
 
 //go:embed data_source_list.md
-var datacenterDataSourceListMarkdownDescription string
+var dataSourceListMarkdownDescription string
 
 // Schema should return the schema for this data source.
 func (d *dataSourceList) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -279,7 +279,7 @@ func (d *dataSourceList) Schema(_ context.Context, _ datasource.SchemaRequest, r
 		},
 	}
 
-	resp.Schema.MarkdownDescription = datacenterDataSourceListMarkdownDescription
+	resp.Schema.MarkdownDescription = dataSourceListMarkdownDescription
 }
 
 type resourceDataList struct {

--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -3,6 +3,7 @@ package datacenter
 import (
 	"context"
 	"crypto/sha1"
+	_ "embed"
 	"fmt"
 	"sort"
 	"strconv"
@@ -145,23 +146,13 @@ func (d *dataSource) Configure(_ context.Context, req datasource.ConfigureReques
 	}
 }
 
+//go:embed data_source.md
+var datacenterDataSourceMarkdownDescription string
+
 // Schema should return the schema for this data source.
 func (d *dataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema.Attributes = getCommonDataSchema()
-
-	resp.Schema.MarkdownDescription = `
-Provides details about a specific Hetzner Cloud Datacenter.
-Use this resource to get detailed information about specific datacenter.
-
-## Example Usage
-` + "```" + `hcl
-data "hcloud_datacenter" "ds_1" {
-  name = "fsn1-dc14"
-}
-data "hcloud_datacenter" "ds_2" {
-  id = 4
-}
-` + "```"
+	resp.Schema.MarkdownDescription = datacenterDataSourceMarkdownDescription
 }
 
 // ConfigValidators returns a list of ConfigValidators. Each ConfigValidator's Validate method will be called when validating the data source.
@@ -256,6 +247,9 @@ func (d *dataSourceList) Configure(_ context.Context, req datasource.ConfigureRe
 	}
 }
 
+//go:embed data_source_list.md
+var datacenterDataSourceListMarkdownDescription string
+
 // Schema should return the schema for this data source.
 func (d *dataSourceList) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema.Attributes = map[string]schema.Attribute{
@@ -285,19 +279,7 @@ func (d *dataSourceList) Schema(_ context.Context, _ datasource.SchemaRequest, r
 		},
 	}
 
-	resp.Schema.MarkdownDescription = `
-Provides details about a specific Hetzner Cloud Datacenter.
-Use this resource to get detailed information about specific datacenter.
-
-## Example Usage
-` + "```" + `hcl
-data "hcloud_datacenter" "ds_1" {
-  name = "fsn1-dc8"
-}
-data "hcloud_datacenter" "ds_2" {
-  id = 4
-}
-` + "```"
+	resp.Schema.MarkdownDescription = datacenterDataSourceListMarkdownDescription
 }
 
 type resourceDataList struct {

--- a/internal/datacenter/data_source.md
+++ b/internal/datacenter/data_source.md
@@ -1,0 +1,15 @@
+Provides details about a specific Hetzner Cloud Datacenter. 
+
+Use this resource to get detailed information about a specific datacenter.
+
+## Example
+
+```hcl
+data "hcloud_datacenter" "datacenter1" {
+  name = "fsn1-dc14"
+}
+
+data "hcloud_datacenter" "datacenter2" {
+  id = 4
+}
+```

--- a/internal/datacenter/data_source_list.md
+++ b/internal/datacenter/data_source_list.md
@@ -1,0 +1,18 @@
+Provides a list of available Hetzner Cloud Datacenters.
+
+This resource may be useful to create highly available infrastructure, distributed across several datacenters.
+
+## Example
+
+```hcl
+data "hcloud_datacenters" "datacenters" {}
+
+resource "hcloud_server" "workers" {
+  count = 5
+
+  name        = "node${count.index}"
+  image       = "debian-11"
+  server_type = "cx31"
+  datacenter  = element(data.hcloud_datacenters.datacenters.datacenters, count.index).name
+}
+```


### PR DESCRIPTION
This embeds the description from external markdown files.

In addition, the datacenter list markdown description was using the same as for the datacenter data source, the markdown file now contains the new description picked from `website/docs/d/datacenters.html.md`