### PR TITLE
test: cloud-init may exit with 2 when hitting recoverable errors

### DIFF
--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -911,7 +911,7 @@ resource "terraform_data" "wait" {
   }
 
   provisioner "remote-exec" {
-    inline = ["cloud-init status --wait --long"]
+    inline = ["cloud-init status --wait --long || test $? -eq 2"]
   }
 }
 `, sshKeyRes.PrivateKey),


### PR DESCRIPTION
We don't want to fail the remote-exec if cloud-init only fails with recoverable error, as we are testing whether the SSH connection was made.