### PR TITLE
chore: utility to convert labels to hcloud-go types

### DIFF
--- a/internal/util/hcloudutil/labels.go
+++ b/internal/util/hcloudutil/labels.go
@@ -1,0 +1,19 @@
+package hcloudutil
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TerraformLabelsToHCloud(ctx context.Context, inputLabels types.Map, outputLabels *map[string]string) diag.Diagnostics {
+	var diagnostics diag.Diagnostics
+	*outputLabels = make(map[string]string, len(inputLabels.Elements()))
+
+	if !inputLabels.IsNull() {
+		diagnostics.Append(inputLabels.ElementsAs(ctx, outputLabels, false)...)
+	}
+
+	return diagnostics
+}

--- a/internal/util/hcloudutil/labels_test.go
+++ b/internal/util/hcloudutil/labels_test.go
@@ -1,0 +1,47 @@
+package hcloudutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTerraformLabelsToHCloud(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputLabels     types.Map
+		wantLabels      *map[string]string
+		wantDiagnostics bool
+	}{
+		{
+			name:            "Some Labels",
+			inputLabels:     types.MapValueMust(types.StringType, map[string]attr.Value{"key1": types.StringValue("value1")}),
+			wantLabels:      &map[string]string{"key1": "value1"},
+			wantDiagnostics: false,
+		},
+		{
+			name:            "Empty Labels",
+			inputLabels:     types.MapNull(types.StringType),
+			wantLabels:      &map[string]string{},
+			wantDiagnostics: false,
+		},
+		{
+			name:            "Invalid Map Labels",
+			inputLabels:     types.MapValueMust(types.BoolType, map[string]attr.Value{"key1": types.BoolValue(true)}),
+			wantLabels:      &map[string]string{},
+			wantDiagnostics: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var outputLabels map[string]string
+			diagnostics := TerraformLabelsToHCloud(context.Background(), tt.inputLabels, &outputLabels)
+			assert.Equalf(t, tt.wantDiagnostics, diagnostics != nil, "Unexpected Diagnostics: %v", diagnostics)
+			assert.Equalf(t, *tt.wantLabels, outputLabels, "Unexpected Labels")
+		})
+	}
+}


### PR DESCRIPTION
We often have to convert between the Terraform Plugin Framework and hcloud-go representations for labels.

Will be used by #817 