### PR TITLE
feat: drop builds for windows arm (32 bit)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,6 +30,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:


### PR DESCRIPTION
Stop building binaries for windows arm32.

Those targets are marked as broken in go 1.24: https://github.com/golang/go/blob/release-branch.go1.24/src/cmd/dist/build.go#L1826-L1830

And will be removed in go 1.26: https://github.com/golang/go/issues/71671