### PR TITLE
feat(provider): choose between constant & exponential backoff for actions

### DIFF
--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -73,7 +73,7 @@ func Provider() *schema.Provider {
 				Optional:     true,
 				Default:      "exponential",
 				Description:  "The type of function to be used during the polling.",
-				ExactlyOneOf: []string{"constant", "exponential"},
+				ValidateFunc: validation.StringInSlice([]string{"constant", "exponential"}, false),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hetznercloud/hcloud-go/hcloud"

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -38,7 +38,8 @@ The following arguments are supported:
 
 - `token` - (Required, string) This is the Hetzner Cloud API Token, can also be specified with the `HCLOUD_TOKEN` environment variable.
 - `endpoint` - (Optional, string) Hetzner Cloud API endpoint, can be used to override the default API Endpoint `https://api.hetzner.cloud/v1`.
-- `poll_interval` -  (Optional, string) Configures the interval in which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.
+- `poll_interval` - (Optional, string) Configures the interval in which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.
+- `poll_function` - (Optional, string) Configures the type of function to be used during the polling. Valid values are `constant` and `exponential`. Default `exponential`.
 
 ## Delete Protection
 


### PR DESCRIPTION
This changes the poll backoff function to use `ConstantBackoff` instead of `ExponentialBackoff`. The current `poll_interval` option is a bit misleading because assumes a constant polling interval instead of an exponential one. This causes to wait much more time in some scenarios where you requested the resource status to the API a few times.

In scenarios where you expect a specific amount of time, such as creating a cloud instance with a custom snapshot, this change makes the behavior more predictable.