### PR TITLE
fix: ensure partially created resources are tainted in the state

### DIFF
--- a/internal/loadbalancer/resource_network.go
+++ b/internal/loadbalancer/resource_network.go
@@ -276,6 +276,10 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return
 	}
+	// Make sure to save the ID immediately so we can recover if the process stops after
+	// this call. Terraform marks the resource as "tainted", so it can be deleted and no
+	// surprise "duplicate resource" errors happen.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(fmt.Sprintf("%d-%d", loadBalancer.ID, opts.Network.ID)))...)
 
 	// Refresh
 	loadBalancer, _, err = r.client.LoadBalancer.GetByID(ctx, loadBalancer.ID)

--- a/internal/server/resource_network.go
+++ b/internal/server/resource_network.go
@@ -278,6 +278,10 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return
 	}
+	// Make sure to save the ID immediately so we can recover if the process stops after
+	// this call. Terraform marks the resource as "tainted", so it can be deleted and no
+	// surprise "duplicate resource" errors happen.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(fmt.Sprintf("%d-%d", server.ID, opts.Network.ID)))...)
 
 	// Refresh server
 	server, _, err = r.client.Server.GetByID(ctx, server.ID)

--- a/internal/zone/resource.go
+++ b/internal/zone/resource.go
@@ -222,6 +222,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return
 	}
+	// Make sure to save the ID immediately so we can recover if the process stops after
+	// this call. Terraform marks the resource as "tainted", so it can be deleted and no
+	// surprise "duplicate resource" errors happen.
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), types.Int64Value(result.Zone.ID))...)
 
 	actions = append(actions, result.Action)
 

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
@@ -201,6 +202,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 			return
 		}
+		// Make sure to save the ID immediately so we can recover if the process stops after
+		// this call. Terraform marks the resource as "tainted", so it can be deleted and no
+		// surprise "duplicate resource" errors happen.
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), types.StringValue(result.RRSet.ID))...)
 	}
 
 	actions = append(actions, result.Action)


### PR DESCRIPTION
Make sure to save the ID immediately after the resource was created, so we can recover if the create process stops at a later stage. Terraform will mark the resource as "tainted" in the state, so it can be deleted and no surprise "duplicate resource" errors happen.