### PR TITLE
chore: request hashicorp registry owner change

### DIFF
--- a/.terraform-registry
+++ b/.terraform-registry
@@ -1,0 +1,3 @@
+Request: Change Owner to GitHub Username "hcloud-bot"
+Registry Link: https://registry.terraform.io/providers/hetznercloud/hcloud/latest
+Request By: julian.toelle@hetzner-cloud.de


### PR DESCRIPTION
The registry entry is currently owned by a former maintainer of the provider. We would like to change it to the teams bot account so everyone can access the registry entry if necessary.