### PR TITLE
fix(load-balancer): mark health check retries as required

### DIFF
--- a/docs/resources/load_balancer_service.md
+++ b/docs/resources/load_balancer_service.md
@@ -67,7 +67,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `port` - (Required, int) Port the health check tries to connect to, required if protocol is `tcp`. Can be everything between `1` and `65535`. Must be unique per Load Balancer.
 - `interval` - (Required, int) Interval how often the health check will be performed, in seconds.
 - `timeout` - (Required, int) Timeout when a health check try will be canceled if there is no response, in seconds.
-- `retries` - (Optional, int) Number of tries a health check will be performed until a target will be listed as `unhealthy`.
+- `retries` - (Required, int) Number of tries a health check will be performed until a target will be listed as `unhealthy`.
 - `http` - (Optional, block) HTTP configuration. Required if `protocol` is `http`.
 
 (health check) `http` supports the following fields:

--- a/internal/loadbalancer/resource_service.go
+++ b/internal/loadbalancer/resource_service.go
@@ -135,8 +135,7 @@ func ServiceResource() *schema.Resource {
 						},
 						"retries": {
 							Type:     schema.TypeInt,
-							Optional: true,
-							Computed: true,
+							Required: true,
 						},
 						"http": {
 							Type:     schema.TypeList,

--- a/templates/resources/load_balancer_service.md.tmpl
+++ b/templates/resources/load_balancer_service.md.tmpl
@@ -36,7 +36,7 @@ Define services for Hetzner Cloud Load Balancers.
 - `port` - (Required, int) Port the health check tries to connect to, required if protocol is `tcp`. Can be everything between `1` and `65535`. Must be unique per Load Balancer.
 - `interval` - (Required, int) Interval how often the health check will be performed, in seconds.
 - `timeout` - (Required, int) Timeout when a health check try will be canceled if there is no response, in seconds.
-- `retries` - (Optional, int) Number of tries a health check will be performed until a target will be listed as `unhealthy`.
+- `retries` - (Required, int) Number of tries a health check will be performed until a target will be listed as `unhealthy`.
 - `http` - (Optional, block) HTTP configuration. Required if `protocol` is `http`.
 
 (health check) `http` supports the following fields:


### PR DESCRIPTION
They are required in the API spec, so should also be required in the provider.

Any existing configuration that does not specify the field should fail with API validation errors.

Closes #1162 