### PR TITLE
chore: ignore all log and .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@
 /*.sh
 /*.json
 /*.yaml
-/*.log
+*.log
 /_output
 !.golangci.yaml
 !renovate.json
+
+.env*


### PR DESCRIPTION
Log files are generated for each e2e test in their respective directory. This is annoying in Git.