### PR TITLE
feat: add support for Hetzner API endpoint

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ The following arguments are supported:
 
 - `token` - (Required, string) This is the Hetzner Cloud API Token, can also be specified with the `HCLOUD_TOKEN` environment variable.
 - `endpoint` - (Optional, string) Hetzner Cloud API endpoint, can be used to override the default API Endpoint `https://api.hetzner.cloud/v1`.
+- `endpoint_hetzner` - (Optional, string) Hetzner API endpoint, can be used to override the default API Endpoint `https://api.hetzner.com/v1`.
 - `poll_interval` - (Optional, string) Configures the interval in which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.
 - `poll_function` - (Optional, string) Configures the type of function to be used during the polling. Valid values are `constant` and `exponential`. Default `exponential`.
 

--- a/hcloud/plugin_provider.go
+++ b/hcloud/plugin_provider.go
@@ -58,6 +58,10 @@ func (p *PluginProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 				Description: "The Hetzner Cloud API endpoint, can be used to override the default API Endpoint https://api.hetzner.cloud/v1.",
 				Optional:    true,
 			},
+			"endpoint_hetzner": schema.StringAttribute{
+				Description: "The Hetzner API endpoint, can be used to override the default API Endpoint https://api.hetzner.com/v1.",
+				Optional:    true,
+			},
 			"poll_interval": schema.StringAttribute{
 				Description: "The interval at which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.",
 				Optional:    true,
@@ -79,10 +83,11 @@ func (p *PluginProvider) Schema(_ context.Context, _ provider.SchemaRequest, res
 
 // PluginProviderModel describes the provider data model.
 type PluginProviderModel struct {
-	Token        types.String `tfsdk:"token"`
-	Endpoint     types.String `tfsdk:"endpoint"`
-	PollInterval types.String `tfsdk:"poll_interval"`
-	PollFunction types.String `tfsdk:"poll_function"`
+	Token           types.String `tfsdk:"token"`
+	Endpoint        types.String `tfsdk:"endpoint"`
+	EndpointHetzner types.String `tfsdk:"endpoint_hetzner"`
+	PollInterval    types.String `tfsdk:"poll_interval"`
+	PollFunction    types.String `tfsdk:"poll_function"`
 }
 
 // Configure is called at the beginning of the provider lifecycle, when
@@ -110,6 +115,14 @@ func (p *PluginProvider) Configure(ctx context.Context, req provider.ConfigureRe
 	}
 	if endpoint != "" {
 		opts = append(opts, hcloud.WithEndpoint(endpoint))
+	}
+
+	endpointHetzner := os.Getenv("HETZNER_ENDPOINT")
+	if data.EndpointHetzner.ValueString() != "" {
+		endpointHetzner = data.Endpoint.ValueString()
+	}
+	if endpointHetzner != "" {
+		opts = append(opts, hcloud.WithHetznerEndpoint(endpointHetzner))
 	}
 
 	token := os.Getenv("HCLOUD_TOKEN")

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -57,6 +57,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("HCLOUD_ENDPOINT", nil),
 				Description: "The Hetzner Cloud API endpoint, can be used to override the default API Endpoint https://api.hetzner.cloud/v1.",
 			},
+			"endpoint_hetzner": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("HETZNER_ENDPOINT", nil),
+				Description: "The Hetzner API endpoint, can be used to override the default API Endpoint https://api.hetzner.com/v1.",
+			},
 			"poll_interval": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -128,6 +134,9 @@ func providerConfigure(_ context.Context, d *schema.ResourceData) (interface{}, 
 	}
 	if endpoint, ok := d.GetOk("endpoint"); ok {
 		opts = append(opts, hcloud.WithEndpoint(endpoint.(string)))
+	}
+	if endpointHetzner, ok := d.GetOk("endpoint_hetzner"); ok {
+		opts = append(opts, hcloud.WithHetznerEndpoint(endpointHetzner.(string)))
 	}
 	if pollInterval, ok := d.GetOk("poll_interval"); ok {
 		pollInterval, err := time.ParseDuration(pollInterval.(string))

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -20,6 +20,7 @@ The following arguments are supported:
 
 - `token` - (Required, string) This is the Hetzner Cloud API Token, can also be specified with the `HCLOUD_TOKEN` environment variable.
 - `endpoint` - (Optional, string) Hetzner Cloud API endpoint, can be used to override the default API Endpoint `https://api.hetzner.cloud/v1`.
+- `endpoint_hetzner` - (Optional, string) Hetzner API endpoint, can be used to override the default API Endpoint `https://api.hetzner.com/v1`.
 - `poll_interval` - (Optional, string) Configures the interval in which actions are polled by the client. Default `500ms`. Increase this interval if you run into rate limiting errors.
 - `poll_function` - (Optional, string) Configures the type of function to be used during the polling. Valid values are `constant` and `exponential`. Default `exponential`.
 


### PR DESCRIPTION
Add the new `endpoint_hetzner` provider option, to override the default `https://api.hetzner.com/v1` API endpoint.