### PR TITLE
fix(load-balancer): automatic import of target adds conflicting fields

### DIFF
--- a/internal/loadbalancer/resource_target.go
+++ b/internal/loadbalancer/resource_target.go
@@ -459,15 +459,20 @@ func findLoadBalancerTarget(
 func setLoadBalancerTarget(d *schema.ResourceData, lbID int, tgt hcloud.LoadBalancerTarget) {
 	d.Set("type", tgt.Type)
 	d.Set("load_balancer_id", lbID)
-	d.Set("use_private_ip", tgt.UsePrivateIP)
 
 	switch tgt.Type {
 	case hcloud.LoadBalancerTargetTypeServer:
 		d.Set("server_id", tgt.Server.Server.ID)
+		// use_private_ip conflicts with TargetTypeIP. See #961
+		d.Set("use_private_ip", tgt.UsePrivateIP)
+
 		tgtID := generateLoadBalancerServerTargetID(tgt.Server.Server, lbID)
 		d.SetId(tgtID)
 	case hcloud.LoadBalancerTargetTypeLabelSelector:
 		d.Set("label_selector", tgt.LabelSelector.Selector)
+		// use_private_ip conflicts with TargetTypeIP. See #961
+		d.Set("use_private_ip", tgt.UsePrivateIP)
+
 		tgtID := generateLoadBalancerLabelSelectorTargetID(tgt.LabelSelector.Selector, lbID)
 		d.SetId(tgtID)
 	case hcloud.LoadBalancerTargetTypeIP:


### PR DESCRIPTION
The fields `ip` and `use_private_ip` are marked as conflicting because `use_private_ip` only takes effect with label selector and server id targets.

So far we have always set `use_private_ip` to whatever the API returned. But this causes issues with the command `terraform plan -generate-config-out=` as it writes all attributes we set in the state to a TF file. For an LB Target IP this now causes a conflict because both fields are set.

This is fixed by only setting the field when the target type is not IP.

Closes #961