### PR TITLE
feat(871): add support and documentation for ISO datasources

### DIFF
--- a/docs/data-sources/iso.md
+++ b/docs/data-sources/iso.md
@@ -1,0 +1,53 @@
+---
+page_title: "Hetzner Cloud: hcloud_iso"
+description: |-
+  Provides details about a specific Hetzner Cloud ISO.
+---
+
+# Data Source: hcloud_iso
+
+Provides details about a Hetzner Cloud ISO.
+
+When relevant, it is recommended to always provide the targeted architecture
+(`with_architecture`) when fetching ISOs.
+
+## Example Usage
+
+```terraform
+data "hcloud_iso" "by_id" {
+  id = "117577"
+}
+
+data "hcloud_iso" "by_name_x86" {
+  name              = "nixos-minimal-24.11.712431.cbd8ec4de446-x86_64-linux.iso"
+  with_architecture = "x86"
+}
+
+data "hcloud_iso" "by_name_prefix_arm" {
+  name_prefix       = "nixos-minimal-24.11"
+  with_architecture = "arm"
+}
+
+resource "hcloud_server" "main" {
+  iso = data.hcloud_iso.by_name_x86.id
+}
+```
+
+## Argument Reference
+
+- `id` - (Optional, string) ID of the ISO.
+- `name` - (Optional, string) Name of the ISO.
+- `name_prefix` - (Optional, string) List only ISOs with names starting with this prefix.
+- `type` - (Optional, string) List only ISOs with the associated type, could be `public` or `private`.
+- `with_architecture` - (Optional, string) Select only ISOs with this architecture, could be `x86` (default) or `arm`.
+- `include_architecture_wildcard` - (Optional, boolean) If set to `true`, return custom ISOs that have no architecture set
+
+## Attributes Reference
+
+- `id` - (int) Unique ID of the ISO.
+- `name` - (string) Name of the ISO.
+- `type` - (string) Type of the ISO, could be `public` or `private`.
+- `architecture` - (string) If defined, architecture of the ISO, could be `x86` or `arm`
+- `description` - (string) Description of the ISO.
+- `deprecated_announced` - (string) If defined, date when the ISO will be deprecated (in ISO-8601 format).
+- `unavailable_after` - (string) If defined, date when the ISO will be removed (in ISO-8601 format).

--- a/docs/data-sources/isos.md
+++ b/docs/data-sources/isos.md
@@ -1,0 +1,39 @@
+---
+page_title: "Hetzner Cloud: hcloud_isos"
+description: |-
+  Provides details about multiple Hetzner Cloud ISOs.
+---
+
+# Data Source: hcloud_isos
+
+Provides details about multiple Hetzner Cloud ISOs.
+
+When relevant, it is recommended to always provide the targeted architecture
+(`with_architecture`) when fetching ISOs.
+
+## Example Usage
+
+```terraform
+data "hcloud_isos" "by_architecture" {
+  with_architecture = ["x86"]
+}
+
+data "hcloud_isos" "by_name_prefix" {
+  name_prefix = "nixos"
+}
+
+data "hcloud_isos" "by_type" {
+  type = "private"
+}
+```
+
+## Argument Reference
+
+- `name_prefix` - (Optional, string) List only ISOs with names starting with this prefix.
+- `type` - (Optional, string) List only ISOs with the associated type, could be `public` or `private`.
+- `with_architecture` - (Optional, list) List only ISOs with this architecture, could contain `x86` or `arm`.
+- `include_architecture_wildcard` - (Optional, boolean) If set to `true`, return custom ISOs that have no architecture set
+
+## Attributes Reference
+
+- `isos` - (list) List of all matching ISOs. See `data.hcloud_iso` for schema.

--- a/examples/data-sources/hcloud_iso/data-source.tf
+++ b/examples/data-sources/hcloud_iso/data-source.tf
@@ -1,0 +1,17 @@
+data "hcloud_iso" "by_id" {
+  id = "117577"
+}
+
+data "hcloud_iso" "by_name_x86" {
+  name              = "nixos-minimal-24.11.712431.cbd8ec4de446-x86_64-linux.iso"
+  with_architecture = "x86"
+}
+
+data "hcloud_iso" "by_name_prefix_arm" {
+  name_prefix       = "nixos-minimal-24.11"
+  with_architecture = "arm"
+}
+
+resource "hcloud_server" "main" {
+  iso = data.hcloud_iso.by_name_x86.id
+}

