### PR TITLE
chore: group go hashicorp dependencies updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>hetznercloud/.github//renovate/default"]
+  "extends": ["github>hetznercloud/.github//renovate/default"],
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["github.com/hashicorp/"],
+      "groupName": "hashicorp"
+    }
+  ]
 }


### PR DESCRIPTION
- Reduce the amount of CI pipelines.
- Some packages might require others HashiCorp packages to be updated to function.