### PR TITLE
feat(firewall): importing firewall attachments

### DIFF
--- a/docs/resources/firewall_attachment.md
+++ b/docs/resources/firewall_attachment.md
@@ -139,3 +139,11 @@ resource "hcloud_firewall_attachment" "allow_rules_att" {
 - `server_ids` (List) - List of Server IDs attached to the Firewall.
 - `label_selectors` (List) - List of label selectors attached to the
   Firewall.
+
+## Import
+
+Firewall Attachments can be imported using the `id` of the firewall:
+
+```shell
+terraform import hcloud_firewall_attachment.example "$FIREWALL_ID"
+```

--- a/examples/resources/hcloud_firewall_attachment/import.sh
+++ b/examples/resources/hcloud_firewall_attachment/import.sh
@@ -1,0 +1,1 @@
+terraform import hcloud_firewall_attachment.example "$FIREWALL_ID"

--- a/internal/firewall/attachment_resource_test.go
+++ b/internal/firewall/attachment_resource_test.go
@@ -21,9 +21,10 @@ func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 
 	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
 	srvRes := &server.RData{
-		Name:  "test-server",
-		Type:  teste2e.TestServerType,
-		Image: teste2e.TestImage,
+		Name:       "test-server",
+		Type:       teste2e.TestServerType,
+		Image:      teste2e.TestImage,
+		Datacenter: teste2e.TestDataCenter,
 	}
 	srvRes.SetRName("test_server")
 
@@ -51,6 +52,15 @@ func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 					testsupport.LiftTCF(hasServerResource(t, &fw, &srv)),
 				),
 			},
+			{
+				ResourceName: fwAttRes.TFID(),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", srvRes,
+					"testdata/r/hcloud_firewall", fwRes,
+					"testdata/r/hcloud_firewall_attachment", fwAttRes,
+				),
+				ImportState: true,
+			},
 		},
 	})
 }
@@ -63,9 +73,10 @@ func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 
 	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
 	srvRes := &server.RData{
-		Name:  "test-server",
-		Type:  teste2e.TestServerType,
-		Image: teste2e.TestImage,
+		Name:       "test-server",
+		Type:       teste2e.TestServerType,
+		Image:      teste2e.TestImage,
+		Datacenter: teste2e.TestDataCenter,
 		Labels: map[string]string{
 			"firewall-attachment": "test-server",
 		},
@@ -95,6 +106,15 @@ func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 					testsupport.CheckResourceExists(fwRes.TFID(), firewall.ByID(t, &fw)),
 					testsupport.LiftTCF(hasLabelSelectorResource(t, &fw, "firewall-attachment=test-server")),
 				),
+			},
+			{
+				ResourceName: fwAttRes.TFID(),
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", srvRes,
+					"testdata/r/hcloud_firewall", fwRes,
+					"testdata/r/hcloud_firewall_attachment", fwAttRes,
+				),
+				ImportState: true,
 			},
 		},
 	})

--- a/templates/resources/firewall_attachment.md.tmpl
+++ b/templates/resources/firewall_attachment.md.tmpl
@@ -139,3 +139,9 @@ resource "hcloud_firewall_attachment" "allow_rules_att" {
 - `server_ids` (List) - List of Server IDs attached to the Firewall.
 - `label_selectors` (List) - List of label selectors attached to the
   Firewall.
+
+## Import
+
+Firewall Attachments can be imported using the `id` of the firewall:
+
+{{ codefile "shell" .ImportFile }}


### PR DESCRIPTION
This adds the functionality to import `hcloud_firewall_attachment` resources by specifying the firewall ID.