### PR TITLE
feat: support terraform v1.7.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        terraform: [v1.5.x, v1.6.x]
+        terraform: [v1.6.x, v1.7.x]
       fail-fast: false
 
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads)
-  - HashiCorp recommends to use the two latest terraform releases (1.5.x, 1.6.x). Our test suite validates that our provider works with these versions.
+  - HashiCorp recommends to use the two latest terraform releases (1.6.x, 1.7.x). Our test suite validates that our provider works with these versions.
   - This provider uses the [terraform plugin protocol version 6](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol#protocol-version-6), and should work with all tools (ie. Terraform & OpenTofu) that supports it.
 - [Go](https://go.dev/doc/install) 1.21.x (to build the provider plugin)
 


### PR DESCRIPTION
- Start testing with terraform 1.7
- Remove terraform 1.5 from our test matrix
- Update recommended terraform version