### PR TITLE
fix(server): missing field primary_disk_size

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -261,6 +261,10 @@ func Resource() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"primary_disk_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }


### PR DESCRIPTION
I missed that this field was not added to the resource schema in #801.

This bug causes e2e tests to fail in main.