### PR TITLE
ci: fix coverage of e2e tests not reported

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       - run: make test TESTARGS=-coverprofile=coverage.txt
 
       - uses: codecov/codecov-action@v3
+        with:
+          flags: unit
 
   integration:
     runs-on: ubuntu-latest
@@ -44,7 +46,7 @@ jobs:
 
       - uses: hetznercloud/tps-action@main
 
-      - run: make testacc TESTARGS=-coverprofile=coverage.txt
+      - run: make testacc TESTARGS="-coverprofile=coverage.txt -coverpkg=./..."
         env:
           # Domain must be available in the account running the tests. This domain is
           # available in the account running the public integration tests.
@@ -54,6 +56,8 @@ jobs:
           TF_LOG_PATH_MASK: test-%s.log
 
       - uses: codecov/codecov-action@v3
+        with:
+          flags: e2e
 
       - uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
By default "go test" only considers the coverage of code in the same package as the test. As our e2e tests are located in different packages to the actual resources, this always resulted in 0% coverage.

I also added codecov flags to e2e & unit tests so we can differentiate between the coverage in codecov UI.