### PR TITLE
chore: only build or install top level main package

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,10 +1,10 @@
 default: lint install generate
 
 build:
-	go build -v ./...
+	go build -v .
 
 install: build
-	go install -v ./...
+	go install -v .
 
 lint:
 	golangci-lint run --fix


### PR DESCRIPTION
Using `./...` will result in building unwanted packages (e.g teste2e). 