### PR TITLE
test: use test location and datacenter variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,9 @@ jobs:
           TF_LOG: DEBUG
           TF_LOG_PATH_MASK: test-%s.log
 
+          TEST_DATACENTER: ${{ vars.TEST_DATACENTER }}
+          TEST_LOCATION: ${{ vars.TEST_LOCATION }}
+
       - uses: codecov/codecov-action@v4
         if: >
           !startsWith(github.head_ref, 'renovate/') &&

--- a/internal/loadbalancer/resource_service_test.go
+++ b/internal/loadbalancer/resource_service_test.go
@@ -19,7 +19,9 @@ import (
 func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, loadbalancer.Basic.Name)
+	lbRes := LoadBalancerRData()
+
+	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, lbRes.Name)
 	svcName := "lb-tcp-service-test"
 	svcResName := fmt.Sprintf("%s.%s", loadbalancer.ServiceResourceType, svcName)
 
@@ -31,11 +33,11 @@ func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      70,
 						DestinationPort: 70,
 						Proxyprotocol:   true,
@@ -64,11 +66,11 @@ func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 			},
 			{ // Test disable Proxyprotocol
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      70,
 						DestinationPort: 70,
 						Proxyprotocol:   false,
@@ -93,7 +95,9 @@ func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, loadbalancer.Basic.Name)
+	lbRes := LoadBalancerRData()
+
+	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, lbRes.Name)
 	svcName := "lb-http-service-test"
 	svcResName := fmt.Sprintf("%s.%s", loadbalancer.ServiceResourceType, svcName)
 
@@ -106,11 +110,11 @@ func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 			{
 				// Create a HTTP service using defaults
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:           svcName,
 						Protocol:       "http",
-						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -127,13 +131,13 @@ func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 			{
 				// Create a HTTP service using non-default ports.
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "http",
 						ListenPort:      81,
 						DestinationPort: 8080,
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						AddHTTP:         true,
 						HTTP: loadbalancer.RDataServiceHTTP{
 							CookieName:     "TESTCOOKIE",
@@ -157,12 +161,12 @@ func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 			{
 				// Create a HTTP service with health check
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "http",
 						DestinationPort: 8080,
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						AddHealthCheck:  true,
 						HealthCheck: loadbalancer.RDataServiceHealthCheck{
 							Protocol: "http",
@@ -207,7 +211,9 @@ func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 func TestAccHcloudLoadBalancerService_HTTP_StickySessions(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, loadbalancer.Basic.Name)
+	lbRes := LoadBalancerRData()
+
+	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, lbRes.Name)
 	svcName := "lb-http-sticky-sessions-test"
 	svcResName := fmt.Sprintf("%s.%s", loadbalancer.ServiceResourceType, svcName)
 
@@ -220,7 +226,7 @@ func TestAccHcloudLoadBalancerService_HTTP_StickySessions(t *testing.T) {
 			{
 				// Create a HTTP service using defaults
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:     svcName,
 						Protocol: "http",
@@ -229,7 +235,7 @@ func TestAccHcloudLoadBalancerService_HTTP_StickySessions(t *testing.T) {
 							StickySessions: true,
 							CookieLifeTime: 1800,
 						},
-						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 					},
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -255,7 +261,9 @@ func TestAccHcloudLoadBalancerService_HTTPS(t *testing.T) {
 
 	certData := certificate.NewUploadedRData(t, "test-cert", "example.org")
 
-	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, loadbalancer.Basic.Name)
+	lbRes := LoadBalancerRData()
+
+	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, lbRes.Name)
 	svcName := "lb-https-service-test"
 	svcResName := fmt.Sprintf("%s.%s", loadbalancer.ServiceResourceType, svcName)
 
@@ -268,7 +276,7 @@ func TestAccHcloudLoadBalancerService_HTTPS(t *testing.T) {
 			{
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_uploaded_certificate", certData,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:           svcName,
 						LoadBalancerID: lbResName + ".id",
@@ -337,6 +345,7 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 	svcName := "lb-create-delete-service-test"
 
 	certData := certificate.NewUploadedRData(t, "test-cert", "example.org")
+	lbRes := LoadBalancerRData()
 
 	tmplMan := testtemplate.Manager{}
 
@@ -349,17 +358,17 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 			{
 				// Create a HTTP service without setting a listen port.
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:           svcName,
 						Protocol:       "http",
-						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 					},
 				),
 			},
 			{
 				// Immediately remove it from the Load Balancer.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_load_balancer", loadbalancer.Basic),
+				Config: tmplMan.Render(t, "testdata/r/hcloud_load_balancer", lbRes),
 			},
 
 			// HTTPS
@@ -367,11 +376,11 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 				// Create a HTTPS service without setting a listen port.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_uploaded_certificate", certData,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:           svcName,
 						Protocol:       "https",
-						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID: fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						AddHTTP:        true,
 						HTTP: loadbalancer.RDataServiceHTTP{
 							Certificates: []string{fmt.Sprintf("hcloud_uploaded_certificate.%s.id", certData.Name)},
@@ -381,7 +390,7 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 			},
 			{
 				// Immediately remove it from the Load Balancer.
-				Config: tmplMan.Render(t, "testdata/r/hcloud_load_balancer", loadbalancer.Basic),
+				Config: tmplMan.Render(t, "testdata/r/hcloud_load_balancer", lbRes),
 			},
 		},
 	})
@@ -390,7 +399,9 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 func TestAccHcloudLoadBalancerService_ChangeListenPort(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, loadbalancer.Basic.Name)
+	lbRes := LoadBalancerRData()
+
+	lbResName := fmt.Sprintf("%s.%s", loadbalancer.ResourceType, lbRes.Name)
 	svcName := "lb-change-listen-port-service-test"
 	svcName2 := "lb-change-lp-test"
 	svcResName := fmt.Sprintf("%s.%s", loadbalancer.ServiceResourceType, svcName)
@@ -404,18 +415,18 @@ func TestAccHcloudLoadBalancerService_ChangeListenPort(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      70,
 						DestinationPort: 70,
 					},
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName2,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      443,
 						DestinationPort: 443,
 					},
