### PR TITLE
refactor: check if labels are unknown

### DIFF
--- a/internal/sshkey/resource.go
+++ b/internal/sshkey/resource.go
@@ -95,8 +95,11 @@ func (r *resourceImpl) Create(ctx context.Context, req resource.CreateRequest, r
 		Name:      data.Name.ValueString(),
 		PublicKey: data.PublicKey.ValueString(),
 	}
-	if !data.Labels.IsNull() {
-		hcloudutil.TerraformLabelsToHCloud(ctx, data.Labels, &opts.Labels)
+
+	resp.Diagnostics.Append(hcloudutil.TerraformLabelsToHCloud(ctx, data.Labels, &opts.Labels)...)
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	in, _, err := r.client.SSHKey.Create(ctx, opts)
@@ -162,7 +165,11 @@ func (r *resourceImpl) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	if !plan.Labels.Equal(data.Labels) {
-		hcloudutil.TerraformLabelsToHCloud(ctx, plan.Labels, &opts.Labels)
+		resp.Diagnostics.Append(hcloudutil.TerraformLabelsToHCloud(ctx, plan.Labels, &opts.Labels)...)
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	id, newDiags := resourceutil.ParseID(data.ID)

--- a/internal/util/hcloudutil/labels.go
+++ b/internal/util/hcloudutil/labels.go
@@ -11,7 +11,7 @@ func TerraformLabelsToHCloud(ctx context.Context, inputLabels types.Map, outputL
 	var diagnostics diag.Diagnostics
 	*outputLabels = make(map[string]string, len(inputLabels.Elements()))
 
-	if !inputLabels.IsNull() {
+	if !inputLabels.IsUnknown() && !inputLabels.IsNull() {
 		diagnostics.Append(inputLabels.ElementsAs(ctx, outputLabels, false)...)
 	}
 

--- a/internal/util/hcloudutil/labels_test.go
+++ b/internal/util/hcloudutil/labels_test.go
@@ -29,6 +29,12 @@ func TestTerraformLabelsToHCloud(t *testing.T) {
 			wantDiagnostics: false,
 		},
 		{
+			name:            "Unknown Labels",
+			inputLabels:     types.MapUnknown(types.StringType),
+			wantLabels:      &map[string]string{},
+			wantDiagnostics: false,
+		},
+		{
 			name:            "Invalid Map Labels",
 			inputLabels:     types.MapValueMust(types.BoolType, map[string]attr.Value{"key1": types.BoolValue(true)}),
 			wantLabels:      &map[string]string{},


### PR DESCRIPTION
When converting terraform labels to API labels, make sure we account for unknown labels.