### PR TITLE
fix: abort when data transformation errors

### DIFF
--- a/internal/server/resource_network.go
+++ b/internal/server/resource_network.go
@@ -384,6 +384,11 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 
 		opts.AliasIPs = sliceutil.Transform(aliasIPsRaw, net.ParseIP)
 
+		// If data conversion failed we should abort before sending API requests.
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		action, _, err := r.client.Server.ChangeAliasIPs(ctx, server, opts)
 		if err != nil {
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)

--- a/internal/zone/resource.go
+++ b/internal/zone/resource.go
@@ -328,6 +328,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			})
 		}
 
+		// If data conversion failed we should abort before sending API requests.
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		action, _, err := r.client.Zone.ChangePrimaryNameservers(ctx, zone, opts)
 		if err != nil {
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -324,6 +324,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		hcItems, diags := values.ToAPI(ctx)
 		resp.Diagnostics.Append(diags...)
 
+		// If data conversion failed we should abort before sending API requests.
+		if resp.Diagnostics.HasError() {
+			return
+		}
+
 		action, _, err := r.client.Zone.SetRRSetRecords(ctx, rrset, hcloud.ZoneRRSetSetRecordsOpts{
 			Records: hcItems,
 		})


### PR DESCRIPTION
In the previous code any error diagnostics in the data transformation code for nested objects were not checked before making API calls with the faulty data. We are not aware of any current issues. This validation is just out of caution and protects against bugs we may introduce in the future.