--- a/examples/data-sources/hcloud_isos/data-source.tf
+++ b/examples/data-sources/hcloud_isos/data-source.tf
@@ -1,0 +1,11 @@
+data "hcloud_isos" "by_architecture" {
+  with_architecture = ["x86"]
+}
+
+data "hcloud_isos" "by_name_prefix" {
+  name_prefix = "nixos"
+}
+
+data "hcloud_isos" "by_type" {
+  type = "private"
+}

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/image"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/iso"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/placementgroup"
@@ -106,6 +107,8 @@ func Provider() *schema.Provider {
 			primaryip.DataSourceListType:      primaryip.DataSourceList(),
 			image.DataSourceType:              image.DataSource(),
 			image.DataSourceListType:          image.DataSourceList(),
+			iso.DataSourceType:                iso.DataSource(),
+			iso.DataSourceListType:            iso.DataSourceList(),
 			loadbalancer.DataSourceType:       loadbalancer.DataSource(),
 			loadbalancer.DataSourceListType:   loadbalancer.DataSourceList(),
 			network.DataSourceType:            network.DataSource(),

--- a/hcloud/provider_test.go
+++ b/hcloud/provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/floatingip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/image"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/iso"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/placementgroup"
@@ -73,6 +74,8 @@ func TestProvider_DataSources(t *testing.T) {
 		primaryip.DataSourceListType,
 		image.DataSourceType,
 		image.DataSourceListType,
+		iso.DataSourceType,
+		iso.DataSourceListType,
 		loadbalancer.DataSourceType,
 		loadbalancer.DataSourceListType,
 		network.DataSourceType,

--- a/internal/iso/data_source.go
+++ b/internal/iso/data_source.go
@@ -1,0 +1,303 @@
+package iso
+
+import (
+	"context"
+	"log"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/datasourceutil"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/merge"
+)
+
+const (
+	// DataSourceType is the type name of the Hetzner Cloud ISO resource.
+	DataSourceType = "hcloud_iso"
+
+	// DataSourceListType is the type name to receive a list of Hetzner Cloud ISO resources.
+	DataSourceListType = "hcloud_isos"
+)
+
+// getCommonDataSchema returns a new common schema used by all iso data sources.
+func getCommonDataSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"name": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"description": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"architecture": {
+			Type:     schema.TypeString,
+			Optional: true,
+			Computed: true,
+		},
+		"deprecated_announced": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+		"unavailable_after": {
+			Type:     schema.TypeString,
+			Computed: true,
+			Optional: true,
+		},
+	}
+}
+
+// DataSource creates a Terraform schema for the hcloud_iso data source.
+func DataSource() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHcloudISORead,
+		Schema: merge.Maps(
+			getCommonDataSchema(),
+			map[string]*schema.Schema{
+				"name_prefix": {
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				"with_architecture": {
+					Type:     schema.TypeString,
+					Default:  hcloud.ArchitectureX86,
+					Optional: true,
+				},
+				"include_architecture_wildcard": {
+					Type:     schema.TypeBool,
+					Default:  false,
+					Optional: true,
+				},
+			},
+		),
+	}
+}
+
+func DataSourceList() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceHcloudISOListRead,
+		Schema: map[string]*schema.Schema{
+			"isos": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: getCommonDataSchema(),
+				},
+			},
+			"name_prefix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"with_architecture": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"include_architecture_wildcard": {
+				Type:     schema.TypeBool,
+				Default:  false,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceHcloudISORead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*hcloud.Client)
+	if id, ok := d.GetOk("id"); ok {
+		i, _, err := client.ISO.GetByID(ctx, util.CastInt64(id))
+		if err != nil {
+			return hcloudutil.ErrorToDiag(err)
+		}
+		if i == nil {
+			return diag.Errorf("no ISO found with id %d", id)
+		}
+		setISOSchema(d, i)
+		return nil
+	}
+
+	opts := hcloud.ISOListOpts{}
+
+	name := d.Get("name").(string)
+	if name != "" {
+		opts.Name = name
+	}
+
+	namePrefix, useNamePrefix := d.Get("name_prefix").(string)
+
+	// Resources can be selected either by name
+	if name == "" || (!useNamePrefix || namePrefix == "") {
+		diag.Errorf("please specify an id, a name or a name prefix to lookup the ISO")
+	}
+
+	var isoType hcloud.ISOType
+	if isoTypeStr := d.Get("type").(string); isoTypeStr != "" {
+		switch isoTypeStr {
+		case string(hcloud.ISOTypePublic), string(hcloud.ISOTypePrivate):
+			isoType = hcloud.ISOType(isoTypeStr)
+		default:
+			return diag.Errorf("unknown ISO types %s", isoTypeStr)
+		}
+	}
+
+	log.Printf("Arches: %+v", d.Get("with_architecture"))
+
+	architecture := hcloud.Architecture(d.Get("with_architecture").(string))
+	if architecture != "" {
+		opts.Architecture = []hcloud.Architecture{architecture}
+	}
+
+	if d.Get("include_architecture_wildcard").(bool) {
+		opts.IncludeArchitectureWildcard = true
+	}
+
+	allISOs, err := client.ISO.AllWithOpts(ctx, opts)
+	if err != nil {
+		return hcloudutil.ErrorToDiag(err)
+	}
+	if len(allISOs) == 0 {
+		return diag.Errorf("no ISO found matching the selection")
+	}
+	if len(allISOs) > 1 {
+		if useNamePrefix {
+			// If we have a name prefix, we filter the list to only include the first
+			// ISO that matches the prefix.
+			allISOs = filterByNamePrefix(allISOs, namePrefix)
+		}
+		if isoType != "" {
+			allISOs = filterByType(allISOs, isoType)
+		}
+		if len(allISOs) == 0 {
+			return diag.Errorf("no ISO found matching the selection with name prefix %s", name)
+		} else if len(allISOs) > 1 {
+			return diag.Errorf("multiple ISOs found matching the selection with name prefix %s, please use a more specific prefix", name)
+		}
+		log.Printf("[INFO] %d ISOs found, using %d as the more accurate one", len(allISOs), allISOs[0].ID)
+	}
+	setISOSchema(d, allISOs[0])
+	return nil
+}
+
+func dataSourceHcloudISOListRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	client := m.(*hcloud.Client)
+
+	architectures := make([]hcloud.Architecture, 0)
+	for _, arch := range d.Get("with_architecture").(*schema.Set).List() {
+		architectures = append(architectures, hcloud.Architecture(arch.(string)))
+	}
+
+	var isoType hcloud.ISOType
+	if isoTypeStr := d.Get("type").(string); isoTypeStr != "" {
+		switch isoTypeStr {
+		case string(hcloud.ISOTypePublic), string(hcloud.ISOTypePrivate):
+			isoType = hcloud.ISOType(isoTypeStr)
+		default:
+			return diag.Errorf("unknown ISO types %s", isoTypeStr)
+		}
+	}
+
+	opts := hcloud.ISOListOpts{
+		Architecture: architectures,
+	}
+	if d.Get("include_architecture_wildcard").(bool) {
+		opts.IncludeArchitectureWildcard = true
+	}
+
+	allISOs, err := client.ISO.AllWithOpts(ctx, opts)
+	if err != nil {
+		return hcloudutil.ErrorToDiag(err)
+	}
+
+	namePrefix := d.Get("name_prefix").(string)
+	if namePrefix != "" {
+		allISOs = filterByNamePrefix(allISOs, namePrefix)
+	}
+	if isoType != "" {
+		allISOs = filterByType(allISOs, isoType)
+	}
+
+	ids := make([]string, len(allISOs))
+	tfISOs := make([]map[string]interface{}, len(allISOs))
+	for i, iso := range allISOs {
+		ids[i] = util.FormatID(iso.ID)
+		tfISOs[i] = getISOAttributes(iso)
+	}
+	d.Set("isos", tfISOs)
+	d.SetId(datasourceutil.ListID(ids))
+
+	return nil
+}
+
+func filterByNamePrefix(isoList []*hcloud.ISO, namePrefix string) []*hcloud.ISO {
+	slices.SortFunc(isoList, func(a, b *hcloud.ISO) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	seq := func(yield func(*hcloud.ISO) bool) {
+		for _, i := range isoList {
+			if !strings.HasPrefix(i.Name, namePrefix) {
+				continue
+			}
+			// If the yield function returns false, we stop iterating.
+			if !yield(i) {
+				return
+			}
+		}
+	}
+	return slices.Collect(seq)
+}
+
+func filterByType(isoList []*hcloud.ISO, isoType hcloud.ISOType) []*hcloud.ISO {
+	seq := func(yield func(*hcloud.ISO) bool) {
+		for _, i := range isoList {
+			if i.Type != isoType {
+				continue
+			}
+			// If the yield function returns false, we stop iterating.
+			if !yield(i) {
+				return
+			}
+		}
+	}
+	return slices.Collect(seq)
+}
+
+func setISOSchema(d *schema.ResourceData, i *hcloud.ISO) {
+	util.SetSchemaFromAttributes(d, getISOAttributes(i))
+}
+
+func getISOAttributes(i *hcloud.ISO) map[string]interface{} {
+	res := map[string]interface{}{
+		"id":          i.ID,
+		"type":        i.Type,
+		"name":        i.Name,
+		"description": i.Description,
+	}
+	if i.Architecture != nil {
+		res["architecture"] = i.Architecture
+	}
+	if !i.IsDeprecated() {
+		res["deprecated_announced"] = i.DeprecationAnnounced().Format(time.RFC3339)
+		res["unavailable_after"] = i.UnavailableAfter().Format(time.RFC3339)
+	}
+	return res
+}

--- a/internal/iso/data_source_test.go
+++ b/internal/iso/data_source_test.go
@@ -1,0 +1,140 @@
+package iso_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/iso"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancer"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
+)
+
+func TestAccISODataSource(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	// Define struct for getting an ISO by name
+	isoByName := &iso.DData{
+		IsoName: teste2e.TestISO,
+	}
+	isoByName.SetRName("iso_by_name")
+
+	// Define struct for getting an ISO by name
+	isoByNamePrefix := &iso.DData{
+		IsoNamePrefix: teste2e.TestISO[:10],
+	}
+	isoByName.SetRName("iso_by_name_prefix")
+
+	// Define struct for getting an ISO by ID
+	isoByID := &iso.DData{
+		IsoID: teste2e.TestIsoID,
+	}
+	isoByID.SetRName("iso_by_id")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(loadbalancer.ResourceType, loadbalancer.ByID(t, nil)),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/d/hcloud_iso", isoByName,
+					"testdata/d/hcloud_iso", isoByNamePrefix,
+					"testdata/d/hcloud_iso", isoByID,
+				),
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(isoByName.TFID(),
+						"name", teste2e.TestISO),
+					resource.TestCheckResourceAttr(isoByName.TFID(), "id", teste2e.TestIsoID),
+
+					resource.TestCheckResourceAttr(isoByNamePrefix.TFID(),
+						"name", teste2e.TestISO),
+					resource.TestCheckResourceAttr(isoByNamePrefix.TFID(), "id", teste2e.TestIsoID),
+
+					resource.TestCheckResourceAttr(isoByID.TFID(),
+						"name", teste2e.TestISO),
+					resource.TestCheckResourceAttr(isoByID.TFID(), "id", teste2e.TestIsoID),
+				),
+			},
+		},
+	})
+}
+
+func TestAccISODataSource_WithFilters(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	isoByNamePrefix := &iso.DData{
+		IsoNamePrefix:               teste2e.TestImage[:10],
+		Architecture:                "arm",
+		IncludeArchitectureWildcard: true,
+	}
+	isoByNamePrefix.SetRName("iso_by_name_prefix")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(loadbalancer.ResourceType, loadbalancer.ByID(t, nil)),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/d/hcloud_iso", isoByNamePrefix,
+				),
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(isoByNamePrefix.TFID(),
+						"name", teste2e.TestISO),
+					resource.TestCheckResourceAttr(isoByNamePrefix.TFID(),
+						"architecture", "arm"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccISODataSourceList(t *testing.T) {
+	allISOsPrivSel := &iso.DDataList{
+		IsoType: hcloud.ISOTypePrivate,
+	}
+	allISOsPrivSel.SetRName("all_isos_priv_sel")
+
+	allISOsPubSel := &iso.DDataList{
+		IsoType: hcloud.ISOTypePublic,
+	}
+	allISOsPubSel.SetRName("all_isos_pub_sel")
+
+	tmplMan := testtemplate.Manager{}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(loadbalancer.ResourceType, loadbalancer.ByID(t, nil)),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/d/hcloud_isos", allISOsPrivSel,
+					"testdata/d/hcloud_isos", allISOsPubSel,
+				),
+
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckTypeSetElemNestedAttrs(allISOsPrivSel.TFID(), "images.*",
+						map[string]string{
+							"name": teste2e.TestISO,
+							"id":   teste2e.TestIsoID,
+							"type": string(hcloud.ISOTypePrivate),
+						},
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(allISOsPubSel.TFID(), "images.*",
+						map[string]string{
+							"name": teste2e.TestISO,
+							"id":   teste2e.TestIsoID,
+							"type": string(hcloud.ISOTypePublic),
+						},
+					),
+				),
+			},
+		},
+	})
+}

