### PR TITLE
fix: add api request status code in error diagnostics

### DIFF
--- a/internal/hcclient/error_framework_test.go
+++ b/internal/hcclient/error_framework_test.go
@@ -1,31 +1,42 @@
 package hcclient
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 )
 
 func TestAPIErrorDiagnostics(t *testing.T) {
 	for _, tc := range []struct {
-		name        string
-		err         error
-		diagnostics diag.Diagnostics
+		name          string
+		err           error
+		errRaw        map[string]interface{}
+		errStatusCode int
+		diagnostics   diag.Diagnostics
 	}{
 		{
 			name: "hcloud invalid input error",
-			err: hcloud.Error{
-				Code:    hcloud.ErrorCodeInvalidInput,
-				Message: "something is fishy",
-				Details: hcloud.ErrorDetailsInvalidInput{
-					Fields: []hcloud.ErrorDetailsInvalidInputField{
-						{Name: "foobar", Messages: []string{"must be bar", "foo too long"}},
+			errRaw: map[string]interface{}{
+				"error": map[string]interface{}{
+					"code":    "invalid_input",
+					"message": "something is fishy",
+					"details": map[string]interface{}{
+						"fields": []map[string]interface{}{
+							{"name": "foobar", "messages": []string{"must be bar", "foo too long"}},
+						},
 					},
 				},
 			},
+			errStatusCode: http.StatusBadRequest,
 			diagnostics: []diag.Diagnostic{
 				diag.NewErrorDiagnostic(
 					"Invalid field in API request",
@@ -38,6 +49,7 @@ Messages:
  - must be bar
  - foo too long
 Error code: invalid_input
+Status code: 400
 `),
 			},
 		},
@@ -47,6 +59,13 @@ Error code: invalid_input
 				Code:    hcloud.ErrorCodeRateLimitExceeded,
 				Message: "rate limit exceeded",
 			},
+			errRaw: map[string]interface{}{
+				"error": map[string]interface{}{
+					"code":    "rate_limit_exceeded",
+					"message": "rate limit exceeded",
+				},
+			},
+			errStatusCode: http.StatusTooManyRequests,
 			diagnostics: []diag.Diagnostic{
 				diag.NewErrorDiagnostic(
 					"API request failed",
@@ -55,6 +74,7 @@ Error code: invalid_input
 rate limit exceeded
 
 Error code: rate_limit_exceeded
+Status code: 429
 `),
 			},
 		},
@@ -72,10 +92,40 @@ something broke :(
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			diags := APIErrorDiagnostics(tc.err)
+			err := tc.err
+			if tc.errRaw != nil {
+				err = hcloudErrorFromErrorAndStatus(tc.errRaw, tc.errStatusCode)
+			}
+
+			diags := APIErrorDiagnostics(err)
 			if !reflect.DeepEqual(diags, tc.diagnostics) {
 				t.Errorf("expected %+v\n\nfound %+v", tc.diagnostics, diags)
 			}
 		})
 	}
+}
+
+// hcloudErrorFromErrorAndStatus is a hack to fill the private field `hcloud.Error.response` with a sensible response
+// so we can fully test the logged error messages.
+func hcloudErrorFromErrorAndStatus(errRaw map[string]interface{}, statusCode int) error {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := hcloud.NewClient(
+		hcloud.WithEndpoint(server.URL),
+		hcloud.WithToken("token"),
+	)
+
+	mux.HandleFunc("/actions/1", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		err := json.NewEncoder(w).Encode(errRaw)
+		if err != nil {
+			log.Fatal(err)
+		}
+	})
+
+	_, _, err := client.Action.GetByID(context.Background(), 1)
+	return err
 }


### PR DESCRIPTION
Include the HTTP response status code in the API error diagnostics.