@@ -442,18 +453,18 @@ func TestAccHcloudLoadBalancerService_ChangeListenPort(t *testing.T) {
 
 			{ // Test Change Listenport
 				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_load_balancer", loadbalancer.Basic,
+					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      71,
 						DestinationPort: 70,
 					},
 					"testdata/r/hcloud_load_balancer_service", &loadbalancer.RDataService{
 						Name:            svcName2,
 						Protocol:        "tcp",
-						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, loadbalancer.Basic.Name),
+						LoadBalancerID:  fmt.Sprintf("%s.%s.id", loadbalancer.ResourceType, lbRes.Name),
 						ListenPort:      443,
 						DestinationPort: 443,
 					},

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -18,7 +18,7 @@ import (
 func TestLoadBalancerResource_Basic(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	res := loadbalancer.Basic
+	res := LoadBalancerRData()
 	resRenamed := &loadbalancer.RData{
 		Name:         res.Name + "-renamed",
 		LocationName: teste2e.TestLocationName,
@@ -77,7 +77,8 @@ func TestLoadBalancerResource_Basic(t *testing.T) {
 func TestLoadBalancerResource_Resize(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
-	res := loadbalancer.Basic
+	res := LoadBalancerRData()
+
 	resResized := &loadbalancer.RData{
 		Name:         res.Name,
 		LocationName: teste2e.TestLocationName,
@@ -202,7 +203,7 @@ func TestLoadBalancerResource_Protection(t *testing.T) {
 
 		res = &loadbalancer.RData{
 			Name:             "load-balancer-protection",
-			LocationName:     "nbg1",
+			LocationName:     teste2e.TestLocationName,
 			DeleteProtection: true,
 		}
 

--- a/internal/loadbalancer/testing.go
+++ b/internal/loadbalancer/testing.go
@@ -26,14 +26,6 @@ func init() {
 	})
 }
 
-// Basic Load Balancer for use in load balancer related test.
-//
-// Do not modify!
-var Basic = &RData{
-	Name:         "basic-load-balancer",
-	LocationName: "nbg1",
-}
-
 // Sweep removes all Load Balancers from the Hetzner Cloud backend.
 func Sweep(r string) error {
 	client, err := testsupport.CreateClient()

--- a/internal/loadbalancer/testing_test.go
+++ b/internal/loadbalancer/testing_test.go
@@ -1,0 +1,14 @@
+package loadbalancer_test
+
+import (
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
+)
+
+// LoadBalancerRData is a resource for use in load balancer related test.
+func LoadBalancerRData() *loadbalancer.RData {
+	return &loadbalancer.RData{
+		Name:         "basic-load-balancer",
+		LocationName: teste2e.TestLocationName,
+	}
+}

--- a/internal/volume/resource_test.go
+++ b/internal/volume/resource_test.go
@@ -17,7 +17,7 @@ import (
 func TestVolumeResource_Basic(t *testing.T) {
 	var vol hcloud.Volume
 
-	res := volume.Basic
+	res := VolumeRData()
 	resRenamed := &volume.RData{
 		Name:         res.Name + "-renamed",
 		LocationName: teste2e.TestLocationName,
@@ -75,7 +75,7 @@ func TestVolumeResource_Basic(t *testing.T) {
 func TestVolumeResource_Resize(t *testing.T) {
 	var vol hcloud.Volume
 
-	res := volume.Basic
+	res := VolumeRData()
 	res.Name = "resized-volume"
 	resResized := &volume.RData{
 		Name:         res.Name,
@@ -144,12 +144,12 @@ func TestVolumeResource_WithServer(t *testing.T) {
 	}
 	resServer2.SetRName("another-server")
 
-	res := volume.Basic
+	res := VolumeRData()
 	res.Name = "volume-with-server"
 	res.LocationName = ""
 	res.ServerID = resServer1.TFID() + ".id"
 
-	resAnotherServer := volume.Basic
+	resAnotherServer := VolumeRData()
 	resAnotherServer.Name = "volume-with-server"
 	resAnotherServer.LocationName = ""
 	resAnotherServer.ServerID = resServer2.TFID() + ".id"
@@ -211,7 +211,7 @@ func TestVolumeResource_WithServerMultipleVolumes(t *testing.T) {
 	}
 	resServer1.SetRName("some-server")
 
-	res := volume.Basic
+	res := VolumeRData()
 	res.Name = "volume-with-server"
 	res.LocationName = ""
 	res.ServerID = resServer1.TFID() + ".id"

--- a/internal/volume/testing.go
+++ b/internal/volume/testing.go
@@ -103,15 +103,6 @@ func (d *RData) TFID() string {
 	return fmt.Sprintf("%s.%s", ResourceType, d.RName())
 }
 
-// Basic Volume for use in volume related test.
-//
-// Do not modify!
-var Basic = &RData{
-	Name:         "basic-volume",
-	LocationName: "nbg1",
-	Size:         10,
-}
-
 // RDataAttachment defines the fields for the "testdata/r/hcloud_volume_attachment" template.
 type RDataAttachment struct {
 	testtemplate.DataCommon

--- a/internal/volume/testing_test.go
+++ b/internal/volume/testing_test.go
@@ -1,0 +1,15 @@
+package volume_test
+
+import (
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
+)
+
+// VolumeRData is a resource for use in volume related test.
+func VolumeRData() *volume.RData {
+	return &volume.RData{
+		Name:         "basic-volume",
+		LocationName: teste2e.TestLocationName,
+		Size:         10,
+	}
+}


### PR DESCRIPTION
We sometimes have to update the location of our resources to work around possible shortages.

The variables declared in GitHub were not forwarded to our tests.