--- a/internal/iso/testing.go
+++ b/internal/iso/testing.go
@@ -1,0 +1,43 @@
+package iso
+
+import (
+	"fmt"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
+)
+
+// DData defines the fields for the "testdata/d/hcloud_iso"
+// template.
+type DData struct {
+	testtemplate.DataCommon
+
+	IsoID                       string
+	IsoName                     string
+	IsoNamePrefix               string
+	IsoType                     hcloud.ISOType
+	Architecture                hcloud.Architecture
+	IncludeArchitectureWildcard bool
+}
+
+// TFID returns the data source identifier.
+func (d *DData) TFID() string {
+	return fmt.Sprintf("data.%s.%s", DataSourceType, d.RName())
+}
+
+// DDataList defines the fields for the "testdata/d/hcloud_isos"
+// template.
+type DDataList struct {
+	testtemplate.DataCommon
+
+	IsoNamePrefix               string
+	IsoType                     hcloud.ISOType
+	Architecture                hcloud.Architecture
+	IncludeArchitectureWildcard bool
+}
+
+// TFID returns the data source identifier.
+func (d *DDataList) TFID() string {
+	return fmt.Sprintf("data.%s.%s", DataSourceListType, d.RName())
+}

--- a/internal/testdata/d/hcloud_iso.tf.tmpl
+++ b/internal/testdata/d/hcloud_iso.tf.tmpl
@@ -1,0 +1,10 @@
+{{- /* vim: set ft=terraform: */ -}}
+
+data "hcloud_iso" "{{ .RName }}" {
+  {{ if .IsoID -}}   id            = "{{ .IsoID }}"{{ end -}}
+  {{ if .IsoName -}} name          = "{{ .IsoName }}"{{ end -}}
+  {{ if .IsoNamePrefix -}}    name_prefix = "{{ .IsoNamePrefix }}"{{ end }}
+  {{ if .IsoType -}} type          = "{{ .IsoType }}"{{ end -}}
+  {{ if .Architecture -}}    with_architecture = "{{ .Architecture }}"{{ end }}
+  {{ if .IncludeArchitectureWildcard -}}    include_architecture_wildcard = {{ .IncludeArchitectureWildcard }}{{ end }}
+}

