### PR TITLE
feat: drop support for opentofu v1.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,8 +49,6 @@ jobs:
       matrix:
         include:
           - tool: opentofu
-            version: v1.6.x
-          - tool: opentofu
             version: v1.7.x
           - tool: terraform
             version: v1.8.x


### PR DESCRIPTION
Removes support for opentofu v1.6.

See https://endoflife.date/opentofu