### PR TITLE
docs: add link to locations and datacenters docs

### DIFF
--- a/website/docs/d/datacenter.html.md
+++ b/website/docs/d/datacenter.html.md
@@ -26,6 +26,6 @@ data "hcloud_datacenter" "ds_2" {
 - `id` - (int) Unique ID of the datacenter.
 - `name` - (string) Name of the datacenter.
 - `description` - (string) Description of the datacenter.
-- `location` - (map) Physical datacenter location.
+- `location` - (map) Location details of the datacenter. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `supported_server_type_ids` - (list) List of server types supported by the datacenter.
 - `available_server_type_ids` - (list) List of available server types.

--- a/website/docs/d/load_balancer.html.md
+++ b/website/docs/d/load_balancer.html.md
@@ -34,7 +34,7 @@ data "hcloud_load_balancer" "lb_3" {
 - `id` - (int) Unique ID of the Load Balancer.
 - `load_balancer_type` - (string) Name of the Type of the Load Balancer.
 - `name` - (string) Name of the Load Balancer.
-- `location` - (string) Name of the location the Load Balancer is in.
+- `location` - (string) Name of the location the Load Balancer is in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `ipv4` - (string) IPv4 Address of the Load Balancer.
 - `ipv6` - (string) IPv4 Address of the Load Balancer.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.

--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -63,7 +63,7 @@ resource "hcloud_server" "server_test" {
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string) The datacenter name of the Primary IP.
+- `datacenter` - (string) The datacenter name of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).
 - `ip_address` - (string) IP Address of the Primary IP.

--- a/website/docs/d/server.html.md
+++ b/website/docs/d/server.html.md
@@ -33,8 +33,8 @@ data "hcloud_server" "s_3" {
 - `name` - (string) Name of the server.
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
-- `location` - (string) The location name.
-- `datacenter` - (string) The datacenter name.
+- `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image. Architecture of ISO must equal the server (type) architecture.

--- a/website/docs/d/volume.html.md
+++ b/website/docs/d/volume.html.md
@@ -31,7 +31,7 @@ data "hcloud_volume" "volume_3" {
 - `id` - (int) Unique ID of the volume.
 - `name` - (string) Name of the volume.
 - `size` - (int) Size of the volume.
-- `location` - (string) The location name.
+- `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `server_id` - (Optional, int) Server ID the volume is attached to
 - `labels` - (map) User-defined labels (key-value pairs).
 - `linux_device` - (string) Device path on the file system for the Volume.

--- a/website/docs/r/load_balancer.html.md
+++ b/website/docs/r/load_balancer.html.md
@@ -36,7 +36,7 @@ resource "hcloud_load_balancer_target" "load_balancer_target" {
 
 - `name` - (Required, string) Name of the Load Balancer.
 - `load_balancer_type` - (Required, string) Type of the Load Balancer.
-- `location` - (Optional, string) The location name of the Load Balancer. Require when no network_zone is set.
+- `location` - (Optional, string) The location name of the Load Balancer. Require when no network_zone is set. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `network_zone` - (Optional, string) The Network Zone of the Load Balancer. Require when no location is set.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.
 - `labels` - (Optional, map) User-defined labels (key-value pairs) should be created with.
@@ -50,7 +50,7 @@ resource "hcloud_load_balancer_target" "load_balancer_target" {
 - `id` - (int) Unique ID of the Load Balancer.
 - `load_balancer_type` - (string) Name of the Type of the Load Balancer.
 - `name` - (string) Name of the Load Balancer.
-- `location` - (string) Name of the location the Load Balancer is in.
+- `location` - (string) Name of the location the Load Balancer is in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `ipv4` - (string) IPv4 Address of the Load Balancer.
 - `ipv6` - (string) IPv6 Address of the Load Balancer.
 - `algorithm` - (Optional) Configuration of the algorithm the Load Balancer use.

--- a/website/docs/r/primary_ip.html.md
+++ b/website/docs/r/primary_ip.html.md
@@ -46,7 +46,7 @@ resource "hcloud_server" "server_test" {
 
 - `type` - (string) Type of the Primary IP. `ipv4` or `ipv6`
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string, optional) The datacenter name to create the resource in.
+- `datacenter` - (string, optional) The datacenter name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (map, optional) User-defined labels (key-value pairs).
@@ -60,7 +60,7 @@ Note: At least one of `datacenter` or `assignee_id` is required.
 
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
-- `datacenter` - (string) The datacenter of the Primary IP.
+- `datacenter` - (string) The datacenter of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `name` - (string) Name of the Primary IP.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).

--- a/website/docs/r/server.html.md
+++ b/website/docs/r/server.html.md
@@ -159,8 +159,8 @@ The following arguments are supported:
 - `name` - (Required, string) Name of the server to create (must be unique per project and a valid hostname as per RFC 1123).
 - `server_type` - (Required, string) Name of the server type this server should be created with.
 - `image` - (Required, string) Name or ID of the image the server is created from. **Note** the `image` property is only required when using the resource to create servers. As the Hetzner Cloud API may return servers without an image ID set it is not marked as required in the Terraform Provider itself. Thus, users will get an error from the underlying client library if they forget to set the property and try to create a server.
-- `location` - (Optional, string) The location name to create the server in. `nbg1`, `fsn1`, `hel1`, `ash` or `hil`
-- `datacenter` - (Optional, string) The datacenter name to create the server in. `nbg1-dc3`, `fsn1-dc14`, `hel1-dc2`, `ash-dc1` or `hil-dc1`
+- `location` - (Optional, string) The location name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (Optional, string) The datacenter name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation
 - `ssh_keys` - (Optional, list) SSH key IDs or names which should be injected into the server at creation time. Once the server is created, you can not update the list of SSH Keys. If you do change this, you will be prompted to destroy and recreate the server. You can avoid this by setting [lifecycle.ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) to `[ ssh_keys ]`.
 - `public_net` - (Optional, block) In this block you can either enable / disable ipv4 and ipv6 or link existing primary IPs (checkout the examples).
@@ -199,8 +199,8 @@ The following attributes are exported:
 - `name` - (string) Name of the server.
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
-- `location` - (string) The location name.
-- `datacenter` - (string) The datacenter name.
+- `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image.

--- a/website/docs/r/volume.html.md
+++ b/website/docs/r/volume.html.md
@@ -34,7 +34,7 @@ resource "hcloud_volume" "master" {
 - `size` - (Required, int) Size of the volume (in GB).
 - `labels` - (Optional, map) User-defined labels (key-value pairs).
 - `server_id` - (Optional, int) Server to attach the Volume to, not allowed if location argument is passed.
-- `location` - (Optional, string) The location name of the volume to create, not allowed if server_id argument is passed.
+- `location` - (Optional, string) The location name of the volume to create, not allowed if server_id argument is passed. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `automount` - (Optional, bool) Automount the volume upon attaching it (server_id must be provided).
 - `format` - (Optional, string) Format volume after creation. `xfs` or `ext4`
 - `delete_protection` - (Optional, bool) Enable or disable delete protection. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
@@ -46,7 +46,7 @@ resource "hcloud_volume" "master" {
 - `id` - (int) Unique ID of the volume.
 - `name` - (string) Name of the volume.
 - `size` - (int) Size of the volume.
-- `location` - (string) The location name.
+- `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `server_id` - (Optional, int) Server ID the volume is attached to
 - `labels` - (map) User-defined labels (key-value pairs).
 - `linux_device` - (string) Device path on the file system for the Volume.


### PR DESCRIPTION
Adds links to the upstream Hetzner Docs to give more details about locations and datacenters.