### PR TITLE
docs: fix markdown front matter

### DIFF
--- a/website/docs/d/certificates.md
+++ b/website/docs/d/certificates.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_certificates"
 sidebar_current: "docs-hcloud-datasource-certificate-x"
 description: |-
-Provides details about multiple Hetzner Cloud Certificates.
+  Provides details about multiple Hetzner Cloud Certificates.
 ---
 
 # hcloud_certificates

--- a/website/docs/d/firewall.html.md
+++ b/website/docs/d/firewall.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_load_firewall"
 sidebar_current: "docs-hcloud-datasource-firewall-x"
 description: |-
-Provides details about a specific Hetzner Cloud Firewall.
+  Provides details about a specific Hetzner Cloud Firewall.
 ---
 
 # hcloud_firewall

--- a/website/docs/d/firewalls.html.md
+++ b/website/docs/d/firewalls.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_load_firewalls"
 sidebar_current: "docs-hcloud-datasource-firewalls-x"
 description: |-
-Provides details about multiple Hetzner Cloud Firewall.
+  Provides details about multiple Hetzner Cloud Firewall.
 ---
 
 # hcloud_firewalls

--- a/website/docs/d/floating_ips.html.md
+++ b/website/docs/d/floating_ips.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_floating_ips"
 sidebar_current: "docs-hcloud-datasource-floating-ips-x"
 description: |-
-Provides details about multiple Hetzner Cloud Floating IPs.
+  Provides details about multiple Hetzner Cloud Floating IPs.
 ---
 
 # Data Source: hcloud_floating_ips

--- a/website/docs/d/images.html.md
+++ b/website/docs/d/images.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_images"
 sidebar_current: "docs-hcloud-datasource-images-x"
 description: |-
-Provides details about multiple Hetzner Cloud Images.
+  Provides details about multiple Hetzner Cloud Images.
 ---
 
 # Data Source: hcloud_images

--- a/website/docs/d/load_balancers.html.md
+++ b/website/docs/d/load_balancers.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_load_balancers"
 sidebar_current: "docs-hcloud-datasource-load-balancers-x"
 description: |-
-Provides details about multiple Hetzner Cloud Load Balancers.
+  Provides details about multiple Hetzner Cloud Load Balancers.
 ---
 
 # hcloud_load_balancer

--- a/website/docs/d/networks.html.md
+++ b/website/docs/d/networks.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_networks"
 sidebar_current: "docs-hcloud-datasource-networks-x"
 description: |-
-Provides details about multiple Hetzner Cloud Networks.
+  Provides details about multiple Hetzner Cloud Networks.
 ---
 
 # hcloud_networks

--- a/website/docs/d/placement_group.html.md
+++ b/website/docs/d/placement_group.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_placement_group"
 sidebar_current: "docs-hcloud-datasource-placement-group"
 description: |-
-Provides details about a specific Hetzner Cloud Placement Group.
+  Provides details about a specific Hetzner Cloud Placement Group.
 ---
 
 # hcloud_placement_group

--- a/website/docs/d/placement_groups.html.md
+++ b/website/docs/d/placement_groups.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_placement_groups"
 sidebar_current: "docs-hcloud-datasource-placement-groups-x"
 description: |-
-Provides details about multiple Hetzner Cloud Placement Groups.
+  Provides details about multiple Hetzner Cloud Placement Groups.
 ---
 
 # hcloud_placement_groups

--- a/website/docs/d/primary_ip.html.md
+++ b/website/docs/d/primary_ip.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_primary_ip"
 sidebar_current: "docs-hcloud-datasource-primary-ip"
 description: |-
-Provides details about a specific Hetzner Cloud Primary IP.
+  Provides details about a specific Hetzner Cloud Primary IP.
 ---
 
 # Data Source: hcloud_primary_ip

--- a/website/docs/d/primary_ips.html.md
+++ b/website/docs/d/primary_ips.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_primary_ips"
 sidebar_current: "docs-hcloud-datasource-primary-ips-x"
 description: |-
-Provides details about multiple Hetzner Cloud Primary IPs.
+  Provides details about multiple Hetzner Cloud Primary IPs.
 ---
 
 # Data Source: hcloud_primary_ips

--- a/website/docs/r/placement_group.html.md
+++ b/website/docs/r/placement_group.html.md
@@ -3,7 +3,7 @@ layout: "hcloud"
 page_title: "Hetzner Cloud: hcloud_placement_group"
 sidebar_current: "docs-hcloud-placement-group"
 description: |-
-Provides a Hetzner Cloud Placement Group to represent a Placement Group in the Hetzner Cloud.
+  Provides a Hetzner Cloud Placement Group to represent a Placement Group in the Hetzner Cloud.
 ---
 
 # hcloud_placement_group


### PR DESCRIPTION
The missing indent rendered the front matter parsing invalid.