### PR TITLE
docs(lb): various fixes

### DIFF
--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -8,12 +8,12 @@ description: |-
 
 # hcloud_load_balancer
 
-  Provides a Hetzner Cloud Load Balancer to represent a Load Balancer in the Hetzner Cloud.
+Provides a Hetzner Cloud Load Balancer to represent a Load Balancer in the Hetzner Cloud.
 
 ## Example Usage
 
 ```hcl
-resource "hcloud_server" "myserver" {
+resource "hcloud_server" "my_server" {
   name        = "server-%d"
   server_type = "cx11"
   image       = "ubuntu-18.04"
@@ -23,10 +23,12 @@ resource "hcloud_load_balancer" "load_balancer" {
   name               = "my-load-balancer"
   load_balancer_type = "lb11"
   location           = "nbg1"
-  target {
-    type      = "server"
-    server_id = hcloud_server.myserver.id
-  }
+}
+
+resource "hcloud_load_balancer_target" "load_balancer_target" {
+  type             = "server"
+  load_balancer_id = hcloud_load_balancer.load_balancer.id
+  server_id        = hcloud_server.my_server.id
 }
 ```
 

--- a/website/docs/r/load_balancer_network.html.md
+++ b/website/docs/r/load_balancer_network.html.md
@@ -35,6 +35,14 @@ resource "hcloud_load_balancer_network" "srvnetwork" {
   load_balancer_id = hcloud_load_balancer.lb1.id
   network_id       = hcloud_network.mynet.id
   ip               = "10.0.1.5"
+
+  # **Note**: the depends_on is important when directly attaching the
+  # server to a network. Otherwise Terraform will attempt to create
+  # server and sub-network in parallel. This may result in the server
+  # creation failing randomly.
+  depends_on = [
+    hcloud_network_subnet.srvnetwork
+  ]
 }
 ```
 


### PR DESCRIPTION
docs: load_balancer target block is deprecated
  The `target` block in `hcloud_load_balancer` was deprecated [3 years ago](https://github.com/hetznercloud/terraform-provider-hcloud/commit/14c100065d06717e4e3209dd64c46626dd84e917) and not even documented on the docs page. For clarity the example should not use it.

docs: fix broken load_balancer_network example
  The example does not specify the dependency on the subnet resource. This can cause a race condition when the Load Balancer is attached to the network before the subnet is created.