### PR TITLE
fix: add experimental features maturity

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -59,9 +59,14 @@ Experimental features are published as part of our regular releases (e.g. a prod
 public beta). During an experimental phase, breaking changes on those features may occur
 within minor releases.
 
+The stability of experimental features is not related to the stability of its upstream API.
+
+Experimental features have different levels of maturity (e.g. experimental, alpha, beta)
+based on the maturity of the upstream API.
+
 While experimental features will be announced in the release notes, you can also find
 whether a resource, datasource or function is experimental in its documentation:
 
 ```markdown
-Experimental: Product is experimental, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#new-product for more details.
+Experimental: $PRODUCT is $MATURITY, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#$SLUG for more details.
 ```

--- a/internal/util/experimental/experimental.go
+++ b/internal/util/experimental/experimental.go
@@ -11,7 +11,7 @@ import (
 //
 // Usage:
 //
-//	var Product = New("Product name", "https://docs.hetzner.cloud/changelog#new-product")
+//	var Product = New("Product name", "in beta", "https://docs.hetzner.cloud/changelog#new-product")
 //
 //	func (r *Resource) Configure(_ context.Context, _ resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 //		experimental.Product.AppendDiagnostic(&resp.Diagnostics)
@@ -26,28 +26,29 @@ import (
 //		experimental.Product.AppendNotice(&resp.Schema.MarkdownDescription)
 //	}
 type Experimental struct {
-	product string
-	url     string
+	product  string
+	maturity string
+	url      string
 
 	diagnostic diag.Diagnostic
 	notice     string
 }
 
-func New(product string, url string) Experimental {
-	e := Experimental{product: product, url: url}
+func New(product string, maturity string, url string) Experimental {
+	e := Experimental{product: product, maturity: maturity, url: url}
 
 	e.diagnostic = diag.NewWarningDiagnostic(
 		fmt.Sprintf("Experimental: %s", e.product),
-		fmt.Sprintf(`%s is experimental, breaking changes may occur within minor releases.
+		fmt.Sprintf(`%s is %s, breaking changes may occur within minor releases.
 
 See %s for more details.
-`, e.product, e.url))
+`, e.product, e.maturity, e.url))
 
 	e.notice = fmt.Sprintf(`
 
-**Experimental:** %s is experimental, breaking changes may occur within minor releases.
+**Experimental:** %s is %s, breaking changes may occur within minor releases.
 See %s for more details.
-`, e.product, e.url)
+`, e.product, e.maturity, e.url)
 
 	return e
 }

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -37,9 +37,14 @@ Experimental features are published as part of our regular releases (e.g. a prod
 public beta). During an experimental phase, breaking changes on those features may occur
 within minor releases.
 
+The stability of experimental features is not related to the stability of its upstream API.
+
+Experimental features have different levels of maturity (e.g. experimental, alpha, beta)
+based on the maturity of the upstream API.
+
 While experimental features will be announced in the release notes, you can also find
 whether a resource, datasource or function is experimental in its documentation:
 
 ```markdown
-Experimental: Product is experimental, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#new-product for more details.
+Experimental: $PRODUCT is $MATURITY, breaking changes may occur within minor releases. See https://docs.hetzner.cloud/changelog#$SLUG for more details.
 ```


### PR DESCRIPTION
Add the API upstream maturity information to our experimental features release
process.