### PR TITLE
docs: recommend providing architecture when fetching images

### DIFF
--- a/docs/data-sources/image.md
+++ b/docs/data-sources/image.md
@@ -9,22 +9,32 @@ description: |-
 Provides details about a Hetzner Cloud Image.
 This resource is useful if you want to use a non-terraform managed image.
 
+When relevant, it is recommended to always provide the image architecture
+(`with_architecture`) when fetching images.
+
 ## Example Usage
 
 ```terraform
-data "hcloud_image" "image_1" {
-  id = "1234"
+data "hcloud_image" "by_id" {
+  id = "114690387"
 }
-data "hcloud_image" "image_2" {
-  name              = "ubuntu-18.04"
+
+data "hcloud_image" "by_name_x86" {
+  name              = "debian-12"
   with_architecture = "x86"
 }
-data "hcloud_image" "image_3" {
+
+data "hcloud_image" "by_name_arm" {
+  name              = "debian-12"
+  with_architecture = "arm"
+}
+
+data "hcloud_image" "by_label" {
   with_selector = "key=value"
 }
 
 resource "hcloud_server" "main" {
-  image = data.hcloud_image.image_1.id
+  image = data.hcloud_image.by_name.id
 }
 ```
 

--- a/docs/data-sources/images.md
+++ b/docs/data-sources/images.md
@@ -8,14 +8,17 @@ description: |-
 
 Provides details about multiple Hetzner Cloud Images.
 
+When relevant, it is recommended to always provide the image architecture
+(`with_architecture`) when fetching images.
+
 ## Example Usage
 
 ```terraform
-data "hcloud_images" "image_2" {
+data "hcloud_images" "by_architecture" {
   with_architecture = ["x86"]
 }
 
-data "hcloud_images" "image_3" {
+data "hcloud_images" "by_label" {
   with_selector = "key=value"
 }
 ```

--- a/examples/data-sources/hcloud_image/data-source.tf
+++ b/examples/data-sources/hcloud_image/data-source.tf
@@ -1,14 +1,21 @@
-data "hcloud_image" "image_1" {
-  id = "1234"
+data "hcloud_image" "by_id" {
+  id = "114690387"
 }
-data "hcloud_image" "image_2" {
-  name              = "ubuntu-18.04"
+
+data "hcloud_image" "by_name_x86" {
+  name              = "debian-12"
   with_architecture = "x86"
 }
-data "hcloud_image" "image_3" {
+
+data "hcloud_image" "by_name_arm" {
+  name              = "debian-12"
+  with_architecture = "arm"
+}
+
+data "hcloud_image" "by_label" {
   with_selector = "key=value"
 }
 
 resource "hcloud_server" "main" {
-  image = data.hcloud_image.image_1.id
+  image = data.hcloud_image.by_name.id
 }

--- a/examples/data-sources/hcloud_images/data-source.tf
+++ b/examples/data-sources/hcloud_images/data-source.tf
@@ -1,7 +1,7 @@
-data "hcloud_images" "image_2" {
+data "hcloud_images" "by_architecture" {
   with_architecture = ["x86"]
 }
 
-data "hcloud_images" "image_3" {
+data "hcloud_images" "by_label" {
   with_selector = "key=value"
 }

--- a/templates/data-sources/image.md.tmpl
+++ b/templates/data-sources/image.md.tmpl
@@ -9,6 +9,9 @@ description: |-
 Provides details about a Hetzner Cloud Image.
 This resource is useful if you want to use a non-terraform managed image.
 
+When relevant, it is recommended to always provide the image architecture
+(`with_architecture`) when fetching images.
+
 ## Example Usage
 
 {{ tffile .ExampleFile }}

--- a/templates/data-sources/images.md.tmpl
+++ b/templates/data-sources/images.md.tmpl
@@ -8,6 +8,9 @@ description: |-
 
 Provides details about multiple Hetzner Cloud Images.
 
+When relevant, it is recommended to always provide the image architecture
+(`with_architecture`) when fetching images.
+
 ## Example Usage
 
 {{ tffile .ExampleFile }}


### PR DESCRIPTION
Address the following comment: https://github.com/hetznercloud/terraform-provider-hcloud/issues/762#issuecomment-2848697017 

Recommend users to always provide the architecture field. 