### PR TITLE
test(server): use same location when testing network updates

### DIFF
--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -335,11 +335,11 @@ func TestServerResource_DirectAttachToNetwork(t *testing.T) {
 	snw2Res.SetRName("test-network-subnet-2")
 
 	sRes := &server.RData{
-		Name:       "server-direct-attach",
-		Type:       teste2e.TestServerType,
-		Datacenter: teste2e.TestDataCenter,
-		Image:      teste2e.TestImage,
-		SSHKeys:    []string{sk.TFID() + ".id"},
+		Name:         "server-direct-attach",
+		Type:         teste2e.TestServerType,
+		LocationName: teste2e.TestLocationName,
+		Image:        teste2e.TestImage,
+		SSHKeys:      []string{sk.TFID() + ".id"},
 	}
 	sRes.SetRName(sRes.Name)
 


### PR DESCRIPTION
Using a different location will force deleting the server and creating a new one, instead of updating the same server.

