### PR TITLE
fix: wait for floating_ip assign action to complete

### DIFF
--- a/internal/floatingip/resource_assignment.go
+++ b/internal/floatingip/resource_assignment.go
@@ -50,8 +50,11 @@ func resourceFloatingIPAssignmentCreate(ctx context.Context, d *schema.ResourceD
 
 	server := &hcloud.Server{ID: util.CastInt64(serverID)}
 
-	_, _, err := client.FloatingIP.Assign(ctx, floatingIP, server)
+	action, _, err := client.FloatingIP.Assign(ctx, floatingIP, server)
 	if err != nil {
+		return hcloudutil.ErrorToDiag(err)
+	}
+	if err := hcloudutil.WaitForAction(ctx, &client.Action, action); err != nil {
 		return hcloudutil.ErrorToDiag(err)
 	}
 


### PR DESCRIPTION
Ensures that the Floating IP assign background task succeeds by waiting on the returned action. Report an error if the action failed.