### PR TITLE
feat(server): add private networks in data_source

### DIFF
--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -67,6 +67,12 @@ type DData struct {
 	ServerID      string
 	ServerName    string
 	LabelSelector string
+	Network       []struct {
+		NetworkID string
+		IP        string
+		AliasIPs  []string
+		Mac       string
+	}
 }
 
 // TFID returns the data source identifier.

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -67,12 +67,6 @@ type DData struct {
 	ServerID      string
 	ServerName    string
 	LabelSelector string
-	Network       []struct {
-		NetworkID string
-		IP        string
-		AliasIPs  []string
-		Mac       string
-	}
 }
 
 // TFID returns the data source identifier.

--- a/templates/data-sources/server.md.tmpl
+++ b/templates/data-sources/server.md.tmpl
@@ -36,8 +36,16 @@ This resource is useful if you want to use a non-terraform managed server.
 - `ipv6_network` - (string) The IPv6 network.
 - `status` - (string) The status of the server.
 - `labels` - (map) User-defined labels (key-value pairs)
+- `network` - (map) Private Network the server is attached to.
 - `firewall_ids` - (Optional, list) Firewall IDs the server is attached to.
 - `placement_group_id` - (Optional, string) Placement Group ID the server is assigned to.
 - `delete_protection` - (bool) Whether delete protection is enabled.
 - `rebuild_protection` - (bool) Whether rebuild protection is enabled.
 - `primary_disk_size` - (int) The size of the primary disk in GB.
+
+a single entry in `network` support the following fields:
+
+- `network_id` - (int) The unique identifier for the network.
+- `ip` - (string) The server's IP address within the network.
+- `alias_ips` - (list) A list of alias IP addresses assigned to the server in the network.
+- `mac_address` - (string) The MAC address associated with the server's private network interface.


### PR DESCRIPTION
Hi hetzner,

This provider is super cool ! I noticed something that would be a nice to have: the current data_source for servers does not outputs the private network data. That would be a great addition, as it makes working with private-network-only servers easier. There is a use case identified around autoscaling nodes [here](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/pull/1567#discussion_r2039499973).
I'm not sure if that's the best way to go, but that's a starting point, feel free to give feedback,

Have a nice week-end,