### PR TITLE
feat(server-type): mark `included_traffic` attribute as deprecated

### DIFF
--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -67,8 +67,9 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"included_traffic": {
-			Type:     schema.TypeInt,
-			Computed: true,
+			Type:       schema.TypeInt,
+			Deprecated: "The field is deprecated and will always report 0 after 2024-08-05.",
+			Computed:   true,
 		},
 	})
 }

--- a/website/docs/d/server_type.html.md
+++ b/website/docs/d/server_type.html.md
@@ -30,7 +30,7 @@ data "hcloud_server_type" "ds_2" {
 - `memory` - (int) Memory a Server of this type will have in GB.
 - `disk` - (int) Disk size a Server of this type will have in GB.
 - `architecture` - (string) Architecture of the server_type.
-- `included_traffic` - (int) Free traffic per month in bytes.
+- `included_traffic` - (int) Free traffic per month in bytes. **Warning**: This field is deprecated and will report `0` after 2024-08-05.
 - `is_deprecated` - (bool) Deprecation status of server type.
 - `deprecation_announced` (Optional, string) Date when the deprecation of the server type was announced. Only set when the server type is deprecated.
 - `unavailable_after` (Optional, string) Date when the server type will not be available for new servers. Only set when the server type is deprecated.

--- a/website/docs/d/server_types.html.md
+++ b/website/docs/d/server_types.html.md
@@ -23,4 +23,4 @@ resource "hcloud_server" "workers" {
 ```
 
 ## Attributes Reference
-- `server_types` - (list) List of all server types. See `data.hcloud_type` for schema.
+- `server_types` - (list) List of all server types. See `data.hcloud_server_type` for schema.


### PR DESCRIPTION
The field is deprecated in the API and will be set to `null` in the API starting on 2024-08-05. This will show up as `0` in the terraform attribute.

There is currently no alternative for this field in Terraform, as the pricing information is not being passed through. If you rely on this, please open an issue to request this with your use case.

Learn more about this change on the [Hetzner Cloud Changelog](https://docs.hetzner.cloud/changelog#2024-07-25-cloud-api-returns-traffic-information-in-different-format).