### PR TITLE
fix: do not continue if an api error occurred

### DIFF
--- a/internal/location/data_source.go
+++ b/internal/location/data_source.go
@@ -179,6 +179,7 @@ func (d *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		result, _, err = d.client.Location.GetByName(ctx, data.Name.ValueString())
 		if err != nil {
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+			return
 		}
 		if result == nil {
 			resp.Diagnostics.AddError(


### PR DESCRIPTION
Missing return statement after an api error occurred.