### PR TITLE
test: enable parallel test for remaining serial test

### DIFF
--- a/internal/firewall/attachment_resource_test.go
+++ b/internal/firewall/attachment_resource_test.go
@@ -31,8 +31,7 @@ func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 	fwAttRes.ServerIDRefs = append(fwAttRes.ServerIDRefs, srvRes.TFID()+".id")
 
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
@@ -77,8 +76,7 @@ func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 	fwAttRes.LabelSelectors = append(fwAttRes.LabelSelectors, "firewall-attachment=test-server")
 
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy: resource.ComposeAggregateTestCheckFunc(

--- a/internal/firewall/data_source_test.go
+++ b/internal/firewall/data_source_test.go
@@ -30,8 +30,7 @@ func TestAccFirewallDataSource(t *testing.T) {
 	}
 	firewallBySel.SetRName("firewall_by_sel")
 
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, nil)),
@@ -76,8 +75,7 @@ func TestAccFirewallDataSourceList(t *testing.T) {
 	allFirewallsSel.SetRName("all_firewalls_sel")
 
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, nil)),

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -66,8 +66,7 @@ func TestAccFirewallResource(t *testing.T) {
 	}, nil)
 	updated.SetRName(res.RName())
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &f)),
@@ -144,8 +143,7 @@ func TestAccFirewallResource_ApplyTo(t *testing.T) {
 	})
 	resUpdated.SetRName(res.RName())
 	tmplMan := testtemplate.Manager{}
-	// TODO: Move to parallel test once API endpoint is fixed
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &f)),
@@ -214,8 +212,7 @@ func TestAccFirewallResource_Normalization(t *testing.T) {
 	}, nil)
 	tmplMan := testtemplate.Manager{}
 
-	// TODO: Move to parallel test once API endpoint supports higher parallelism
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &f)),

--- a/internal/rdns/resource_test.go
+++ b/internal/rdns/resource_test.go
@@ -62,8 +62,7 @@ func TestAccRDNSResource_Server(t *testing.T) {
 			resServer.SetRName(tt.name)
 			resRDNS := rdns.NewRDataServer(t, tt.name, resServer.TFID()+".id", resServer.TFID()+tt.ipAddress, tt.dns)
 
-			// TODO: Debug issues that causes this to fail when running in parallel
-			resource.Test(t, resource.TestCase{
+			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:                 teste2e.PreCheck(t),
 				ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 				CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &s)),
@@ -128,8 +127,7 @@ func TestAccRDNSResource_PrimaryIP(t *testing.T) {
 			restPrimaryIP.SetRName(tt.name)
 			resRDNS := rdns.NewRDataPrimaryIP(t, tt.name, restPrimaryIP.TFID()+".id", restPrimaryIP.TFID()+".ip_address", tt.dns)
 
-			// TODO: Debug issues that causes this to fail when running in parallel
-			resource.Test(t, resource.TestCase{
+			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:                 teste2e.PreCheck(t),
 				ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 				CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &primaryIP)),
@@ -192,8 +190,7 @@ func TestAccRDNSResource_FloatingIP(t *testing.T) {
 			restFloatingIP.SetRName(tt.name)
 			resRDNS := rdns.NewRDataFloatingIP(t, tt.name, restFloatingIP.TFID()+".id", restFloatingIP.TFID()+".ip_address", tt.dns)
 
-			// TODO: Debug issues that causes this to fail when running in parallel
-			resource.Test(t, resource.TestCase{
+			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:                 teste2e.PreCheck(t),
 				ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 				CheckDestroy:             testsupport.CheckResourcesDestroyed(floatingip.ResourceType, floatingip.ByID(t, &fl)),
@@ -263,8 +260,7 @@ func TestAccRDNSResource_LoadBalancer(t *testing.T) {
 
 			resRDNS := rdns.NewRDataLoadBalancer(t, tt.name, restLoadBalancer.TFID()+".id", restLoadBalancer.TFID()+tt.ipAddress, tt.dns)
 
-			// TODO: Debug issues that causes this to fail when running in parallel
-			resource.Test(t, resource.TestCase{
+			resource.ParallelTest(t, resource.TestCase{
 				PreCheck:                 teste2e.PreCheck(t),
 				ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 				CheckDestroy:             testsupport.CheckResourcesDestroyed(loadbalancer.ResourceType, loadbalancer.ByID(t, &lb)),

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -130,7 +130,7 @@ func TestAccServerResource_ImageID(t *testing.T) {
 	}
 	res.SetRName("server-image-id")
 	tmplMan := testtemplate.Manager{}
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &s)),


### PR DESCRIPTION
Speed up the e2e tests by running them in parallel.