### PR TITLE
docs: fix labels arguments and attributes for volumes and primary ips

### DIFF
--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -65,7 +65,7 @@ resource "hcloud_server" "server_test" {
 - `name` - (string) Name of the Primary IP.
 - `datacenter` - (string) The datacenter name of the Primary IP.
 - `auto_delete` - (bool) Whether auto delete is enabled.
-- `labels` - (string) Description of the Primary IP.
+- `labels` - (map) User-defined labels (key-value pairs).
 - `ip_address` - (string) IP Address of the Primary IP.
 - `ip_network` - (string) IPv6 subnet of the Primary IP for IPv6 addresses. (Only set if `type` is `ipv6`)
 - `assignee_id` - (int) ID of the assigned resource.

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -49,7 +49,7 @@ resource "hcloud_server" "server_test" {
 - `datacenter` - (string, optional) The datacenter name to create the resource in.
 - `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
-- `labels` - (string) Description of the Primary IP.
+- `labels` - (map, optional) User-defined labels (key-value pairs).
 - `assignee_id` - (int) ID of the assigned resource
 - `assignee_type` - (string) The type of the assigned resource. Currently supported: `server`
 - `delete_protection` - (bool) Whether delete protection is enabled. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
@@ -62,7 +62,7 @@ resource "hcloud_server" "server_test" {
 - `name` - (string) Name of the Primary IP.
 - `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to a managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
-- `labels` - (string) Description of the Primary IP.
+- `labels` - (map) User-defined labels (key-value pairs).
 - `ip_address` - (string) IP Address of the Primary IP.
 - `ip_network` - (string) IPv6 subnet of the Primary IP for IPv6 addresses. (Only set if `type` is `ipv6`)
 - `assignee_id` - (int) ID of the assigned resource

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -32,6 +32,7 @@ resource "hcloud_volume" "master" {
 
 - `name` - (Required, string) Name of the volume to create (must be unique per project).
 - `size` - (Required, int) Size of the volume (in GB).
+- `labels` - (Optional, map) User-defined labels (key-value pairs).
 - `server_id` - (Optional, int) Server to attach the Volume to, not allowed if location argument is passed.
 - `location` - (Optional, string) The location name of the volume to create, not allowed if server_id argument is passed.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).


### PR DESCRIPTION
The `labels` documentation was either missing or incorrect in some places for the primary ips and the volumes.

Closes #1013