--- a/internal/testdata/d/hcloud_isos.tf.tmpl
+++ b/internal/testdata/d/hcloud_isos.tf.tmpl
@@ -1,0 +1,8 @@
+{{- /* vim: set ft=terraform: */ -}}
+
+data "hcloud_isos" "{{ .RName }}" {
+  {{ if .IsoNamePrefix -}}    name_prefix = "{{ .IsoNamePrefix }}"{{ end }}
+  {{ if .IsoType -}}    type = "{{ .IsoType }}"{{ end -}}
+  {{ if .Architecture -}}    with_architecture = ["{{ .Architecture }}"]{{ end }}
+  {{ if .IncludeArchitectureWildcard -}}    include_architecture_wildcard = {{ .IncludeArchitectureWildcard }}{{ end }}
+}

--- a/internal/teste2e/testing.go
+++ b/internal/teste2e/testing.go
@@ -19,8 +19,14 @@ var (
 	// TestImage is the system image that is used in all tests
 	TestImage = getEnv("TEST_IMAGE", "ubuntu-24.04")
 
-	// TestImage is the system image ID that is used in all tests
+	// TestImageID is the system image ID that is used in all tests
 	TestImageID = getEnv("TEST_IMAGE_ID", "161547269")
+
+	// TestISO is the ISO name that is used in all tests
+	TestISO = getEnv("TEST_ISO_ID", "nixos-minimal-24.11.712431.cbd8ec4de446-x86_64-linux.iso")
+
+	// TestIsoID is the ISO ID that is used in all tests
+	TestIsoID = getEnv("TEST_ISO_ID", "117577")
 
 	// TestServerType is the default server type used in all tests
 	TestServerType = getEnv("TEST_SERVER_TYPE", "cpx11")

--- a/templates/data-sources/iso.md.tmpl
+++ b/templates/data-sources/iso.md.tmpl
@@ -1,0 +1,35 @@
+---
+page_title: "Hetzner Cloud: hcloud_iso"
+description: |-
+  Provides details about a specific Hetzner Cloud ISO.
+---
+
+# Data Source: hcloud_iso
+
+Provides details about a Hetzner Cloud ISO.
+
+When relevant, it is recommended to always provide the targeted architecture
+(`with_architecture`) when fetching ISOs.
+
+## Example Usage
+
+{{ tffile .ExampleFile }}
+
+## Argument Reference
+
+- `id` - (Optional, string) ID of the ISO.
+- `name` - (Optional, string) Name of the ISO.
+- `name_prefix` - (Optional, string) List only ISOs with names starting with this prefix.
+- `type` - (Optional, string) List only ISOs with the associated type, could be `public` or `private`.
+- `with_architecture` - (Optional, string) Select only ISOs with this architecture, could be `x86` (default) or `arm`.
+- `include_architecture_wildcard` - (Optional, boolean) If set to `true`, return custom ISOs that have no architecture set
+
+## Attributes Reference
+
+- `id` - (int) Unique ID of the ISO.
+- `name` - (string) Name of the ISO.
+- `type` - (string) Type of the ISO, could be `public` or `private`.
+- `architecture` - (string) If defined, architecture of the ISO, could be `x86` or `arm`
+- `description` - (string) Description of the ISO.
+- `deprecated_announced` - (string) If defined, date when the ISO will be deprecated (in ISO-8601 format).
+- `unavailable_after` - (string) If defined, date when the ISO will be removed (in ISO-8601 format).

--- a/templates/data-sources/isos.md.tmpl
+++ b/templates/data-sources/isos.md.tmpl
@@ -1,0 +1,27 @@
+---
+page_title: "Hetzner Cloud: hcloud_isos"
+description: |-
+  Provides details about multiple Hetzner Cloud ISOs.
+---
+
+# Data Source: hcloud_isos
+
+Provides details about multiple Hetzner Cloud ISOs.
+
+When relevant, it is recommended to always provide the targeted architecture
+(`with_architecture`) when fetching ISOs.
+
+## Example Usage
+
+{{ tffile .ExampleFile }}
+
+## Argument Reference
+
+- `name_prefix` - (Optional, string) List only ISOs with names starting with this prefix.
+- `type` - (Optional, string) List only ISOs with the associated type, could be `public` or `private`.
+- `with_architecture` - (Optional, list) List only ISOs with this architecture, could contain `x86` or `arm`.
+- `include_architecture_wildcard` - (Optional, boolean) If set to `true`, return custom ISOs that have no architecture set
+
+## Attributes Reference
+
+- `isos` - (list) List of all matching ISOs. See `data.hcloud_iso` for schema.


### PR DESCRIPTION
Add the following datasource for ISO:
* `hcloud_iso` : to retrieve an ISO from its id, name, architecture or name prefix
* `hcloud_isos` : to retrieve a list of ISO from their name, architecture or name prefix

The documentation has been updated with these 2.
