### PR TITLE
test: allow overriding hcloud test client endpoint

### DIFF
--- a/internal/testsupport/client.go
+++ b/internal/testsupport/client.go
@@ -16,5 +16,10 @@ func CreateClient() (*hcloud.Client, error) {
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(os.Getenv("HCLOUD_TOKEN")),
 	}
+
+	if value := os.Getenv("HCLOUD_ENDPOINT"); value != "" {
+		opts = append(opts, hcloud.WithEndpoint(value))
+	}
+
 	return hcloud.NewClient(opts...), nil
 }


### PR DESCRIPTION
Allows use to run the tests on a different endpoint.