### PR TITLE
feat: support managing records of type SOA

### DIFF
--- a/docs/resources/zone_rrset.md
+++ b/docs/resources/zone_rrset.md
@@ -9,7 +9,8 @@ description: |-
   RRSets of type SOA:
   SOA records are created or deleted by the Hetzner Cloud API when creating or deleting
   the parent Zone, therefor this Terraform resource will:
-  import the RRSet in the state, instead of creating it.remove the RRSet from the state, instead of deleting it.set the SOA record SERIAL value to 0 before saving it to the state.
+  import the RRSet in the state, instead of creating it.remove the RRSet from the state, instead of deleting it.set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
+  incremented by the API and would cause issues otherwise.
   Experimental: DNS API is in beta, breaking changes may occur within minor releases.
   See https://docs.hetzner.cloud/changelog#2025-10-07-dns-beta for more details.
 ---
@@ -29,7 +30,8 @@ the parent Zone, therefor this Terraform resource will:
 
 - import the RRSet in the state, instead of creating it.
 - remove the RRSet from the state, instead of deleting it.
-- set the SOA record SERIAL value to 0 before saving it to the state.
+- set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
+  incremented by the API and would cause issues otherwise.
 
 **Experimental:** DNS API is in beta, breaking changes may occur within minor releases.
 See https://docs.hetzner.cloud/changelog#2025-10-07-dns-beta for more details.

--- a/docs/resources/zone_rrset.md
+++ b/docs/resources/zone_rrset.md
@@ -6,6 +6,10 @@ description: |-
   Provides a Hetzner Cloud Zone Resource Record Set (RRSet) resource.
   This can be used to create, modify, and delete Zone RRSets.
   See the Zone RRSets API documentation https://docs.hetzner.cloud/reference/cloud#zone-rrsets for more details.
+  RRSets of type SOA:
+  SOA records are created or deleted by the Hetzner Cloud API when creating or deleting
+  the parent Zone, therefor this Terraform resource will:
+  import the RRSet in the state, instead of creating it.remove the RRSet from the state, instead of deleting it.set the SOA record SERIAL value to 0 before saving it to the state.
   Experimental: DNS API is in beta, breaking changes may occur within minor releases.
   See https://docs.hetzner.cloud/changelog#2025-10-07-dns-beta for more details.
 ---
