### PR TITLE
test(e2e): some suites only used the SDK provider

### DIFF
--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -5,10 +5,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	tfhcloud "github.com/hetznercloud/terraform-provider-hcloud/hcloud"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/primaryip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
@@ -48,14 +47,9 @@ func TestAccHcloudDataSourcePrimaryIPTest(t *testing.T) {
 	primaryIPBySel.SetRName("primaryip_by_sel")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
-		CheckDestroy: testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, nil)),
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, nil)),
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
@@ -111,14 +105,9 @@ func TestAccHcloudDataSourcePrimaryIPListTest(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
-		CheckDestroy: testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, nil)),
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, nil)),
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	tfhcloud "github.com/hetznercloud/terraform-provider-hcloud/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/primaryip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -39,14 +38,9 @@ func TestPrimaryIPResource_Basic(t *testing.T) {
 	resRenamed.SetRName(res.Name)
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
-		CheckDestroy: testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &pip)),
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &pip)),
 		Steps: []resource.TestStep{
 			{
 				// Create a new primary IP using the required values
@@ -145,13 +139,8 @@ func TestPrimaryIPResource_with_server(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
 			testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &srv)),
 			testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &primaryIPv4One)),
@@ -238,14 +227,9 @@ func TestPrimaryIPResource_FieldUpdates(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
-		CheckDestroy: testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &pip)),
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &pip)),
 		Steps: []resource.TestStep{
 			{
 				// Create a new primary IP using the required values

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -8,12 +8,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hetznercloud/hcloud-go/hcloud"
-	tfhcloud "github.com/hetznercloud/terraform-provider-hcloud/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/image"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
@@ -581,14 +579,9 @@ func TestServerResource_PrimaryIPNetworkTests(t *testing.T) {
 
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: teste2e.PreCheck(t),
-		ProviderFactories: map[string]func() (*schema.Provider, error){
-			//nolint:unparam
-			"hcloud": func() (*schema.Provider, error) {
-				return tfhcloud.Provider(), nil
-			},
-		},
-		CheckDestroy: testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, nil)),
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, nil)),
 		Steps: []resource.TestStep{
 			{
 				// Create a new server with unmanaged primary IPs + network


### PR DESCRIPTION
This breaks if they rely on any resource/datasource that was already migrated to the Plugin Framework. The new code uses the muxed provider to make sure all resources/datasources are available.