### PR TITLE
chore: add unconvert linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -26,6 +26,7 @@ linters:
     - typecheck
     - unparam
     - unused
+    - unconvert
     - whitespace
 
 issues:


### PR DESCRIPTION
Helps to remove unnecessary type conversions. It will be most useful once we migrate to hcloud-go v2 and need to cleanup a bunch of `int64`/`int` conversions.