### PR TITLE
chore: replace deprecated server type with cx22

### DIFF
--- a/internal/datacenter/data_source_list.md
+++ b/internal/datacenter/data_source_list.md
@@ -12,7 +12,7 @@ resource "hcloud_server" "workers" {
 
   name        = "node${count.index}"
   image       = "debian-11"
-  server_type = "cx31"
+  server_type = "cx22"
   datacenter  = element(data.hcloud_datacenters.datacenters.datacenters, count.index).name
 }
 ```

--- a/internal/location/data_source_list.md
+++ b/internal/location/data_source_list.md
@@ -12,7 +12,7 @@ resource "hcloud_server" "workers" {
 
   name        = "node${count.index}"
   image       = "debian-11"
-  server_type = "cx31"
+  server_type = "cx22"
   location    = element(data.hcloud_locations.locations.locations, count.index).name
 }
 ```

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -18,7 +18,7 @@ func TestAccHcloudDataSourceServerTypeTest(t *testing.T) {
 	}
 	stByName.SetRName("st_by_name")
 	stByID := &servertype.DData{
-		ServerTypeID: "1",
+		ServerTypeID: "22",
 	}
 	stByID.SetRName("st_by_id")
 	resource.ParallelTest(t, resource.TestCase{
@@ -32,18 +32,16 @@ func TestAccHcloudDataSourceServerTypeTest(t *testing.T) {
 				),
 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(stByName.TFID(), "id", "1"),
-					resource.TestCheckResourceAttr(stByName.TFID(), "name", "cx11"),
-					resource.TestCheckResourceAttr(stByName.TFID(), "description", "CX11"),
-					resource.TestCheckResourceAttr(stByName.TFID(), "cores", "1"),
+					resource.TestCheckResourceAttr(stByName.TFID(), "id", "22"),
+					resource.TestCheckResourceAttr(stByName.TFID(), "name", "cpx11"),
+					resource.TestCheckResourceAttr(stByName.TFID(), "cores", "2"),
 					resource.TestCheckResourceAttr(stByName.TFID(), "memory", "2"),
 					resource.TestCheckResourceAttr(stByName.TFID(), "architecture", "x86"),
 					resource.TestCheckResourceAttr(stByName.TFID(), "included_traffic", "21990232555520"),
 
-					resource.TestCheckResourceAttr(stByID.TFID(), "id", "1"),
-					resource.TestCheckResourceAttr(stByID.TFID(), "name", "cx11"),
-					resource.TestCheckResourceAttr(stByID.TFID(), "description", "CX11"),
-					resource.TestCheckResourceAttr(stByID.TFID(), "cores", "1"),
+					resource.TestCheckResourceAttr(stByID.TFID(), "id", "22"),
+					resource.TestCheckResourceAttr(stByID.TFID(), "name", "cpx11"),
+					resource.TestCheckResourceAttr(stByID.TFID(), "cores", "2"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "memory", "2"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "architecture", "x86"),
 					resource.TestCheckResourceAttr(stByID.TFID(), "included_traffic", "21990232555520"),

--- a/internal/teste2e/testing.go
+++ b/internal/teste2e/testing.go
@@ -18,16 +18,16 @@ import (
 
 var (
 	// TestImage is the system image that is used in all tests
-	TestImage = getEnv("TEST_IMAGE", "ubuntu-22.04")
+	TestImage = getEnv("TEST_IMAGE", "ubuntu-24.04")
 
 	// TestImage is the system image ID that is used in all tests
-	TestImageID = getEnv("TEST_IMAGE_ID", "67794396")
+	TestImageID = getEnv("TEST_IMAGE_ID", "161547269")
 
 	// TestServerType is the default server type used in all tests
-	TestServerType = getEnv("TEST_SERVER_TYPE", "cx11")
+	TestServerType = getEnv("TEST_SERVER_TYPE", "cpx11")
 
 	// TestServerTypeUpgrade is the upgrade server type used in all tests
-	TestServerTypeUpgrade = getEnv("TEST_SERVER_TYPE_UPGRADE", "cx21")
+	TestServerTypeUpgrade = getEnv("TEST_SERVER_TYPE_UPGRADE", "cpx21")
 
 	// TestArchitecture is the default architecture used in all tests, should match the architecture of the TestServerType.
 	TestArchitecture = getEnv("TEST_ARCHITECTURE", string(hcloud.ArchitectureX86))

--- a/internal/volume/resource_test.go
+++ b/internal/volume/resource_test.go
@@ -205,8 +205,8 @@ func TestVolumeResource_WithServerMultipleVolumes(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 	resServer1 := &server.RData{
 		Name:         "some-server",
-		Type:         "cx11",
-		Image:        "ubuntu-20.04",
+		Type:         teste2e.TestServerType,
+		Image:        teste2e.TestImage,
 		LocationName: teste2e.TestLocationName,
 	}
 	resServer1.SetRName("some-server")

--- a/website/docs/d/datacenters.html.md
+++ b/website/docs/d/datacenters.html.md
@@ -19,7 +19,7 @@ resource "hcloud_server" "workers" {
 
   name        = "node${count.index}"
   image       = "debian-11"
-  server_type = "cx31"
+  server_type = "cx22"
   datacenter  = element(data.hcloud_datacenters.ds.datacenters, count.index).name
 }
 ```

--- a/website/docs/d/locations.html.md
+++ b/website/docs/d/locations.html.md
@@ -19,7 +19,7 @@ resource "hcloud_server" "workers" {
 
   name        = "node${count.index}"
   image       = "debian-11"
-  server_type = "cx31"
+  server_type = "cx22"
   location    = element(data.hcloud_locations.ds.locations, count.index).name
 }
 ```

--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -41,7 +41,7 @@ data "hcloud_primary_ip" "ip_3" {
 resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-20.04"
-  server_type = "cx11"
+  server_type = "cx22"
   datacenter  = "fsn1-dc14"
   labels = {
     "test" : "tessst1"

--- a/website/docs/d/server_type.html.md
+++ b/website/docs/d/server_type.html.md
@@ -12,7 +12,7 @@ Use this resource to get detailed information about specific Server Type.
 ## Example Usage
 ```hcl
 data "hcloud_server_type" "ds_1" {
-  name = "cx11"
+  name = "cx22"
 }
 data "hcloud_server_type" "ds_2" {
   id = 1

--- a/website/docs/r/firewall.html.md
+++ b/website/docs/r/firewall.html.md
@@ -38,7 +38,7 @@ resource "hcloud_firewall" "myfirewall" {
 resource "hcloud_server" "node1" {
   name         = "node1"
   image        = "debian-11"
-  server_type  = "cx11"
+  server_type  = "cx22"
   firewall_ids = [hcloud_firewall.myfirewall.id]
 }
 ```

--- a/website/docs/r/firewall_attachment.html.md
+++ b/website/docs/r/firewall_attachment.html.md
@@ -21,7 +21,7 @@ specified in that `hcloud_firewall_attachment`.
 ```hcl
 resource "hcloud_server" "test_server" {
     name        = "test-server"
-    server_type = "cx11"
+    server_type = "cx22"
     image       = "ubuntu-20.04"
 }
 
@@ -40,7 +40,7 @@ resource "hcloud_firewall_attachment" "fw_ref" {
 ```hcl
 resource "hcloud_server" "test_server" {
     name        = "test-server"
-    server_type = "cx11"
+    server_type = "cx22"
     image       = "ubuntu-20.04"
 
     labels = {
@@ -88,7 +88,7 @@ resource "hcloud_firewall" "deny_all" {
 
 resource "hcloud_server" "test_server" {
     name                       = "test-server"
-    server_type                = "cx11"
+    server_type                = "cx22"
     image                      = "ubuntu-20.04"
     ignore_remote_firewall_ids = true
     firewall_ids               = [

--- a/website/docs/r/floating_ip.html.md
+++ b/website/docs/r/floating_ip.html.md
@@ -16,7 +16,7 @@ Provides a Hetzner Cloud Floating IP to represent a publicly-accessible static I
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
 }
 
 resource "hcloud_floating_ip" "master" {

--- a/website/docs/r/floating_ip_assignment.html.md
+++ b/website/docs/r/floating_ip_assignment.html.md
@@ -21,7 +21,7 @@ resource "hcloud_floating_ip_assignment" "main" {
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
   datacenter  = "fsn1-dc8"
 }
 

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -15,7 +15,7 @@ Provides a Hetzner Cloud Load Balancer to represent a Load Balancer in the Hetzn
 ```hcl
 resource "hcloud_server" "my_server" {
   name        = "server-%d"
-  server_type = "cx11"
+  server_type = "cx22"
   image       = "ubuntu-18.04"
 }
 

--- a/website/docs/r/load_balancer_target.html.md
+++ b/website/docs/r/load_balancer_target.html.md
@@ -15,7 +15,7 @@ Adds a target to a Hetzner Cloud Load Balancer.
 ```hcl
 resource "hcloud_server" "my_server" {
   name        = "my-server"
-  server_type = "cx11"
+  server_type = "cx22"
   image       = "ubuntu-18.04"
 }
 

--- a/website/docs/r/placement_group.html.md
+++ b/website/docs/r/placement_group.html.md
@@ -24,7 +24,7 @@ resource "hcloud_placement_group" "my-placement-group" {
 resource "hcloud_server" "node1" {
   name         = "node1"
   image        = "debian-11"
-  server_type  = "cx11"
+  server_type  = "cx22"
   placement_group_id = hcloud_placement_group.my-placement-group.id
 }
 ```

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -30,7 +30,7 @@ resource "hcloud_primary_ip" "main" {
 resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-20.04"
-  server_type = "cx11"
+  server_type = "cx22"
   datacenter  = "fsn1-dc14"
   labels = {
     "test" : "tessst1"

--- a/website/docs/r/rdns.html.md
+++ b/website/docs/r/rdns.html.md
@@ -18,7 +18,7 @@ For servers:
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
 }
 
 resource "hcloud_rdns" "master" {

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -19,7 +19,7 @@ Provides an Hetzner Cloud server resource. This can be used to create, modify, a
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
   public_net {
     ipv4_enabled = true
     ipv6_enabled = true
@@ -42,7 +42,7 @@ auto_delete   = true
 resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-20.04"
-  server_type = "cx11"
+  server_type = "cx22"
   datacenter  = "fsn1-dc14"
   labels = {
     "test" : "tessst1"
@@ -70,7 +70,7 @@ resource "hcloud_network_subnet" "network-subnet" {
 
 resource "hcloud_server" "server" {
   name        = "server"
-  server_type = "cx11"
+  server_type = "cx22"
   image       = "ubuntu-20.04"
   location    = "nbg1"
 
@@ -106,7 +106,7 @@ data "hcloud_image" "packer_snapshot" {
 resource "hcloud_server" "from_snapshot" {
   name        = "from-snapshot"
   image       = data.hcloud_image.packer_snapshot.id
-  server_type = "cx11"
+  server_type = "cx22"
   public_net {
     ipv4_enabled = true
     ipv6_enabled = true

--- a/website/docs/r/server_network.html.md
+++ b/website/docs/r/server_network.html.md
@@ -16,7 +16,7 @@ description: |-
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
 }
 resource "hcloud_network" "mynet" {
   name     = "my-net"

--- a/website/docs/r/snapshot.html.md
+++ b/website/docs/r/snapshot.html.md
@@ -16,7 +16,7 @@ Provides a Hetzner Cloud snapshot to represent an image with type snapshot in th
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
 }
 
 resource "hcloud_snapshot" "my-snapshot" {

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -16,7 +16,7 @@ Provides a Hetzner Cloud volume resource to manage volumes.
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
 }
 
 resource "hcloud_volume" "master" {

--- a/website/docs/r/volume_attachment.html.md
+++ b/website/docs/r/volume_attachment.html.md
@@ -22,7 +22,7 @@ resource "hcloud_volume_attachment" "main" {
 resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-11"
-  server_type = "cx11"
+  server_type = "cx22"
   datacenter  = "nbg1-dc3"
 }
 


### PR DESCRIPTION
Learn more: https://docs.hetzner.cloud/changelog#2024-06-06-old-server-types-with-shared-intel-vcpus-are-deprecated

- Updated docs with newer server types
- Use CPX server type for tests