@@ -17,6 +21,15 @@ Provides a Hetzner Cloud Zone Resource Record Set (RRSet) resource.
 This can be used to create, modify, and delete Zone RRSets.
 
 See the [Zone RRSets API documentation](https://docs.hetzner.cloud/reference/cloud#zone-rrsets) for more details.
+
+**RRSets of type SOA:**
+
+SOA records are created or deleted by the Hetzner Cloud API when creating or deleting
+the parent Zone, therefor this Terraform resource will:
+
+- import the RRSet in the state, instead of creating it.
+- remove the RRSet from the state, instead of deleting it.
+- set the SOA record SERIAL value to 0 before saving it to the state.
 
 **Experimental:** DNS API is in beta, breaking changes may occur within minor releases.
 See https://docs.hetzner.cloud/changelog#2025-10-07-dns-beta for more details.
@@ -45,6 +58,19 @@ resource "hcloud_zone_rrset" "example" {
   ]
 
   change_protection = false
+}
+
+resource "hcloud_zone_rrset" "example_soa" {
+  zone = hcloud_zone.example.name
+  name = "@"
+  type = "SOA"
+
+  records = [
+    // SOA record SERIAL value will be set to 0, before saving it to the state. Make
+    // sure to use 0 as SERIAL value to prevent running into inconsistent state errors.
+    { value = "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600" }
+    //                                                   ^ here
+  ]
 }
 ```
 

--- a/examples/resources/hcloud_zone_rrset/resource.tf
+++ b/examples/resources/hcloud_zone_rrset/resource.tf
@@ -20,3 +20,16 @@ resource "hcloud_zone_rrset" "example" {
 
   change_protection = false
 }
+
+resource "hcloud_zone_rrset" "example_soa" {
+  zone = hcloud_zone.example.name
+  name = "@"
+  type = "SOA"
+
+  records = [
+    // SOA record SERIAL value will be set to 0, before saving it to the state. Make
+    // sure to use 0 as SERIAL value to prevent running into inconsistent state errors.
+    { value = "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600" }
+    //                                                   ^ here
+  ]
+}

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -71,7 +71,8 @@ the parent Zone, therefor this Terraform resource will:
 
 - import the RRSet in the state, instead of creating it.
 - remove the RRSet from the state, instead of deleting it.
-- set the SOA record SERIAL value to 0 before saving it to the state.
+- set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
+  incremented by the API and would cause issues otherwise.
 `
 
 	experimental.DNS.AppendNotice(&resp.Schema.MarkdownDescription)

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -2,6 +2,7 @@ package zonerrset
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -62,6 +63,15 @@ Provides a Hetzner Cloud Zone Resource Record Set (RRSet) resource.
 This can be used to create, modify, and delete Zone RRSets.
 
 See the [Zone RRSets API documentation](https://docs.hetzner.cloud/reference/cloud#zone-rrsets) for more details.
+
+**RRSets of type SOA:**
+
+SOA records are created or deleted by the Hetzner Cloud API when creating or deleting
+the parent Zone, therefor this Terraform resource will:
+
+- import the RRSet in the state, instead of creating it.
+- remove the RRSet from the state, instead of deleting it.
+- set the SOA record SERIAL value to 0 before saving it to the state.
 `
 
 	experimental.DNS.AppendNotice(&resp.Schema.MarkdownDescription)
@@ -161,12 +171,33 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	actions := make([]*hcloud.Action, 0)
+	var result hcloud.ZoneRRSetCreateResult
+	var err error
+	var actions []*hcloud.Action
 
-	result, _, err := r.client.Zone.CreateRRSet(ctx, zone, opts)
-	if err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
-		return
+	// SOA records are managed by the backend
+	if data.Type.ValueString() == string(hcloud.ZoneRRSetTypeSOA) {
+		resp.Diagnostics.AddWarning(
+			"SOA records are managed by the API",
+			"Importing the SOA record (managed by the API) in the state.",
+		)
+
+		rrset, _, err := r.client.Zone.GetRRSetByNameAndType(ctx, zone, opts.Name, opts.Type)
+		if err != nil {
+			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+			return
+		}
+		if rrset == nil {
+			resp.Diagnostics.Append(hcloudutil.NotFoundDiagnostic("zone rrset", "id", fmt.Sprintf("%s/%s", opts.Name, opts.Type)))
+		}
+		result.RRSet = rrset
+	} else {
+
+		result, _, err = r.client.Zone.CreateRRSet(ctx, zone, opts)
+		if err != nil {
+			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+			return
+		}
 	}
 
 	actions = append(actions, result.Action)
@@ -194,6 +225,8 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return
 	}
+
+	OverrideRecordsSOASerial(in)
 
 	resp.Diagnostics.Append(data.FromAPI(ctx, in)...)
 	if resp.Diagnostics.HasError() {
@@ -223,6 +256,8 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		resp.State.RemoveResource(ctx)
 		return
 	}
+
+	OverrideRecordsSOASerial(in)
 
 	resp.Diagnostics.Append(data.FromAPI(ctx, in)...)
 	if resp.Diagnostics.HasError() {
@@ -335,6 +370,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		in.Protection.Change = plan.ChangeProtection.ValueBool()
 	}
 
+	OverrideRecordsSOASerial(in)
+
 	resp.Diagnostics.Append(data.FromAPI(ctx, in)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -348,6 +385,15 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// SOA records are managed by the backend
+	if data.Type.ValueString() == string(hcloud.ZoneRRSetTypeSOA) {
+		resp.Diagnostics.AddWarning(
+			"SOA records are managed by the API",
+			"Removing the SOA record (managed by the API) from the state.",
+		)
 		return
 	}
 
@@ -381,4 +427,22 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("zone"), parts[0])...)
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), parts[1])...)
+}
+
+// OverrideRecordsSOASerial set the serial value to 0 in a SOA Resource Record Set.
+func OverrideRecordsSOASerial(hc *hcloud.ZoneRRSet) {
+	if hc.Type != hcloud.ZoneRRSetTypeSOA {
+		return
+	}
+
+	// SOA should have only a single record, this is only defensive
+	for i := range hc.Records {
+		// hydrogen.ns.hetzner.com. dns.hetzner.com. 2025102142 86400 10800 3600000 3600
+		//                                           ^^^^^^^^^^
+		parts := strings.Split(hc.Records[i].Value, " ")
+		if len(parts) > 2 {
+			parts[2] = "0" // Serial
+		}
+		hc.Records[i].Value = strings.Join(parts, " ")
+	}
 }

--- a/internal/zonerrset/resource_test.go
+++ b/internal/zonerrset/resource_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
@@ -139,4 +140,131 @@ func TestAccZoneRRSetResource(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccZoneRRSetResource_SOA(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	resZone := &zone.RData{
+		Zone: schema.Zone{
+			Name: fmt.Sprintf("example-%s.com", randutil.GenerateID()),
+			Mode: "primary",
+		},
+	}
+	resZone.SetRName("main")
+
+	res1 := &zonerrset.RData{
+		Zone: resZone.TFID() + ".name",
+		ZoneRRSet: schema.ZoneRRSet{
+			Name: "@",
+			Type: "SOA",
+			Records: []schema.ZoneRRSetRecord{
+				{Value: "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600"},
+			},
+		},
+	}
+	res1.SetRName("soa")
+
+	res2 := &zonerrset.RData{
+		Zone: resZone.TFID() + ".name",
+		ZoneRRSet: schema.ZoneRRSet{
+			Name: "@",
+			Type: "SOA",
+			Records: []schema.ZoneRRSetRecord{
+				{Value: "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 600"},
+			},
+		},
+	}
+	res2.SetRName("soa")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckAPIResourceAllAbsent(zone.ResourceType, zone.GetAPIResource()),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_zone", resZone,
+					"testdata/r/hcloud_zone_rrset", res1,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckAPIResourcePresent(res1.TFID(), zonerrset.GetAPIResource()),
+					resource.TestCheckResourceAttr(res1.TFID(), "id", "@/SOA"),
+					resource.TestCheckResourceAttr(res1.TFID(), "records.#", "1"),
+					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600"),
+				),
+			},
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_zone", resZone,
+					"testdata/r/hcloud_zone_rrset", res2,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckAPIResourcePresent(res2.TFID(), zonerrset.GetAPIResource()),
+					resource.TestCheckResourceAttr(res2.TFID(), "id", "@/SOA"),
+					resource.TestCheckResourceAttr(res2.TFID(), "records.#", "1"),
+					resource.TestCheckResourceAttr(res2.TFID(), "records.0.value", "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 600"),
+				),
+			},
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_zone", resZone,
+					"testdata/r/hcloud_zone_rrset", res2,
+				),
+				PlanOnly: true,
+			},
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_zone", resZone,
+					"testdata/r/hcloud_zone_rrset", res2,
+				),
+				Destroy: true,
+			},
+		},
+	})
+}
+
+func TestOverrideRecordsSOASerial(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		givenType   hcloud.ZoneRRSetType
+		givenRecord hcloud.ZoneRRSetRecord
+		wantRecord  hcloud.ZoneRRSetRecord
+	}{
+		{
+			desc:        "valid",
+			givenType:   hcloud.ZoneRRSetTypeSOA,
+			givenRecord: hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com. 2025102103 86400 10800 3600000 3600`},
+			wantRecord:  hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600`},
+		},
+		{
+			desc:        "valid minimal",
+			givenType:   hcloud.ZoneRRSetTypeSOA,
+			givenRecord: hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com. 2025102103`},
+			wantRecord:  hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com. 0`},
+		},
+		{
+			desc:        "invalid",
+			givenType:   hcloud.ZoneRRSetTypeSOA,
+			givenRecord: hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com.`},
+			wantRecord:  hcloud.ZoneRRSetRecord{Value: `hydrogen.ns.hetzner.com. dns.hetzner.com.`},
+		},
+		{
+			desc:        "skipped",
+			givenType:   hcloud.ZoneRRSetTypeTXT,
+			givenRecord: hcloud.ZoneRRSetRecord{Value: `"one" "two" "three" "four"`},
+			wantRecord:  hcloud.ZoneRRSetRecord{Value: `"one" "two" "three" "four"`},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			rrset := &hcloud.ZoneRRSet{
+				Type:    testCase.givenType,
+				Records: []hcloud.ZoneRRSetRecord{testCase.givenRecord},
+			}
+			zonerrset.OverrideRecordsSOASerial(rrset)
+
+			require.Equal(t, testCase.wantRecord, rrset.Records[0])
+		})
+	}
 }


### PR DESCRIPTION
Because SOA records are created and destroyed with the parent zone, we now:
- import the SOA RRSet in the state, instead of creating it.
- remove the SOA RRSet from the state, instead of deleting it.
- set the SOA record SERIAL value to 0 before saving it to the state.

Closes #1222


