### PR TITLE
test: do not pollute log output with comment

### DIFF
--- a/internal/testdata/r/terraform_data_resource.tf.tmpl
+++ b/internal/testdata/r/terraform_data_resource.tf.tmpl
@@ -1,6 +1,9 @@
-// This template can be used to work around a bug/limitation in terraform-test-framework, which only checks for plan
-// changes in resources, not in datasources or outputs.
-// You can pass any [testtemplate.DataCommon] to it.
+{{- /*
+  This template can be used to work around a bug/limitation in terraform-test-framework,
+  which only checks for plan changes in resources, not in datasources or outputs.
+
+  You can pass any [testtemplate.DataCommon] to it.
+*/ -}}
 
 resource "terraform_data" "{{ .RName }}" {
   input = {{ .TFID }}


### PR DESCRIPTION
The comment will not be printed in the test logs anymore.