### PR TITLE
feat: attach load balancer to a specific network subnet

### DIFF
--- a/internal/loadbalancer/resource_network_test.go
+++ b/internal/loadbalancer/resource_network_test.go
@@ -358,3 +358,69 @@ func TestAccLoadBalancerNetworkResource_UpgradePluginFramework(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLoadBalancerNetworkResource_UpgradePluginFramework_WrongSubnetID(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	b := makeLoadBalancerNetworkBlueprint(t)
+
+	res := &loadbalancer.RDataNetwork{
+		Name:           "attachment",
+		LoadBalancerID: b.loadBalancer1.TFID() + ".id",
+		SubNetID:       b.subnet1.TFID() + ".id",
+	}
+	res.SetRName("attachment")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: teste2e.PreCheck(t),
+		Steps: []resource.TestStep{
+			{
+				ExternalProviders: map[string]resource.ExternalProvider{
+					"hcloud": {
+						VersionConstraint: "1.54.0",
+						Source:            "hetznercloud/hcloud",
+					},
+				},
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_network", b.network,
+					"testdata/r/hcloud_network_subnet", b.subnet1,
+					"testdata/r/hcloud_network_subnet", b.subnet2,
+					"testdata/r/hcloud_load_balancer", b.loadBalancer1,
+					"testdata/r/hcloud_load_balancer_network", res,
+				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(res.TFID(),
+						tfjsonpath.New("ip"),
+						knownvalue.StringExact("10.0.2.1")),
+				},
+			},
+			{
+				ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_network", b.network,
+					"testdata/r/hcloud_network_subnet", b.subnet1,
+					"testdata/r/hcloud_network_subnet", b.subnet2,
+					"testdata/r/hcloud_load_balancer", b.loadBalancer1,
+					"testdata/r/hcloud_load_balancer_network", res,
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(res.TFID(), plancheck.ResourceActionReplace),
+					},
+					PostApplyPreRefresh: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+						plancheck.ExpectKnownValue(res.TFID(),
+							tfjsonpath.New("ip"),
+							knownvalue.StringExact("10.0.1.1")),
+					},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(res.TFID(),
+						tfjsonpath.New("ip"),
+						knownvalue.StringExact("10.0.1.1")),
+				},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Allows the users to attach a load balancer to a given network subnet.

Using the subnet_id argument is preferred over the network_id argument.
