### PR TITLE
fix(server): unable to attach two new networks

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -1388,6 +1388,16 @@ func validateUniqueNetworkIDs(d *schema.ResourceDiff) error {
 			if !ok {
 				continue
 			}
+			if networkID == 0 {
+				// ID is 0 if Network will be created in same apply, we are unable to reliably detect if the
+				// "to-be-created" networks are the same.
+				// See https://github.com/hetznercloud/terraform-provider-hcloud/issues/899
+
+				// We should revisit this after moving to the Plugin Framework,
+				// as it allows more introspection for the plan/changes made.
+				// See https://github.com/hetznercloud/terraform-provider-hcloud/issues/752
+				continue
+			}
 
 			id, ok := networkID.(int)
 			if !ok {


### PR DESCRIPTION
The current validation fails if a user tries to attach two networks that are created in the same Apply run to a server. In this case, the ResourceDiff has both IDs set to `0`, as that value is unknown at plan time. The current validation fails with error:

    Error: server is only allowed to be attached to each network once: 0

We skip the validation in that case for now. The Terraform SDK v2 does not give us enough insights to figure out if both refer to the same resource or if they reference different network resources. We should revisit this validation after migrating to the Plugin Framework, as it gives us a lot more details about the proposed plan, and we might have enough info to give a definitive yay/nay to the user.

Closes #899