### PR TITLE
test: format rendered test definitions

### DIFF
--- a/internal/testtemplate/template.go
+++ b/internal/testtemplate/template.go
@@ -6,12 +6,16 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
 	"text/template"
 	"time"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	hclwrite "github.com/hashicorp/hcl/v2/hclwrite"
 )
 
 var rng *rand.Rand
@@ -133,9 +137,29 @@ func (ts *Manager) Render(t *testing.T, args ...interface{}) string {
 		buf.WriteString("\n")
 	}
 
-	hcl := strings.TrimSpace(buf.String())
-	t.Logf("\n\nHCL:\n%s\n", addLineNumbers(hcl))
-	return hcl
+	definition := buf.String()
+
+	{
+		// Remove empty lines
+		lines := strings.Split(definition, "\n")
+		lines = slices.DeleteFunc(lines, func(line string) bool { return strings.TrimSpace(line) == "" })
+		definition = strings.Join(lines, "\n")
+	}
+
+	{
+		// Format HCL files
+		buf := bytes.NewBuffer(nil)
+		file, diags := hclwrite.ParseConfig([]byte(definition), "testing.tf", hcl.InitialPos)
+		if diags.HasErrors() {
+			t.Fatal(diags.Error())
+		}
+		file.WriteTo(buf)
+		definition = buf.String()
+	}
+
+	t.Logf("\n\nHCL:\n%s\n", addLineNumbers(definition))
+
+	return definition
 }
 
 func parseTmplGlob(t *testing.T, root *template.Template, prefix, glob string) {

--- a/internal/testtemplate/template.go
+++ b/internal/testtemplate/template.go
@@ -153,7 +153,9 @@ func (ts *Manager) Render(t *testing.T, args ...interface{}) string {
 		if diags.HasErrors() {
 			t.Fatal(diags.Error())
 		}
-		file.WriteTo(buf)
+		if _, err := file.WriteTo(buf); err != nil {
+			t.Fatal(err)
+		}
 		definition = buf.String()
 	}
 


### PR DESCRIPTION
This change ensure that the test logs have a clean output when printing the rendered Terraform definition.