### PR TITLE
feat: add support for opentofu v1.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
         include:
           - tool: opentofu
             version: v1.6.x
+          - tool: opentofu
+            version: v1.7.x
           - tool: terraform
             version: v1.8.x
 


### PR DESCRIPTION
Run tests for opentofu 1.7.x that was released in April: https://github.com/opentofu/opentofu/releases/tag/v1.7.0
