### PR TITLE
feat: drop support for terraform v1.7.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,8 +45,6 @@ jobs:
           - tool: opentofu
             version: v1.6.x
           - tool: terraform
-            version: v1.7.x
-          - tool: terraform
             version: v1.8.x
 
     steps:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Requirements
 
 - [Terraform](https://developer.hashicorp.com/terraform/downloads)
-  - HashiCorp recommends to use the two latest terraform releases (1.7.x, 1.8.x). Our test suite validates that our provider works with these versions.
+  - HashiCorp recommends to use the two latest terraform releases (1.8.x). Our test suite validates that our provider works with these versions.
   - This provider uses the [terraform plugin protocol version 6](https://developer.hashicorp.com/terraform/plugin/terraform-plugin-protocol#protocol-version-6), and should work with all tools (ie. Terraform & OpenTofu) that supports it.
 - [Go](https://go.dev/doc/install) 1.21.x (to build the provider plugin)
 


### PR DESCRIPTION
Remove support for terraform v1.7.x which us now end-of-life: https://endoflife.date/terraform