### PR TITLE
docs: example on provider README does not work

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -15,10 +15,21 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```hcl
+# Tell terraform to use the provider and select a version.
+terraform {
+  required_providers {
+    hcloud = {
+      source = "hetznercloud/hcloud"
+      version = "~> 1.45"
+    }
+  }
+}
+
+
 # Set the variable value in *.tfvars file
 # or using the -var="hcloud_token=..." CLI option
 variable "hcloud_token" {
-  sensitive = true # Requires terraform >= 0.14
+  sensitive = true
 }
 
 # Configure the Hetzner Cloud Provider


### PR DESCRIPTION
If a user just specifies the current code, they will get an error "Error: Failed to query available provider packages".

The "required_providers" block tells Terraform which namespace "hcloud" is coming from. This is required since the Provider was migrated from "hashicorp" to "hetznercloud".