### PR TITLE
ci: split test logs per test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
           CERT_DOMAIN: hc-integrations-test.de
 
           TF_LOG: DEBUG
-          TF_LOG_PATH: test.log
+          TF_LOG_PATH_MASK: test-%s.log
 
       - uses: codecov/codecov-action@v3
 
@@ -59,4 +59,4 @@ jobs:
         if: always()
         with:
           name: debug-logs-${{ matrix.terraform }}
-          path: internal/e2etests/**/test.log
+          path: internal/e2etests/**/*.log


### PR DESCRIPTION
Generates a new logs file for each test we run.

Leverage the TF_LOG_PATH_MASK env variable, which format the string with a test name slug, e.g.: `fmt.Sprintf("test-%s.log", testNameSlug)`

https://pkg.go.dev/github.com/hashicorp/terraform-plugin-testing@v1.6.0/helper/logging#pkg-constants