### PR TITLE
test: refactor acceptance test names

### DIFF
--- a/internal/certificate/data_source_test.go
+++ b/internal/certificate/data_source_test.go
@@ -66,7 +66,7 @@ func TestAccCertificateDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccCertificateDataSource_List(t *testing.T) {
+func TestAccCertificateDataSourceList(t *testing.T) {
 	res := certificate.NewUploadedRData(t, "datasource-test", "TFtestAcc")
 
 	certificateBySel := &certificate.DDataList{

--- a/internal/certificate/data_source_test.go
+++ b/internal/certificate/data_source_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceCertificateTest(t *testing.T) {
+func TestAccCertificateDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := certificate.NewUploadedRData(t, "datasource-test", "TFtestAcc")
@@ -65,7 +66,7 @@ func TestAccHcloudDataSourceCertificateTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceCertificateListTest(t *testing.T) {
+func TestAccCertificateDataSource_List(t *testing.T) {
 	res := certificate.NewUploadedRData(t, "datasource-test", "TFtestAcc")
 
 	certificateBySel := &certificate.DDataList{

--- a/internal/certificate/data_source_test.go
+++ b/internal/certificate/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccCertificateDataSource_Basic(t *testing.T) {
+func TestAccCertificateDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := certificate.NewUploadedRData(t, "datasource-test", "TFtestAcc")

--- a/internal/certificate/resource_test.go
+++ b/internal/certificate/resource_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
@@ -21,7 +22,7 @@ var (
 	certDomain = os.Getenv("CERT_DOMAIN")
 )
 
-func TestCertificateResource_Uploaded_Basic(t *testing.T) {
+func TestAccCertificateResource_Uploaded_Basic(t *testing.T) {
 	var cert hcloud.Certificate
 
 	res := certificate.NewUploadedRData(t, "basic-cert", "TFAccTests")
@@ -63,7 +64,7 @@ func TestCertificateResource_Uploaded_Basic(t *testing.T) {
 	})
 }
 
-func TestCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testing.T) {
+func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testing.T) {
 	var cert, newCert hcloud.Certificate
 
 	res := certificate.NewUploadedRData(t, "basic-cert", "TFAccTests")
@@ -113,7 +114,7 @@ func TestCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testing.T
 	})
 }
 
-func TestCertificateResource_Managed_Basic(t *testing.T) {
+func TestAccCertificateResource_Managed_Basic(t *testing.T) {
 	if certDomain == "" {
 		t.Skip("Skipping because CERT_DOMAIN is not set")
 	}

--- a/internal/certificate/resource_test.go
+++ b/internal/certificate/resource_test.go
@@ -22,7 +22,7 @@ var (
 	certDomain = os.Getenv("CERT_DOMAIN")
 )
 
-func TestAccCertificateResource_Uploaded_Basic(t *testing.T) {
+func TestAccCertificateResource_Uploaded(t *testing.T) {
 	var cert hcloud.Certificate
 
 	res := certificate.NewUploadedRData(t, "basic-cert", "TFAccTests")
@@ -114,7 +114,7 @@ func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testin
 	})
 }
 
-func TestAccCertificateResource_Managed_Basic(t *testing.T) {
+func TestAccCertificateResource_Managed(t *testing.T) {
 	if certDomain == "" {
 		t.Skip("Skipping because CERT_DOMAIN is not set")
 	}

--- a/internal/datacenter/data_source_test.go
+++ b/internal/datacenter/data_source_test.go
@@ -88,7 +88,7 @@ func TestAccDatacenterDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccDatacenterDataSource_List(t *testing.T) {
+func TestAccDatacenterDataSourceList(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	datacentersD := &datacenter.DDataList{}
@@ -128,7 +128,7 @@ func TestAccDatacenterDataSource_List(t *testing.T) {
 	})
 }
 
-func TestAccDatacenterDataSource_List_UpgradePluginFramework(t *testing.T) {
+func TestAccDatacenterDataSourceList_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	datacentersD := &datacenter.DDataList{}

--- a/internal/datacenter/data_source_test.go
+++ b/internal/datacenter/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccDatacenterDataSource_Basic(t *testing.T) {
+func TestAccDatacenterDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	dcByName := &datacenter.DData{
@@ -43,7 +43,7 @@ func TestAccDatacenterDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccDatacenterDataSource_Basic_UpgradePluginFramework(t *testing.T) {
+func TestAccDatacenterDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	dcByName := &datacenter.DData{

--- a/internal/datacenter/data_source_test.go
+++ b/internal/datacenter/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceDatacenterTest(t *testing.T) {
+func TestAccDatacenterDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	dcByName := &datacenter.DData{
@@ -43,7 +43,7 @@ func TestAccHcloudDataSourceDatacenterTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceDatacenter_UpgradePluginFramework(t *testing.T) {
+func TestAccDatacenterDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	dcByName := &datacenter.DData{
@@ -88,7 +88,7 @@ func TestAccHcloudDataSourceDatacenter_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceDatacentersTest(t *testing.T) {
+func TestAccDatacenterDataSource_List(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	datacentersD := &datacenter.DDataList{}
@@ -128,7 +128,7 @@ func TestAccHcloudDataSourceDatacentersTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceDatacenters_UpgradePluginFramework(t *testing.T) {
+func TestAccDatacenterDataSource_List_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	datacentersD := &datacenter.DDataList{}

--- a/internal/firewall/attachment_resource_test.go
+++ b/internal/firewall/attachment_resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAttachmentResource_Servers(t *testing.T) {
+func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 	var (
 		srv hcloud.Server
 		fw  hcloud.Firewall
@@ -56,7 +56,7 @@ func TestAttachmentResource_Servers(t *testing.T) {
 	})
 }
 
-func TestAttachmentResource_LabelSelectors(t *testing.T) {
+func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 	var (
 		srv hcloud.Server
 		fw  hcloud.Firewall

--- a/internal/firewall/data_source_test.go
+++ b/internal/firewall/data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccFirewallDataSource_Basic(t *testing.T) {
+func TestAccFirewallDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{}, nil)

--- a/internal/firewall/data_source_test.go
+++ b/internal/firewall/data_source_test.go
@@ -64,7 +64,7 @@ func TestAccFirewallDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccFirewallDataSource_List(t *testing.T) {
+func TestAccFirewallDataSourceList(t *testing.T) {
 	res := firewall.NewRData(t, "firewall-ds-test", []firewall.RDataRule{}, nil)
 
 	firewallBySel := &firewall.DDataList{

--- a/internal/firewall/data_source_test.go
+++ b/internal/firewall/data_source_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
+func TestAccFirewallDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{}, nil)
@@ -64,7 +64,7 @@ func TestAccHcloudDataSourceFirewallTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceFirewallListTest(t *testing.T) {
+func TestAccFirewallDataSource_List(t *testing.T) {
 	res := firewall.NewRData(t, "firewall-ds-test", []firewall.RDataRule{}, nil)
 
 	firewallBySel := &firewall.DDataList{

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccFirewallResource_Basic(t *testing.T) {
+func TestAccFirewallResource(t *testing.T) {
 	var f hcloud.Firewall
 
 	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestFirewallResource_Basic(t *testing.T) {
+func TestAccFirewallResource_Basic(t *testing.T) {
 	var f hcloud.Firewall
 
 	res := firewall.NewRData(t, "basic-firewall", []firewall.RDataRule{
@@ -110,7 +110,7 @@ func TestFirewallResource_Basic(t *testing.T) {
 	})
 }
 
-func TestFirewallResource_ApplyTo(t *testing.T) {
+func TestAccFirewallResource_ApplyTo(t *testing.T) {
 	var f hcloud.Firewall
 
 	res := firewall.NewRData(t, "applyto-firewall", []firewall.RDataRule{
@@ -179,7 +179,7 @@ func TestFirewallResource_ApplyTo(t *testing.T) {
 	})
 }
 
-func TestFirewallResource_Normalization(t *testing.T) {
+func TestAccFirewallResource_Normalization(t *testing.T) {
 	var f hcloud.Firewall
 
 	res := firewall.NewRData(t, "ipv6-firewall", []firewall.RDataRule{

--- a/internal/floatingip/data_source_test.go
+++ b/internal/floatingip/data_source_test.go
@@ -6,15 +6,17 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceFloatingIPTest(t *testing.T) {
+func TestAccFloatingIPDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &floatingip.RData{
@@ -75,7 +77,7 @@ func TestAccHcloudDataSourceFloatingIPTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceFloatingIPListTest(t *testing.T) {
+func TestAccFloatingIPDataSource_List(t *testing.T) {
 	res := &floatingip.RData{
 		Name: "floatingip-ds-test",
 		Type: "ipv4",

--- a/internal/floatingip/data_source_test.go
+++ b/internal/floatingip/data_source_test.go
@@ -77,7 +77,7 @@ func TestAccFloatingIPDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccFloatingIPDataSource_List(t *testing.T) {
+func TestAccFloatingIPDataSourceList(t *testing.T) {
 	res := &floatingip.RData{
 		Name: "floatingip-ds-test",
 		Type: "ipv4",

--- a/internal/floatingip/data_source_test.go
+++ b/internal/floatingip/data_source_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccFloatingIPDataSource_Basic(t *testing.T) {
+func TestAccFloatingIPDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &floatingip.RData{

--- a/internal/floatingip/resource_assignment_test.go
+++ b/internal/floatingip/resource_assignment_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccFloatingIPAssignmentResource_Basic(t *testing.T) {
+func TestAccFloatingIPAssignmentResource(t *testing.T) {
 	var s hcloud.Server
 	var s2 hcloud.Server
 	var f hcloud.FloatingIP

--- a/internal/floatingip/resource_assignment_test.go
+++ b/internal/floatingip/resource_assignment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
@@ -12,12 +13,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestFloatingIPAssignmentResource_Basic(t *testing.T) {
+func TestAccFloatingIPAssignmentResource_Basic(t *testing.T) {
 	var s hcloud.Server
 	var s2 hcloud.Server
 	var f hcloud.FloatingIP

--- a/internal/floatingip/resource_test.go
+++ b/internal/floatingip/resource_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestFloatingIPResource_Basic(t *testing.T) {
+func TestAccFloatingIPResource_Basic(t *testing.T) {
 	var fip hcloud.FloatingIP
 
 	res := &floatingip.RData{
@@ -65,7 +66,7 @@ func TestFloatingIPResource_Basic(t *testing.T) {
 		},
 	})
 }
-func TestFloatingIPResource_WithServer(t *testing.T) {
+func TestAccFloatingIPResource_WithServer(t *testing.T) {
 	var fip hcloud.FloatingIP
 	tmplMan := testtemplate.Manager{}
 
@@ -117,7 +118,7 @@ func TestFloatingIPResource_WithServer(t *testing.T) {
 	})
 }
 
-func TestFloatingIPResource_Protection(t *testing.T) {
+func TestAccFloatingIPResource_Protection(t *testing.T) {
 	var (
 		fip hcloud.FloatingIP
 

--- a/internal/floatingip/resource_test.go
+++ b/internal/floatingip/resource_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccFloatingIPResource_Basic(t *testing.T) {
+func TestAccFloatingIPResource(t *testing.T) {
 	var fip hcloud.FloatingIP
 
 	res := &floatingip.RData{

--- a/internal/image/data_source_test.go
+++ b/internal/image/data_source_test.go
@@ -7,12 +7,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceImageTest(t *testing.T) {
+func TestAccImageDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	imageByName := &image.DData{
@@ -49,7 +50,7 @@ func TestAccHcloudDataSourceImageTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceImageWithFiltersTest(t *testing.T) {
+func TestAccImageDataSource_WithFilters(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	imageByName := &image.DData{
@@ -80,7 +81,7 @@ func TestAccHcloudDataSourceImageWithFiltersTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceImageListTest(t *testing.T) {
+func TestAccImageDataSource_List(t *testing.T) {
 	allImagesSel := &image.DDataList{}
 	allImagesSel.SetRName("all_images_sel")
 

--- a/internal/image/data_source_test.go
+++ b/internal/image/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccImageDataSource_Basic(t *testing.T) {
+func TestAccImageDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	imageByName := &image.DData{

--- a/internal/image/data_source_test.go
+++ b/internal/image/data_source_test.go
@@ -81,7 +81,7 @@ func TestAccImageDataSource_WithFilters(t *testing.T) {
 	})
 }
 
-func TestAccImageDataSource_List(t *testing.T) {
+func TestAccImageDataSourceList(t *testing.T) {
 	allImagesSel := &image.DDataList{}
 	allImagesSel.SetRName("all_images_sel")
 

--- a/internal/loadbalancer/data_source_test.go
+++ b/internal/loadbalancer/data_source_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceLoadBalancerTest(t *testing.T) {
+func TestAccLoadBalancerDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &loadbalancer.RData{
@@ -79,7 +80,7 @@ func TestAccHcloudDataSourceLoadBalancerTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceLoadBalancerListTest(t *testing.T) {
+func TestAccLoadBalancerDataSource_List(t *testing.T) {
 	res := &loadbalancer.RData{
 		Name:         "some-load-balancer",
 		LocationName: teste2e.TestLocationName,

--- a/internal/loadbalancer/data_source_test.go
+++ b/internal/loadbalancer/data_source_test.go
@@ -80,7 +80,7 @@ func TestAccLoadBalancerDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccLoadBalancerDataSource_List(t *testing.T) {
+func TestAccLoadBalancerDataSourceList(t *testing.T) {
 	res := &loadbalancer.RData{
 		Name:         "some-load-balancer",
 		LocationName: teste2e.TestLocationName,

--- a/internal/loadbalancer/data_source_test.go
+++ b/internal/loadbalancer/data_source_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccLoadBalancerDataSource_Basic(t *testing.T) {
+func TestAccLoadBalancerDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &loadbalancer.RData{

--- a/internal/loadbalancer/resource_network_test.go
+++ b/internal/loadbalancer/resource_network_test.go
@@ -154,7 +154,7 @@ func TestAccLoadBalancerNetworkResource_SubNetID(t *testing.T) {
 	})
 }
 
-func TestHcloudLoadBalancerNetworkResource_CannotAttachToTwoNetworks(t *testing.T) {
+func TestAccLoadBalancerNetworkResource_CannotAttachToTwoNetworks(t *testing.T) {
 	nwRess := make([]*network.RData, 2)
 	snRess := make([]*network.RDataSubnet, len(nwRess))
 	for i := 0; i < len(nwRess); i++ {

--- a/internal/loadbalancer/resource_network_test.go
+++ b/internal/loadbalancer/resource_network_test.go
@@ -8,16 +8,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestAccHcloudLoadBalancerNetwork_NetworkID(t *testing.T) {
+func TestAccLoadBalancerNetworkResource_NetworkID(t *testing.T) {
 	var (
 		nw hcloud.Network
 		lb hcloud.LoadBalancer
@@ -101,7 +102,7 @@ func TestAccHcloudLoadBalancerNetwork_NetworkID(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerNetwork_SubNetID(t *testing.T) {
+func TestAccLoadBalancerNetworkResource_SubNetID(t *testing.T) {
 	var (
 		nw hcloud.Network
 		lb hcloud.LoadBalancer
@@ -153,7 +154,7 @@ func TestAccHcloudLoadBalancerNetwork_SubNetID(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerNetwork_CannotAttachToTwoNetworks(t *testing.T) {
+func TestHcloudLoadBalancerNetworkResource_CannotAttachToTwoNetworks(t *testing.T) {
 	nwRess := make([]*network.RData, 2)
 	snRess := make([]*network.RDataSubnet, len(nwRess))
 	for i := 0; i < len(nwRess); i++ {

--- a/internal/loadbalancer/resource_service_test.go
+++ b/internal/loadbalancer/resource_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/certificate"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
@@ -16,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
+func TestAccLoadBalancerServiceResource_TCP(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	lbRes := LoadBalancerRData()
@@ -92,7 +93,7 @@ func TestAccHcloudLoadBalancerService_TCP(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
+func TestAccLoadBalancerServiceResource_HTTP(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	lbRes := LoadBalancerRData()
@@ -208,7 +209,7 @@ func TestAccHcloudLoadBalancerService_HTTP(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerService_HTTP_StickySessions(t *testing.T) {
+func TestAccLoadBalancerServiceResource_HTTP_StickySessions(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	lbRes := LoadBalancerRData()
@@ -253,7 +254,7 @@ func TestAccHcloudLoadBalancerService_HTTP_StickySessions(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerService_HTTPS(t *testing.T) {
+func TestAccLoadBalancerServiceResource_HTTPS(t *testing.T) {
 	var (
 		lb   hcloud.LoadBalancer
 		cert hcloud.Certificate
@@ -304,7 +305,7 @@ func TestAccHcloudLoadBalancerService_HTTPS(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerService_HTTPS_UpdateUnchangedCertificates(t *testing.T) {
+func TestAccLoadBalancerServiceResource_HTTPS_UpdateUnchangedCertificates(t *testing.T) {
 	certRes1 := certificate.NewUploadedRData(t, "cert-res1", "TFAccTests1")
 	certRes2 := certificate.NewUploadedRData(t, "cert-res2", "TFAccTests2")
 	lbRes := &loadbalancer.RData{
@@ -341,7 +342,7 @@ func TestAccHcloudLoadBalancerService_HTTPS_UpdateUnchangedCertificates(t *testi
 	})
 }
 
-func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
+func TestAccLoadBalancerServiceResource_CreateDelete_NoListenPort(t *testing.T) {
 	svcName := "lb-create-delete-service-test"
 
 	certData := certificate.NewUploadedRData(t, "test-cert", "example.org")
@@ -396,7 +397,7 @@ func TestAccHcloudLoadBalancerService_CreateDelete_NoListenPort(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerService_ChangeListenPort(t *testing.T) {
+func TestAccLoadBalancerServiceResource_ChangeListenPort(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	lbRes := LoadBalancerRData()

--- a/internal/loadbalancer/resource_target_test.go
+++ b/internal/loadbalancer/resource_target_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudLoadBalancerTarget_ServerTarget(t *testing.T) {
+func TestAccLoadBalancerTargetResource_ServerTarget(t *testing.T) {
 	var (
 		lb  hcloud.LoadBalancer
 		srv hcloud.Server
@@ -83,7 +83,7 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP(t *testing.T) {
+func TestAccLoadBalancerTargetResource_ServerTarget_UsePrivateIP(t *testing.T) {
 	var (
 		lb  hcloud.LoadBalancer
 		srv hcloud.Server
@@ -168,7 +168,7 @@ func TestAccHcloudLoadBalancerTarget_ServerTarget_UsePrivateIP(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget(t *testing.T) {
+func TestAccLoadBalancerTargetResource_LabelSelectorTarget(t *testing.T) {
 	var (
 		lb  hcloud.LoadBalancer
 		srv hcloud.Server
@@ -229,7 +229,7 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget(t *testing.T) {
 	})
 }
 
-func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget_UsePrivateIP(t *testing.T) {
+func TestAccLoadBalancerTargetResource_LabelSelectorTarget_UsePrivateIP(t *testing.T) {
 	var (
 		lb  hcloud.LoadBalancer
 		srv hcloud.Server
@@ -329,7 +329,7 @@ func TestAccHcloudLoadBalancerTarget_LabelSelectorTarget_UsePrivateIP(t *testing
 	})
 }
 
-func TestAccHcloudLoadBalancerTarget_IPTarget(t *testing.T) {
+func TestAccLoadBalancerTargetResource_IPTarget(t *testing.T) {
 	t.Skip("No dedicated server available in test account")
 
 	var (

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccLoadBalancerResource_Basic(t *testing.T) {
+func TestAccLoadBalancerResource(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	res := LoadBalancerRData()

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
@@ -15,7 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestLoadBalancerResource_Basic(t *testing.T) {
+func TestAccLoadBalancerResource_Basic(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	res := LoadBalancerRData()
@@ -74,7 +75,7 @@ func TestLoadBalancerResource_Basic(t *testing.T) {
 	})
 }
 
-func TestLoadBalancerResource_Resize(t *testing.T) {
+func TestAccLoadBalancerResource_Resize(t *testing.T) {
 	var lb hcloud.LoadBalancer
 
 	res := LoadBalancerRData()
@@ -120,7 +121,7 @@ func TestLoadBalancerResource_Resize(t *testing.T) {
 	})
 }
 
-func TestLoadBalancerResource_InlineTarget(t *testing.T) {
+func TestAccLoadBalancerResource_InlineTarget(t *testing.T) {
 	var srv0, srv1 hcloud.Server
 
 	tmplMan := testtemplate.Manager{RandInt: acctest.RandInt()}
@@ -197,7 +198,7 @@ func TestLoadBalancerResource_InlineTarget(t *testing.T) {
 	})
 }
 
-func TestLoadBalancerResource_Protection(t *testing.T) {
+func TestAccLoadBalancerResource_Protection(t *testing.T) {
 	var (
 		lb hcloud.LoadBalancer
 

--- a/internal/loadbalancertype/data_source_test.go
+++ b/internal/loadbalancertype/data_source_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccDataSource(t *testing.T) {
+func TestAccLoadBalancerTypeDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &loadbalancertype.DData{LoadBalancerTypeName: teste2e.TestLoadBalancerType}
@@ -51,7 +52,7 @@ func TestAccDataSource(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceList(t *testing.T) {
+func TestAccLoadBalancerTypeDataSource_List(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &loadbalancertype.DDataList{}

--- a/internal/loadbalancertype/data_source_test.go
+++ b/internal/loadbalancertype/data_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccLoadBalancerTypeDataSource_Basic(t *testing.T) {
+func TestAccLoadBalancerTypeDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &loadbalancertype.DData{LoadBalancerTypeName: teste2e.TestLoadBalancerType}

--- a/internal/loadbalancertype/data_source_test.go
+++ b/internal/loadbalancertype/data_source_test.go
@@ -52,7 +52,7 @@ func TestAccLoadBalancerTypeDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccLoadBalancerTypeDataSource_List(t *testing.T) {
+func TestAccLoadBalancerTypeDataSourceList(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &loadbalancertype.DDataList{}

--- a/internal/location/data_source_test.go
+++ b/internal/location/data_source_test.go
@@ -93,7 +93,7 @@ func TestAccLocationDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccLocationDataSource_List(t *testing.T) {
+func TestAccLocationDataSourceList(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	locationsDS := &location.DDataList{}
@@ -143,7 +143,7 @@ func TestAccLocationDataSource_List(t *testing.T) {
 	})
 }
 
-func TestAccLocationDataSource_List_UpgradePluginFramework(t *testing.T) {
+func TestAccLocationDataSourceList_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	locationsDS := &location.DDataList{}

--- a/internal/location/data_source_test.go
+++ b/internal/location/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccLocationDataSource_Basic(t *testing.T) {
+func TestAccLocationDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	lByName := &location.DData{
@@ -47,7 +47,7 @@ func TestAccLocationDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccLocationDataSource_Basic_UpgradePluginFramework(t *testing.T) {
+func TestAccLocationDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	lByName := &location.DData{

--- a/internal/location/data_source_test.go
+++ b/internal/location/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceLocationTest(t *testing.T) {
+func TestAccLocationDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	lByName := &location.DData{
@@ -47,7 +47,7 @@ func TestAccHcloudDataSourceLocationTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceLocation_UpgradePluginFramework(t *testing.T) {
+func TestAccLocationDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	lByName := &location.DData{
@@ -93,7 +93,7 @@ func TestAccHcloudDataSourceLocation_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceLocationsTest(t *testing.T) {
+func TestAccLocationDataSource_List(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	locationsDS := &location.DDataList{}
@@ -143,7 +143,7 @@ func TestAccHcloudDataSourceLocationsTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceLocations_UpgradePluginFramework(t *testing.T) {
+func TestAccLocationDataSource_List_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	locationsDS := &location.DDataList{}

--- a/internal/network/data_source_test.go
+++ b/internal/network/data_source_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccNetworkDataSource_Basic(t *testing.T) {
+func TestAccNetworkDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &network.RData{

--- a/internal/network/data_source_test.go
+++ b/internal/network/data_source_test.go
@@ -81,7 +81,7 @@ func TestAccNetworkDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccNetworkDataSource_List(t *testing.T) {
+func TestAccNetworkDataSourceList(t *testing.T) {
 	res := &network.RData{
 		Name:    "network-ds-test",
 		IPRange: "10.0.0.0/16",

--- a/internal/network/data_source_test.go
+++ b/internal/network/data_source_test.go
@@ -6,16 +6,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceNetworkTest(t *testing.T) {
+func TestAccNetworkDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &network.RData{
@@ -79,7 +81,7 @@ func TestAccHcloudDataSourceNetworkTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceNetworkListTest(t *testing.T) {
+func TestAccNetworkDataSource_List(t *testing.T) {
 	res := &network.RData{
 		Name:    "network-ds-test",
 		IPRange: "10.0.0.0/16",

--- a/internal/network/resource_route_test.go
+++ b/internal/network/resource_route_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccNetworkRouteResource_Basic(t *testing.T) {
+func TestAccNetworkRouteResource(t *testing.T) {
 	var nw hcloud.Network
 
 	resNetwork := &network.RData{

--- a/internal/network/resource_route_test.go
+++ b/internal/network/resource_route_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestNetworkRouteResource_Basic(t *testing.T) {
+func TestAccNetworkRouteResource_Basic(t *testing.T) {
 	var nw hcloud.Network
 
 	resNetwork := &network.RData{

--- a/internal/network/resource_subnet_test.go
+++ b/internal/network/resource_subnet_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccNetworkSubnetResource_Basic(t *testing.T) {
+func TestAccNetworkSubnetResource(t *testing.T) {
 	var nw hcloud.Network
 
 	resNetwork := &network.RData{

--- a/internal/network/resource_subnet_test.go
+++ b/internal/network/resource_subnet_test.go
@@ -10,12 +10,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestNetworkSubnetResource_Basic(t *testing.T) {
+func TestAccNetworkSubnetResource_Basic(t *testing.T) {
 	var nw hcloud.Network
 
 	resNetwork := &network.RData{
@@ -64,7 +65,7 @@ func TestNetworkSubnetResource_Basic(t *testing.T) {
 	})
 }
 
-func TestNetworkSubnetResource_VSwitch(t *testing.T) {
+func TestAccNetworkSubnetResource_VSwitch(t *testing.T) {
 	t.Skip("No VSwitch available in test account")
 
 	var nw hcloud.Network

--- a/internal/network/resource_test.go
+++ b/internal/network/resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccNetworkResource_Basic(t *testing.T) {
+func TestAccNetworkResource(t *testing.T) {
 	var cert hcloud.Network
 
 	res := &network.RData{

--- a/internal/network/resource_test.go
+++ b/internal/network/resource_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestNetworkResource_Basic(t *testing.T) {
+func TestAccNetworkResource_Basic(t *testing.T) {
 	var cert hcloud.Network
 
 	res := &network.RData{
@@ -62,7 +63,7 @@ func TestNetworkResource_Basic(t *testing.T) {
 	})
 }
 
-func TestNetworkResource_IncreaseNetwork(t *testing.T) {
+func TestAccNetworkResource_IncreaseNetwork(t *testing.T) {
 	var cert hcloud.Network
 
 	res := &network.RData{
@@ -111,7 +112,7 @@ func TestNetworkResource_IncreaseNetwork(t *testing.T) {
 	})
 }
 
-func TestNetworkResource_Protection(t *testing.T) {
+func TestAccNetworkResource_Protection(t *testing.T) {
 	var (
 		cert hcloud.Network
 
@@ -161,7 +162,7 @@ func TestNetworkResource_Protection(t *testing.T) {
 	})
 }
 
-func TestNetworkResource_ExposeRouteToVSwitch(t *testing.T) {
+func TestAccNetworkResource_ExposeRouteToVSwitch(t *testing.T) {
 	var (
 		cert hcloud.Network
 

--- a/internal/placementgroup/data_source_test.go
+++ b/internal/placementgroup/data_source_test.go
@@ -67,7 +67,7 @@ func TestAccPlacementGroupDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccPlacementGroupDataSource_List(t *testing.T) {
+func TestAccPlacementGroupDataSourceList(t *testing.T) {
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")
 	res.SetRName("placement-group-ds-test")
 

--- a/internal/placementgroup/data_source_test.go
+++ b/internal/placementgroup/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccPlacementGroupDataSource_Basic(t *testing.T) {
+func TestAccPlacementGroupDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")

--- a/internal/placementgroup/data_source_test.go
+++ b/internal/placementgroup/data_source_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/placementgroup"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
@@ -12,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourcePlacementGroupTest(t *testing.T) {
+func TestAccPlacementGroupDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")
@@ -66,7 +67,7 @@ func TestAccHcloudDataSourcePlacementGroupTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourcePlacementGroupListTest(t *testing.T) {
+func TestAccPlacementGroupDataSource_List(t *testing.T) {
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")
 	res.SetRName("placement-group-ds-test")
 

--- a/internal/placementgroup/resource_test.go
+++ b/internal/placementgroup/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/placementgroup"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -12,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestPlacementGroupResource_Basic(t *testing.T) {
+func TestAccPlacementGroupResource_Basic(t *testing.T) {
 	var g hcloud.PlacementGroup
 
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")

--- a/internal/placementgroup/resource_test.go
+++ b/internal/placementgroup/resource_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccPlacementGroupResource_Basic(t *testing.T) {
+func TestAccPlacementGroupResource(t *testing.T) {
 	var g hcloud.PlacementGroup
 
 	res := placementgroup.NewRData(t, "basic-placement-group", "spread")

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourcePrimaryIPTest(t *testing.T) {
+func TestAccPrimaryIPDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &primaryip.RData{
@@ -83,7 +83,7 @@ func TestAccHcloudDataSourcePrimaryIPTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourcePrimaryIPListTest(t *testing.T) {
+func TestAccPrimaryIPDataSource_List(t *testing.T) {
 	res := &primaryip.RData{
 		Name: "primary-ds-test",
 		Type: "ipv4",

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccPrimaryIPDataSource_Basic(t *testing.T) {
+func TestAccPrimaryIPDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &primaryip.RData{

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -83,7 +83,7 @@ func TestAccPrimaryIPDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccPrimaryIPDataSource_List(t *testing.T) {
+func TestAccPrimaryIPDataSourceList(t *testing.T) {
 	res := &primaryip.RData{
 		Name: "primary-ds-test",
 		Type: "ipv4",

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccPrimaryIPResource_Basic(t *testing.T) {
+func TestAccPrimaryIPResource(t *testing.T) {
 	var pip hcloud.PrimaryIP
 
 	res := &primaryip.RData{

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestPrimaryIPResource_Basic(t *testing.T) {
+func TestAccPrimaryIPResource_Basic(t *testing.T) {
 	var pip hcloud.PrimaryIP
 
 	res := &primaryip.RData{
@@ -76,7 +76,7 @@ func TestPrimaryIPResource_Basic(t *testing.T) {
 	})
 }
 
-func TestPrimaryIPResource_with_server(t *testing.T) {
+func TestAccPrimaryIPResource_WithServer(t *testing.T) {
 	var srv hcloud.Server
 	var primaryIPv4One hcloud.PrimaryIP
 	var primaryIPv4Two hcloud.PrimaryIP
@@ -208,7 +208,7 @@ primary IP v6 one has assignee id %d and should shouldnt be assigned to server i
 	})
 }
 
-func TestPrimaryIPResource_FieldUpdates(t *testing.T) {
+func TestAccPrimaryIPResource_FieldUpdates(t *testing.T) {
 	var (
 		pip hcloud.PrimaryIP
 
@@ -262,7 +262,7 @@ func TestPrimaryIPResource_FieldUpdates(t *testing.T) {
 	})
 }
 
-func TestPrimaryIPResource_DeleteProtection(t *testing.T) {
+func TestAccPrimaryIPResource_DeleteProtection(t *testing.T) {
 	var pip hcloud.PrimaryIP
 
 	unprotected := &primaryip.RData{

--- a/internal/rdns/resource_test.go
+++ b/internal/rdns/resource_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestRDNSResource_Server(t *testing.T) {
+func TestAccRDNSResource_Server(t *testing.T) {
 	tests := []struct {
 		name        string
 		dns         string
@@ -96,7 +96,7 @@ func TestRDNSResource_Server(t *testing.T) {
 	}
 }
 
-func TestRDNSResource_PrimaryIP(t *testing.T) {
+func TestAccRDNSResource_PrimaryIP(t *testing.T) {
 	tests := []struct {
 		name          string
 		dns           string
@@ -161,7 +161,7 @@ func TestRDNSResource_PrimaryIP(t *testing.T) {
 	}
 }
 
-func TestRDNSResource_FloatingIP(t *testing.T) {
+func TestAccRDNSResource_FloatingIP(t *testing.T) {
 	tests := []struct {
 		name           string
 		dns            string
@@ -225,7 +225,7 @@ func TestRDNSResource_FloatingIP(t *testing.T) {
 	}
 }
 
-func TestRDNSResource_LoadBalancer(t *testing.T) {
+func TestAccRDNSResource_LoadBalancer(t *testing.T) {
 	tests := []struct {
 		name        string
 		ipAddress   string

--- a/internal/server/data_source_test.go
+++ b/internal/server/data_source_test.go
@@ -6,16 +6,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceServerTest(t *testing.T) {
+func TestAccServerDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &server.RData{
@@ -72,7 +74,7 @@ func TestAccHcloudDataSourceServerTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceServerListTest(t *testing.T) {
+func TestAccServerDataSource_List(t *testing.T) {
 	res := &server.RData{
 		Name:  "server-ds-test",
 		Type:  teste2e.TestServerType,

--- a/internal/server/data_source_test.go
+++ b/internal/server/data_source_test.go
@@ -74,7 +74,7 @@ func TestAccServerDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccServerDataSource_List(t *testing.T) {
+func TestAccServerDataSourceList(t *testing.T) {
 	res := &server.RData{
 		Name:  "server-ds-test",
 		Type:  teste2e.TestServerType,

--- a/internal/server/data_source_test.go
+++ b/internal/server/data_source_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccServerDataSource_Basic(t *testing.T) {
+func TestAccServerDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &server.RData{

--- a/internal/server/resource_network_test.go
+++ b/internal/server/resource_network_test.go
@@ -5,19 +5,21 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/assert"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestAccHcloudServerNetwork_NetworkID(t *testing.T) {
+func TestAccServerNetworkResource_NetworkID(t *testing.T) {
 	var (
 		nw hcloud.Network
 		s  hcloud.Server
@@ -86,7 +88,7 @@ func TestAccHcloudServerNetwork_NetworkID(t *testing.T) {
 	})
 }
 
-func TestAccHcloudServerNetwork_SubNetID(t *testing.T) {
+func TestAccServerNetworkResource_SubNetID(t *testing.T) {
 	var (
 		nw hcloud.Network
 		s  hcloud.Server

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
 )
 
-func TestAccServerResource_Basic(t *testing.T) {
+func TestAccServerResource(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-basic")

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
 )
 
-func TestServerResource_Basic(t *testing.T) {
+func TestAccServerResource_Basic(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-basic")
@@ -87,7 +87,7 @@ func TestServerResource_Basic(t *testing.T) {
 	})
 }
 
-func TestServerResource_ImageID(t *testing.T) {
+func TestAccServerResource_ImageID(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-image-id")
@@ -125,7 +125,7 @@ func TestServerResource_ImageID(t *testing.T) {
 	})
 }
 
-func TestServerResource_Resize(t *testing.T) {
+func TestAccServerResource_Resize(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-resize")
@@ -181,7 +181,7 @@ func TestServerResource_Resize(t *testing.T) {
 	})
 }
 
-func TestServerResource_ChangeUserData(t *testing.T) {
+func TestAccServerResource_ChangeUserData(t *testing.T) {
 	var s, s2 hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-userdata")
@@ -236,7 +236,7 @@ func TestServerResource_ChangeUserData(t *testing.T) {
 	})
 }
 
-func TestServerResource_ISO(t *testing.T) {
+func TestAccServerResource_ISO(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-iso")
@@ -275,7 +275,7 @@ func TestServerResource_ISO(t *testing.T) {
 	})
 }
 
-func TestServerResource_DirectAttachToNetwork(t *testing.T) {
+func TestAccServerResource_DirectAttachToNetwork(t *testing.T) {
 	var (
 		nw  hcloud.Network
 		nw2 hcloud.Network
@@ -504,7 +504,7 @@ func TestServerResource_DirectAttachToNetwork(t *testing.T) {
 	})
 }
 
-func TestServerResource_PrimaryIPNetworkTests(t *testing.T) {
+func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	var (
 		nw hcloud.Network
 		s  hcloud.Server
@@ -812,7 +812,7 @@ func TestServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	})
 }
 
-func TestServerResource_PrivateNetworkBastion(t *testing.T) {
+func TestAccServerResource_PrivateNetworkBastion(t *testing.T) {
 	name := "server-private-network-bastion"
 
 	sshKeyRes := sshkey.NewRData(t, name)
@@ -921,7 +921,7 @@ resource "terraform_data" "wait" {
 	})
 }
 
-func TestServerResource_Firewalls(t *testing.T) {
+func TestAccServerResource_Firewalls(t *testing.T) {
 	var s hcloud.Server
 
 	fw := firewall.NewRData(t, "server-test", []firewall.RDataRule{
@@ -996,7 +996,7 @@ func TestServerResource_Firewalls(t *testing.T) {
 	})
 }
 
-func TestServerResource_PlacementGroup(t *testing.T) {
+func TestAccServerResource_PlacementGroup(t *testing.T) {
 	var (
 		pg  hcloud.PlacementGroup
 		srv hcloud.Server
@@ -1099,7 +1099,7 @@ func TestServerResource_PlacementGroup(t *testing.T) {
 	})
 }
 
-func TestServerResource_Protection(t *testing.T) {
+func TestAccServerResource_Protection(t *testing.T) {
 	var (
 		srv hcloud.Server
 
@@ -1156,7 +1156,7 @@ func TestServerResource_Protection(t *testing.T) {
 	})
 }
 
-func TestServerResource_EmptySSHKey(t *testing.T) {
+func TestAccServerResource_EmptySSHKey(t *testing.T) {
 	// Regression Test for https://github.com/hetznercloud/terraform-provider-hcloud/issues/727
 	var srv hcloud.Server
 

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccServerTypeDataSource_Basic(t *testing.T) {
+func TestAccServerTypeDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &servertype.DData{ServerTypeName: teste2e.TestServerType}
@@ -61,7 +61,7 @@ func TestAccServerTypeDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccServerTypeDataSource_Basic_UpgradePluginFramework(t *testing.T) {
+func TestAccServerTypeDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &servertype.DData{ServerTypeName: teste2e.TestServerType}

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccDataSource(t *testing.T) {
+func TestAccServerTypeDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &servertype.DData{ServerTypeName: teste2e.TestServerType}
@@ -61,7 +61,7 @@ func TestAccDataSource(t *testing.T) {
 	})
 }
 
-func TestAccDataSource_UpgradePluginFramework(t *testing.T) {
+func TestAccServerTypeDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	byName := &servertype.DData{ServerTypeName: teste2e.TestServerType}
@@ -104,7 +104,7 @@ func TestAccDataSource_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceList(t *testing.T) {
+func TestAccServerTypeDataSource_List(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &servertype.DDataList{}
@@ -145,7 +145,7 @@ func TestAccDataSourceList(t *testing.T) {
 	})
 }
 
-func TestAccDataSourceList_UpgradePluginFramework(t *testing.T) {
+func TestAccServerTypeDataSource_List_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &servertype.DDataList{}

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -104,7 +104,7 @@ func TestAccServerTypeDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	})
 }
 
-func TestAccServerTypeDataSource_List(t *testing.T) {
+func TestAccServerTypeDataSourceList(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &servertype.DDataList{}
@@ -145,7 +145,7 @@ func TestAccServerTypeDataSource_List(t *testing.T) {
 	})
 }
 
-func TestAccServerTypeDataSource_List_UpgradePluginFramework(t *testing.T) {
+func TestAccServerTypeDataSourceList_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	all := &servertype.DDataList{}

--- a/internal/snapshot/resource_test.go
+++ b/internal/snapshot/resource_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccSnapshotResource_Basic(t *testing.T) {
+func TestAccSnapshotResource(t *testing.T) {
 	var s hcloud.Image
 	tmplMan := testtemplate.Manager{}
 

--- a/internal/snapshot/resource_test.go
+++ b/internal/snapshot/resource_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestSnapshotResource_Basic(t *testing.T) {
+func TestAccSnapshotResource_Basic(t *testing.T) {
 	var s hcloud.Image
 	tmplMan := testtemplate.Manager{}
 

--- a/internal/sshkey/data_source_list_test.go
+++ b/internal/sshkey/data_source_list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceSSHKeysTest(t *testing.T) {
+func TestAccSSHKeyDataSource_List(t *testing.T) {
 	res := sshkey.NewRData(t, "ssh-key-ds-test")
 
 	sshKeysByLabelSelector := &sshkey.DDataList{
@@ -60,7 +60,7 @@ func TestAccHcloudDataSourceSSHKeysTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceSSHKeys_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyDataSource_List_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "ssh-key-ds-test")

--- a/internal/sshkey/data_source_list_test.go
+++ b/internal/sshkey/data_source_list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccSSHKeyDataSource_List(t *testing.T) {
+func TestAccSSHKeyDataSourceList(t *testing.T) {
 	res := sshkey.NewRData(t, "ssh-key-ds-test")
 
 	sshKeysByLabelSelector := &sshkey.DDataList{
@@ -60,7 +60,7 @@ func TestAccSSHKeyDataSource_List(t *testing.T) {
 	})
 }
 
-func TestAccSSHKeyDataSource_List_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyDataSourceList_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "ssh-key-ds-test")

--- a/internal/sshkey/data_source_test.go
+++ b/internal/sshkey/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccHcloudDataSourceSSHKeyTest(t *testing.T) {
+func TestAccSSHKeyDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "datasource-test")
@@ -66,7 +66,7 @@ func TestAccHcloudDataSourceSSHKeyTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDatasourceSSHKey_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyDataSource_Basic_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "datasource-test")

--- a/internal/sshkey/data_source_test.go
+++ b/internal/sshkey/data_source_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccSSHKeyDataSource_Basic(t *testing.T) {
+func TestAccSSHKeyDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "datasource-test")
@@ -66,7 +66,7 @@ func TestAccSSHKeyDataSource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccSSHKeyDataSource_Basic_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "datasource-test")

--- a/internal/sshkey/resource_test.go
+++ b/internal/sshkey/resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestSSHKeyResource_Basic(t *testing.T) {
+func TestAccSSHKeyResource_Basic(t *testing.T) {
 	var sk hcloud.SSHKey
 
 	tmplMan := testtemplate.Manager{}
@@ -60,7 +60,7 @@ func TestSSHKeyResource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccSSHKeyResource_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyResource_Basic_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "upgrade-plugin-framework-test")

--- a/internal/sshkey/resource_test.go
+++ b/internal/sshkey/resource_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccSSHKeyResource_Basic(t *testing.T) {
+func TestAccSSHKeyResource(t *testing.T) {
 	var sk hcloud.SSHKey
 
 	tmplMan := testtemplate.Manager{}
@@ -60,7 +60,7 @@ func TestAccSSHKeyResource_Basic(t *testing.T) {
 	})
 }
 
-func TestAccSSHKeyResource_Basic_UpgradePluginFramework(t *testing.T) {
+func TestAccSSHKeyResource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := sshkey.NewRData(t, "upgrade-plugin-framework-test")

--- a/internal/volume/data_source_test.go
+++ b/internal/volume/data_source_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
 )
 
-func TestAccVolumeDataSource_Basic(t *testing.T) {
+func TestAccVolumeDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &volume.RData{

--- a/internal/volume/data_source_test.go
+++ b/internal/volume/data_source_test.go
@@ -172,7 +172,7 @@ func TestAccVolumeDataSource_Attached(t *testing.T) {
 	})
 }
 
-func TestAccVolumeDataSource_List(t *testing.T) {
+func TestAccVolumeDataSourceList(t *testing.T) {
 	res := &volume.RData{
 		Name:         "volume-ds-test",
 		Size:         10,

--- a/internal/volume/data_source_test.go
+++ b/internal/volume/data_source_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -16,7 +17,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
 )
 
-func TestAccHcloudDataSourceVolumeTest(t *testing.T) {
+func TestAccVolumeDataSource_Basic(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &volume.RData{
@@ -83,7 +84,7 @@ func TestAccHcloudDataSourceVolumeTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceAttachedVolumeTest(t *testing.T) {
+func TestAccVolumeDataSource_Attached(t *testing.T) {
 	var s hcloud.Server
 
 	resServer := &server.RData{
@@ -171,7 +172,7 @@ func TestAccHcloudDataSourceAttachedVolumeTest(t *testing.T) {
 	})
 }
 
-func TestAccHcloudDataSourceVolumeListTest(t *testing.T) {
+func TestAccVolumeDataSource_List(t *testing.T) {
 	res := &volume.RData{
 		Name:         "volume-ds-test",
 		Size:         10,

--- a/internal/volume/resource_attachment_test.go
+++ b/internal/volume/resource_attachment_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccVolumeAttachmentResource_Basic(t *testing.T) {
+func TestAccVolumeAttachmentResource(t *testing.T) {
 	var s hcloud.Server
 	var s2 hcloud.Server
 	var v hcloud.Volume

--- a/internal/volume/resource_attachment_test.go
+++ b/internal/volume/resource_attachment_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/sshkey"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 
@@ -12,12 +13,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestVolumeAssignmentResource_Basic(t *testing.T) {
+func TestAccVolumeAttachmentResource_Basic(t *testing.T) {
 	var s hcloud.Server
 	var s2 hcloud.Server
 	var v hcloud.Volume

--- a/internal/volume/resource_test.go
+++ b/internal/volume/resource_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/volume"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/hetznercloud/hcloud-go/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestVolumeResource_Basic(t *testing.T) {
+func TestAccVolumeResource_Basic(t *testing.T) {
 	var vol hcloud.Volume
 
 	res := VolumeRData()
@@ -72,7 +73,7 @@ func TestVolumeResource_Basic(t *testing.T) {
 	})
 }
 
-func TestVolumeResource_Resize(t *testing.T) {
+func TestAccVolumeResource_Resize(t *testing.T) {
 	var vol hcloud.Volume
 
 	res := VolumeRData()
@@ -125,7 +126,7 @@ func TestVolumeResource_Resize(t *testing.T) {
 	})
 }
 
-func TestVolumeResource_WithServer(t *testing.T) {
+func TestAccVolumeResource_WithServer(t *testing.T) {
 	var vol hcloud.Volume
 	tmplMan := testtemplate.Manager{}
 	resServer1 := &server.RData{
@@ -200,7 +201,7 @@ func TestVolumeResource_WithServer(t *testing.T) {
 	})
 }
 
-func TestVolumeResource_WithServerMultipleVolumes(t *testing.T) {
+func TestAccVolumeResource_WithServerMultipleVolumes(t *testing.T) {
 	var vol, vol2 hcloud.Volume
 	tmplMan := testtemplate.Manager{}
 	resServer1 := &server.RData{
@@ -250,7 +251,7 @@ func TestVolumeResource_WithServerMultipleVolumes(t *testing.T) {
 	})
 }
 
-func TestVolumeResource_Protection(t *testing.T) {
+func TestAccVolumeResource_Protection(t *testing.T) {
 	var (
 		vol hcloud.Volume
 

--- a/internal/volume/resource_test.go
+++ b/internal/volume/resource_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-func TestAccVolumeResource_Basic(t *testing.T) {
+func TestAccVolumeResource(t *testing.T) {
 	var vol hcloud.Volume
 
 	res := VolumeRData()


### PR DESCRIPTION
This PR renames the acceptance test names to have a consistent schema.
Most importantly, all acceptance tests now start with `TestAcc`, making them be runnable separately from regular unit tests by specifying a regex in `go test`.