### PR TITLE
fix: missing assignee_type in assign primary ip call

### DIFF
--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -352,8 +352,9 @@ func setProtection(ctx context.Context, c *hcloud.Client, primaryIP *hcloud.Prim
 
 func AssignPrimaryIP(ctx context.Context, c *hcloud.Client, primaryIPID int64, serverID int64) diag.Diagnostics {
 	action, _, err := c.PrimaryIP.Assign(ctx, hcloud.PrimaryIPAssignOpts{
-		ID:         primaryIPID,
-		AssigneeID: serverID,
+		ID:           primaryIPID,
+		AssigneeID:   serverID,
+		AssigneeType: "server",
 	})
 	if err != nil {
 		return hcloudutil.ErrorToDiag(err)


### PR DESCRIPTION
This is required in the API, but we omitted the field here. The current API uses "server" as a default, but that is a bug and will change in the future.