### PR TITLE
ci: run e2e test on main branch and non draft PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,11 @@ jobs:
           flags: unit
 
   e2e:
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.draft == false
+    needs: [unit]
+
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   unit:


### PR DESCRIPTION
- Run e2e test after unit tests.
- Do not run e2e test on draft pull request to reduce resource usage.