### PR TITLE
fix: dns records order is not guaranteed

### DIFF
--- a/docs/data-sources/zone_rrset.md
+++ b/docs/data-sources/zone_rrset.md
@@ -55,7 +55,7 @@ data "hcloud_zone_rrset" "by_label" {
 
 - `change_protection` (Boolean) Whether change protection is enabled.
 - `labels` (Map of String) User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.
-- `records` (Attributes List) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--records))
+- `records` (Attributes Set) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--records))
 - `ttl` (Number) Time To Live (TTL) of the Zone RRSet.
 
 <a id="nestedatt--records"></a>

--- a/docs/data-sources/zone_rrsets.md
+++ b/docs/data-sources/zone_rrsets.md
@@ -59,7 +59,7 @@ Read-Only:
 - `id` (String) ID of the Zone RRSet.
 - `labels` (Map of String) User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.
 - `name` (String) Name of the Zone RRSet.
-- `records` (Attributes List) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--rrsets--records))
+- `records` (Attributes Set) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--rrsets--records))
 - `ttl` (Number) Time To Live (TTL) of the Zone RRSet.
 - `type` (String) Type of the Zone RRSet.
 

--- a/docs/resources/zone_rrset.md
+++ b/docs/resources/zone_rrset.md
@@ -100,7 +100,7 @@ resource "hcloud_zone_rrset" "example_soa" {
 ### Required
 
 - `name` (String) Name of the Zone RRSet.
-- `records` (Attributes List) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--records))
+- `records` (Attributes Set) Records of the Zone RRSet. (see [below for nested schema](#nestedatt--records))
 - `type` (String) Type of the Zone RRSet.
 - `zone` (String) ID or Name of the parent Zone.
 

--- a/internal/zonerrset/data_source.go
+++ b/internal/zonerrset/data_source.go
@@ -55,7 +55,7 @@ func getCommonDataSourceSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "Whether change protection is enabled.",
 			Computed:            true,
 		},
-		"records": schema.ListNestedAttribute{
+		"records": schema.SetNestedAttribute{
 			MarkdownDescription: "Records of the Zone RRSet.",
 			Computed:            true,
 			NestedObject: schema.NestedAttributeObject{

--- a/internal/zonerrset/data_source_test.go
+++ b/internal/zonerrset/data_source_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
@@ -86,9 +89,6 @@ func TestAccZoneRRSetDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byNameAndType.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(byNameAndType.TFID(), "labels.key", resZoneRRSet.Labels["key"]),
 					resource.TestCheckResourceAttr(byNameAndType.TFID(), "ttl", "10800"),
-					resource.TestCheckResourceAttr(byNameAndType.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(byNameAndType.TFID(), "records.0.value", "201.42.91.35"),
-					resource.TestCheckResourceAttr(byNameAndType.TFID(), "records.1.value", "201.42.91.36"),
 					resource.TestCheckResourceAttr(byNameAndType.TFID(), "change_protection", "false"),
 
 					resource.TestCheckResourceAttr(byID.TFID(), "zone", resZone.Name),
@@ -97,9 +97,6 @@ func TestAccZoneRRSetDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byID.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(byID.TFID(), "labels.key", resZoneRRSet.Labels["key"]),
 					resource.TestCheckResourceAttr(byID.TFID(), "ttl", "10800"),
-					resource.TestCheckResourceAttr(byID.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(byID.TFID(), "records.0.value", "201.42.91.35"),
-					resource.TestCheckResourceAttr(byID.TFID(), "records.1.value", "201.42.91.36"),
 					resource.TestCheckResourceAttr(byID.TFID(), "change_protection", "false"),
 
 					resource.TestCheckResourceAttr(byLabel.TFID(), "zone", resZone.Name),
@@ -108,11 +105,48 @@ func TestAccZoneRRSetDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byLabel.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(byLabel.TFID(), "labels.key", resZoneRRSet.Labels["key"]),
 					resource.TestCheckResourceAttr(byLabel.TFID(), "ttl", "10800"),
-					resource.TestCheckResourceAttr(byLabel.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(byLabel.TFID(), "records.0.value", "201.42.91.35"),
-					resource.TestCheckResourceAttr(byLabel.TFID(), "records.1.value", "201.42.91.36"),
 					resource.TestCheckResourceAttr(byLabel.TFID(), "change_protection", "false"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(byNameAndType.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+
+					statecheck.ExpectKnownValue(byID.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+
+					statecheck.ExpectKnownValue(byLabel.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+				},
 			},
 		},
 	})

--- a/internal/zonerrset/model.go
+++ b/internal/zonerrset/model.go
@@ -21,7 +21,7 @@ type model struct {
 	TTL              types.Int32  `tfsdk:"ttl"`
 	Labels           types.Map    `tfsdk:"labels"`
 	ChangeProtection types.Bool   `tfsdk:"change_protection"`
-	Records          types.List   `tfsdk:"records"`
+	Records          types.Set    `tfsdk:"records"`
 }
 
 func (m *model) tfAttributesTypes() map[string]attr.Type {
@@ -33,7 +33,7 @@ func (m *model) tfAttributesTypes() map[string]attr.Type {
 		"ttl":               types.Int32Type,
 		"labels":            types.MapType{ElemType: types.StringType},
 		"change_protection": types.BoolType,
-		"records":           types.ListType{ElemType: (&modelRecord{}).tfType()},
+		"records":           types.SetType{ElemType: (&modelRecord{}).tfType()},
 	}
 }
 
@@ -131,9 +131,9 @@ func (m *modelRecord) FromTerraform(ctx context.Context, tf types.Object) diag.D
 type modelRecords []modelRecord
 
 var _ util.ModelFromAPI[[]hcloud.ZoneRRSetRecord] = &modelRecords{}
-var _ util.ModelFromTerraform[types.List] = &modelRecords{}
+var _ util.ModelFromTerraform[types.Set] = &modelRecords{}
 var _ util.ModelToAPI[[]hcloud.ZoneRRSetRecord] = &modelRecords{}
-var _ util.ModelToTerraform[types.List] = &modelRecords{}
+var _ util.ModelToTerraform[types.Set] = &modelRecords{}
 
 func (m *modelRecords) FromAPI(ctx context.Context, hcItems []hcloud.ZoneRRSetRecord) (diags diag.Diagnostics) {
 	*m = make([]modelRecord, 0, len(hcItems))
@@ -160,12 +160,12 @@ func (m *modelRecords) ToAPI(ctx context.Context) (hcItems []hcloud.ZoneRRSetRec
 
 }
 
-func (m *modelRecords) FromTerraform(ctx context.Context, tf types.List) diag.Diagnostics {
+func (m *modelRecords) FromTerraform(ctx context.Context, tf types.Set) diag.Diagnostics {
 	*m = make(modelRecords, 0, len(tf.Elements()))
 	return tf.ElementsAs(ctx, m, false)
 }
 
-func (m *modelRecords) ToTerraform(ctx context.Context) (tf types.List, diags diag.Diagnostics) {
+func (m *modelRecords) ToTerraform(ctx context.Context) (tf types.Set, diags diag.Diagnostics) {
 	tfItems := make([]attr.Value, 0, len(*m))
 	for _, value := range *m {
 		tfItem, newDiags := value.ToTerraform(ctx)
@@ -174,7 +174,7 @@ func (m *modelRecords) ToTerraform(ctx context.Context) (tf types.List, diags di
 		tfItems = append(tfItems, tfItem)
 	}
 
-	tf, newDiags := types.ListValue((&modelRecord{}).tfType(), tfItems)
+	tf, newDiags := types.SetValue((&modelRecord{}).tfType(), tfItems)
 	diags.Append(newDiags...)
 
 	return tf, diags

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -119,7 +119,7 @@ the parent Zone, therefor this Terraform resource will:
 			Optional:            true,
 			Computed:            true,
 		},
-		"records": schema.ListNestedAttribute{
+		"records": schema.SetNestedAttribute{
 			MarkdownDescription: "Records of the Zone RRSet.",
 			Required:            true,
 			NestedObject: schema.NestedAttributeObject{
@@ -134,8 +134,8 @@ the parent Zone, therefor this Terraform resource will:
 					},
 				},
 			},
-			Validators: []validator.List{
-				listvalidator.SizeAtLeast(1),
+			Validators: []validator.Set{
+				setvalidator.SizeAtLeast(1),
 			},
 		},
 	}

--- a/internal/zonerrset/resource_test.go
+++ b/internal/zonerrset/resource_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -84,13 +87,22 @@ func TestAccZoneRRSetResource(t *testing.T) {
 					resource.TestCheckResourceAttr(res1.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(res1.TFID(), "labels.key", "value"),
 					resource.TestCheckResourceAttr(res1.TFID(), "ttl", "10800"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", "201.42.91.35"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.value", "201.42.91.36"),
-					resource.TestCheckNoResourceAttr(res1.TFID(), "records.0.comment"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.comment", "some web server"),
 					resource.TestCheckResourceAttr(res1.TFID(), "change_protection", "true"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(res1.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("201.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+				},
 			},
 			{
 				ResourceName:      res1.TFID(),
@@ -110,13 +122,22 @@ func TestAccZoneRRSetResource(t *testing.T) {
 					resource.TestCheckResourceAttr(res1.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(res1.TFID(), "labels.key", "changed"),
 					resource.TestCheckResourceAttr(res1.TFID(), "ttl", "600"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", "42.42.91.35"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.value", "42.42.91.36"),
-					resource.TestCheckNoResourceAttr(res1.TFID(), "records.0.comment"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.comment", "some web server"),
 					resource.TestCheckResourceAttr(res1.TFID(), "change_protection", "false"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(res1.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("42.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("42.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+				},
 			},
 			{
 				Config: tmplMan.Render(t,
@@ -130,13 +151,22 @@ func TestAccZoneRRSetResource(t *testing.T) {
 					resource.TestCheckResourceAttr(res1.TFID(), "type", "A"),
 					resource.TestCheckResourceAttr(res1.TFID(), "labels.#", "0"),
 					resource.TestCheckNoResourceAttr(res1.TFID(), "ttl"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.#", "2"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", "42.42.91.35"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.value", "42.42.91.36"),
-					resource.TestCheckNoResourceAttr(res1.TFID(), "records.0.comment"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.1.comment", "some web server"),
 					resource.TestCheckResourceAttr(res1.TFID(), "change_protection", "false"),
 				),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(res1.TFID(),
+						tfjsonpath.New("records"),
+						knownvalue.SetExact([]knownvalue.Check{
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("42.42.91.35"),
+								"comment": knownvalue.Null(),
+							}),
+							knownvalue.ObjectExact(map[string]knownvalue.Check{
+								"value":   knownvalue.StringExact("42.42.91.36"),
+								"comment": knownvalue.StringExact("some web server"),
+							}),
+						})),
+				},
 			},
 		},
 	})


### PR DESCRIPTION
The order of records is not guaranteed by the API.