### PR TITLE
docs: fix subnetwork name in load balancer config

### DIFF
--- a/docs/resources/load_balancer_network.md
+++ b/docs/resources/load_balancer_network.md
@@ -39,7 +39,7 @@ resource "hcloud_load_balancer_network" "srvnetwork" {
   # server and sub-network in parallel. This may result in the server
   # creation failing randomly.
   depends_on = [
-    hcloud_network_subnet.srvnetwork
+    hcloud_network_subnet.foonet
   ]
 }
 ```

--- a/examples/resources/hcloud_load_balancer_network/resource.tf
+++ b/examples/resources/hcloud_load_balancer_network/resource.tf
@@ -26,6 +26,6 @@ resource "hcloud_load_balancer_network" "srvnetwork" {
   # server and sub-network in parallel. This may result in the server
   # creation failing randomly.
   depends_on = [
-    hcloud_network_subnet.srvnetwork
+    hcloud_network_subnet.foonet
   ]
 }


### PR DESCRIPTION
Hi, I think there's an error in the documentation