### PR TITLE
chore: add string utils

### DIFF
--- a/internal/util/strings.go
+++ b/internal/util/strings.go
@@ -1,0 +1,37 @@
+package util
+
+import (
+	"strings"
+)
+
+// Dedent is a helper function that dedent a tab indented text. The first line defines
+// the number of tabs to remove for the rest of the text.
+func Dedent(s string) string {
+	s = strings.TrimLeft(s, "\n")
+	s = strings.TrimRight(s, "\n\t")
+
+	lines := strings.Split(s, "\n")
+
+	var prefix string
+	for i, line := range lines {
+		if i == 0 {
+			lines[i] = strings.TrimLeft(line, "\t")
+			prefix = line[:len(line)-len(lines[i])]
+		} else {
+			lines[i] = strings.TrimPrefix(line, prefix)
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// MarkdownDescription is a helper function that transforms a Go friendly markdown text
+// into real markdown.
+//
+// - Dedent the description
+// - Replace 2 single quote with a backtick
+func MarkdownDescription(s string) string {
+	s = Dedent(s)
+	s = strings.ReplaceAll(s, "''", "`")
+	return s
+}

--- a/internal/util/strings_test.go
+++ b/internal/util/strings_test.go
@@ -1,0 +1,55 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDedent(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		given string
+		want  string
+	}{
+		{
+			desc:  "with indent",
+			given: "\thello\n\t\tworld",
+			want:  "hello\n\tworld",
+		},
+		{
+			desc:  "with negative indent",
+			given: "\thello\nworld",
+			want:  "hello\nworld",
+		},
+		{
+			desc:  "with extra new lines",
+			given: "\n\thello\n\t\tworld\n",
+			want:  "hello\n\tworld",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			require.Equal(t, testCase.want, Dedent(testCase.given))
+		})
+	}
+}
+
+func TestMarkdownDescription(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		given string
+		want  string
+	}{
+		{
+			desc:  "transform backticks",
+			given: "hello ''world''",
+			want:  "hello `world`",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			require.Equal(t, testCase.want, MarkdownDescription(testCase.given))
+		})
+	}
+}


### PR DESCRIPTION
Add 2 helper function to make writing markdown description easier within Golang.

