### PR TITLE
refactor: add merge.Maps util

### DIFF
--- a/internal/util/merge/maps.go
+++ b/internal/util/merge/maps.go
@@ -1,0 +1,13 @@
+package merge
+
+import (
+	"maps"
+)
+
+func Maps[M ~map[K]V, K comparable, V any](items ...M) M {
+	acc := make(M)
+	for _, item := range items {
+		maps.Copy(acc, item)
+	}
+	return acc
+}

--- a/internal/util/merge/maps_test.go
+++ b/internal/util/merge/maps_test.go
@@ -1,0 +1,22 @@
+package merge
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaps(t *testing.T) {
+	assert.Equal(t,
+		map[string]string{
+			"a": "4",
+			"b": "2",
+			"c": "3",
+		},
+		Maps(
+			map[string]string{"a": "1"},
+			map[string]string{"b": "2"},
+			map[string]string{"c": "3", "a": "4"},
+		),
+	)
+}


### PR DESCRIPTION
Merge multiple maps to merge attributes from shared mixins (e.g. the deprecation mixin).