### PR TITLE
test: update server type list index to ignore cx11 entry

### DIFF
--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -1,12 +1,18 @@
 package servertype_test
 
 import (
+	"context"
+	"fmt"
+	"os"
+	"slices"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hetznercloud/hcloud-go/hcloud"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/servertype"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
-
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
@@ -67,6 +73,28 @@ func TestAccDataSourceList(t *testing.T) {
 	all := &servertype.DDataList{}
 	all.SetRName("all")
 
+	// To make this test more resilient against changes to the server types list, we
+	// pre-calculate the indices of the server types we check against.
+
+	// Acceptance tests are usually skipped by terraform, we need to handle this ourselves here.
+	if os.Getenv(resource.EnvTfAcc) == "" {
+		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
+		return
+	}
+	// Make sure that a token is available
+	teste2e.PreCheck(t)
+	client, err := testsupport.CreateClient()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	serverTypes, err := client.ServerType.All(context.Background())
+	if err != nil {
+		t.Fatalf("failed to get list of server types: %v", err)
+	}
+
+	indexCPX11 := slices.IndexFunc(serverTypes, func(serverType *hcloud.ServerType) bool { return serverType.Name == "cpx11" })
+	indexCPX21 := slices.IndexFunc(serverTypes, func(serverType *hcloud.ServerType) bool { return serverType.Name == "cpx21" })
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -77,25 +105,25 @@ func TestAccDataSourceList(t *testing.T) {
 				),
 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(all.TFID(), "server_type_ids.0", "22"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_type_ids.1", "23"),
-					resource.TestCheckResourceAttr(all.TFID(), "names.0", "cpx11"),
-					resource.TestCheckResourceAttr(all.TFID(), "names.1", "cpx21"),
-					resource.TestCheckResourceAttr(all.TFID(), "descriptions.0", "CPX 11"),
-					resource.TestCheckResourceAttr(all.TFID(), "descriptions.1", "CPX 21"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_type_ids.%d", indexCPX11), "22"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_type_ids.%d", indexCPX21), "23"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("names.%d", indexCPX11), "cpx11"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("names.%d", indexCPX21), "cpx21"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("descriptions.%d", indexCPX11), "CPX 11"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("descriptions.%d", indexCPX21), "CPX 21"),
 
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.id", "22"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.name", "cpx11"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.cores", "2"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.memory", "2"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.disk", "40"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.storage_type", "local"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.cpu_type", "shared"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.architecture", "x86"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.included_traffic", "0"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.is_deprecated", "false"),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.deprecation_announced", ""),
-					resource.TestCheckResourceAttr(all.TFID(), "server_types.0.unavailable_after", ""),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.id", indexCPX11), "22"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.name", indexCPX11), "cpx11"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.cores", indexCPX11), "2"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.memory", indexCPX11), "2"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.disk", indexCPX11), "40"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.storage_type", indexCPX11), "local"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.cpu_type", indexCPX11), "shared"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.architecture", indexCPX11), "x86"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.included_traffic", indexCPX11), "0"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.is_deprecated", indexCPX11), "false"),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.deprecation_announced", indexCPX11), ""),
+					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.unavailable_after", indexCPX11), ""),
 				),
 			},
 		},

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -1,18 +1,12 @@
 package servertype_test
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"slices"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hetznercloud/hcloud-go/hcloud"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/servertype"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
@@ -73,28 +67,6 @@ func TestAccDataSourceList(t *testing.T) {
 	all := &servertype.DDataList{}
 	all.SetRName("all")
 
-	// To make this test more resilient against changes to the server types list, we
-	// pre-calculate the indices of the server types we check against.
-
-	// Acceptance tests are usually skipped by terraform, we need to handle this ourselves here.
-	if os.Getenv(resource.EnvTfAcc) == "" {
-		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
-		return
-	}
-	// Make sure that a token is available
-	teste2e.PreCheck(t)
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		t.Fatal(err.Error())
-	}
-	serverTypes, err := client.ServerType.All(context.Background())
-	if err != nil {
-		t.Fatalf("failed to get list of server types: %v", err)
-	}
-
-	indexCPX11 := slices.IndexFunc(serverTypes, func(serverType *hcloud.ServerType) bool { return serverType.Name == "cpx11" })
-	indexCPX21 := slices.IndexFunc(serverTypes, func(serverType *hcloud.ServerType) bool { return serverType.Name == "cpx21" })
-
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -105,25 +77,25 @@ func TestAccDataSourceList(t *testing.T) {
 				),
 
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_type_ids.%d", indexCPX11), "22"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_type_ids.%d", indexCPX21), "23"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("names.%d", indexCPX11), "cpx11"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("names.%d", indexCPX21), "cpx21"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("descriptions.%d", indexCPX11), "CPX 11"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("descriptions.%d", indexCPX21), "CPX 21"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_type_ids.1", "22"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_type_ids.2", "23"),
+					resource.TestCheckResourceAttr(all.TFID(), "names.1", "cpx11"),
+					resource.TestCheckResourceAttr(all.TFID(), "names.2", "cpx21"),
+					resource.TestCheckResourceAttr(all.TFID(), "descriptions.1", "CPX 11"),
+					resource.TestCheckResourceAttr(all.TFID(), "descriptions.2", "CPX 21"),
 
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.id", indexCPX11), "22"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.name", indexCPX11), "cpx11"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.cores", indexCPX11), "2"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.memory", indexCPX11), "2"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.disk", indexCPX11), "40"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.storage_type", indexCPX11), "local"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.cpu_type", indexCPX11), "shared"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.architecture", indexCPX11), "x86"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.included_traffic", indexCPX11), "0"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.is_deprecated", indexCPX11), "false"),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.deprecation_announced", indexCPX11), ""),
-					resource.TestCheckResourceAttr(all.TFID(), fmt.Sprintf("server_types.%d.unavailable_after", indexCPX11), ""),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.id", "22"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.name", "cpx11"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.cores", "2"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.memory", "2"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.disk", "40"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.storage_type", "local"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.cpu_type", "shared"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.architecture", "x86"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.included_traffic", "0"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.is_deprecated", "false"),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.deprecation_announced", ""),
+					resource.TestCheckResourceAttr(all.TFID(), "server_types.1.unavailable_after", ""),
 				),
 			},
 		},


### PR DESCRIPTION
Do not hardcode the list indices of the two server types we verify. Instead get the list from the API and calculate the expected indices.

This makes us more resilient against changes to the list when server types are deprecated/removed.