### PR TITLE
fix: handle not found volume deletion

### DIFF
--- a/internal/volume/resource.go
+++ b/internal/volume/resource.go
@@ -341,6 +341,11 @@ func resourceVolumeDelete(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return hcloudutil.ErrorToDiag(err)
 	}
+	if volume == nil {
+		log.Printf("[WARN] volume (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
 
 	if volume.Server != nil {
 		err := control.Retry(control.DefaultRetries, func() error {


### PR DESCRIPTION
Ensure the provider does not fail when trying to delete a volume that was not found. The volume might have vanished while still present in the TF state.

Closes #1188 