### PR TITLE
test(e2e): reduce flakiness in firewall attachment tests

### DIFF
--- a/internal/e2etests/firewall/attachment_resource_test.go
+++ b/internal/e2etests/firewall/attachment_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/e2etests"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
@@ -30,7 +31,8 @@ func TestAttachmentResource_Servers(t *testing.T) {
 	fwAttRes.ServerIDRefs = append(fwAttRes.ServerIDRefs, srvRes.TFID()+".id")
 
 	tmplMan := testtemplate.Manager{}
-	resource.ParallelTest(t, resource.TestCase{
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
@@ -75,7 +77,8 @@ func TestAttachmentResource_LabelSelectors(t *testing.T) {
 	fwAttRes.LabelSelectors = append(fwAttRes.LabelSelectors, "firewall-attachment=test-server")
 
 	tmplMan := testtemplate.Manager{}
-	resource.ParallelTest(t, resource.TestCase{
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
+	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(

--- a/internal/e2etests/firewall/data_source_test.go
+++ b/internal/e2etests/firewall/data_source_test.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/e2etests"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
@@ -30,7 +30,7 @@ func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
 	}
 	firewallBySel.SetRName("firewall_by_sel")
 
-	// TODO: Move to parallel test once API endpoint is fixed
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),
@@ -76,7 +76,7 @@ func TestAccHcloudDataSourceFirewallListTest(t *testing.T) {
 	allFirewallsSel.SetRName("all_firewalls_sel")
 
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint is fixed
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),

--- a/internal/e2etests/firewall/resource_test.go
+++ b/internal/e2etests/firewall/resource_test.go
@@ -66,7 +66,7 @@ func TestFirewallResource_Basic(t *testing.T) {
 	}, nil)
 	updated.SetRName(res.RName())
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint is fixed
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),
@@ -192,7 +192,7 @@ func TestFirewallResource_SourceIPs_IPv6Comparison(t *testing.T) {
 	}, nil)
 	tmplMan := testtemplate.Manager{}
 
-	// TODO: Move to parallel test once API endpoint is fixed
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),
@@ -225,7 +225,7 @@ func TestFirewallResource_DestinationIPs_IPv6Comparison(t *testing.T) {
 	}, nil)
 	tmplMan := testtemplate.Manager{}
 
-	// TODO: Move to parallel test once API endpoint is fixed
+	// TODO: Move to parallel test once API endpoint supports higher parallelism
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 e2etests.PreCheck(t),
 		ProtoV6ProviderFactories: e2etests.ProtoV6ProviderFactories(),


### PR DESCRIPTION
The firewall endpoints responds with 500 server_error regularly when being called too many times in parallel. This is annoying as it fails our integration test suite and requires lengthy retries.

Moving the tests to run in series reduces the amount of parallel calls to these endpoints. This was previously already done for the firewall resource and datasource tests.

Sample failure: https://github.com/hetznercloud/terraform-provider-hcloud/actions/runs/7495395337/job/20405373073?pr=836#step:6:1149