### PR TITLE
feat: warn when experimental features are used

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ You should see the following warning:
 
 To publish experimental features as part of regular releases:
 
-- an announcement, including a link to a changelog entry, must written in the release notes.
+- an announcement, including a link to a changelog entry, must be added to the release notes.
 
 - an `Experimental` notice, must be added to the experimental resource, datasource, and functions descriptions:
 

--- a/README.md
+++ b/README.md
@@ -132,3 +132,30 @@ You should see the following warning:
 │ The behavior may therefore not match any released version of the provider and applying changes may cause the state to become incompatible with published releases.
 ╵
 ```
+
+## Releasing experimental features
+
+To publish experimental features as part of regular releases:
+
+- an announcement, including a link to a changelog entry, must written in the release notes.
+
+- an `Experimental` notice, must be added to the experimental resource, datasource, and functions descriptions:
+
+  ```go
+  func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+    resp.Schema.MarkdownDescription = `
+  Manage a Hetzner Cloud Product.
+
+  See https://docs.hetzner.cloud/reference/cloud#product for more details.
+  `
+    experimental.Product.AppendNotice(&resp.Schema.MarkdownDescription)
+  }
+  ```
+
+- a `Experimental` warning must be logged when experimental resource, datasource, or functions are being used:
+
+  ```go
+  func (r *Resource) Configure(_ context.Context, _ resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+    experimental.Product.AppendDiagnostic(&resp.Diagnostics)
+  }
+  ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,3 +52,16 @@ This can also be configured through Terraform through the `delete_protection` ar
 
 Please note, that this does not protect deletion from Terraform itself, as the Provider will lift the lock in that case.
 If you also want to protect your resources from deletion by Terraform, you can use the [`prevent_destroy` lifecycle attribute](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion).
+
+## Experimental features
+
+Experimental features are published as part of our regular releases (e.g. a product
+public beta). During an experimental phase, breaking changes on those features may occur
+within minor releases.
+
+While experimental features will be announced in the release notes, you can also find
+whether a resource, datasource or function is experimental in its documentation:
+
+```markdown
+Experimental: Product is experimental, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#new-product for more details.
+```

--- a/internal/util/experimental/experimental.go
+++ b/internal/util/experimental/experimental.go
@@ -1,0 +1,63 @@
+package experimental
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// Experimental holds the details about an experimental product.
+//
+// Usage:
+//
+//	var Product = New("Product name", "https://docs.hetzner.cloud/changelog#new-product")
+//
+//	func (r *Resource) Configure(_ context.Context, _ resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+//		experimental.Product.AppendDiagnostic(&resp.Diagnostics)
+//	}
+//
+//	func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+//		resp.Schema.MarkdownDescription = `
+//	Manage a Hetzner Cloud Product.
+//
+//	See https://docs.hetzner.cloud/reference/cloud#product for more details.
+//	`
+//		experimental.Product.AppendNotice(&resp.Schema.MarkdownDescription)
+//	}
+type Experimental struct {
+	product string
+	url     string
+
+	diagnostic diag.Diagnostic
+	notice     string
+}
+
+func New(product string, url string) Experimental {
+	e := Experimental{product: product, url: url}
+
+	e.diagnostic = diag.NewWarningDiagnostic(
+		fmt.Sprintf("Experimental: %s", e.product),
+		fmt.Sprintf(`%s is experimental, breaking changes may occur within minor releases.
+
+See %s for more details.
+`, e.product, e.url))
+
+	e.notice = fmt.Sprintf(`
+
+**Experimental:** %s is experimental, breaking changes may occur within minor releases.
+See %s for more details.
+`, e.product, e.url)
+
+	return e
+}
+
+// AppendDiagnostic adds a warning about the experimental product to the provided diagnostics.
+func (e Experimental) AppendDiagnostic(diags *diag.Diagnostics) {
+	diags.Append(e.diagnostic)
+}
+
+// AppendNotice adds a warning about the experimental product to the provided description.
+func (e Experimental) AppendNotice(description *string) {
+	*description = strings.TrimSuffix(*description, "\n") + e.notice
+}

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -30,3 +30,16 @@ This can also be configured through Terraform through the `delete_protection` ar
 
 Please note, that this does not protect deletion from Terraform itself, as the Provider will lift the lock in that case.
 If you also want to protect your resources from deletion by Terraform, you can use the [`prevent_destroy` lifecycle attribute](https://developer.hashicorp.com/terraform/tutorials/state/resource-lifecycle#prevent-resource-deletion).
+
+## Experimental features
+
+Experimental features are published as part of our regular releases (e.g. a product
+public beta). During an experimental phase, breaking changes on those features may occur
+within minor releases.
+
+While experimental features will be announced in the release notes, you can also find
+whether a resource, datasource or function is experimental in its documentation:
+
+```markdown
+Experimental: Product is experimental, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#new-product for more details.
+```


### PR DESCRIPTION
- Document how users can learn about experimental features.
- Document how developers can release experimental features.
- Log a warning when experimental features are being used.