### PR TITLE
refactor: add function to wait for all actions to settle

### DIFF
--- a/internal/loadbalancer/resource_network.go
+++ b/internal/loadbalancer/resource_network.go
@@ -272,8 +272,8 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 			}
 		}
 	}
-	if err := r.client.Action.WaitFor(ctx, action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	// Make sure to save the ID immediately so we can recover if the process stops after
@@ -469,8 +469,8 @@ func (r *NetworkResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	if err := r.client.Action.WaitFor(ctx, action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -550,8 +550,8 @@ func (r *NetworkResource) setLoadBalancerPublicInterfaceEnabled(ctx context.Cont
 		diags.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return diags
 	}
-	if err = r.client.Action.WaitFor(ctx, action); err != nil {
-		diags.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	diags.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+	if diags.HasError() {
 		return diags
 	}
 

--- a/internal/server/resource_network.go
+++ b/internal/server/resource_network.go
@@ -274,8 +274,8 @@ func (r *NetworkResource) Create(ctx context.Context, req resource.CreateRequest
 			return
 		}
 	}
-	if err = r.client.Action.WaitFor(ctx, action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 	// Make sure to save the ID immediately so we can recover if the process stops after
@@ -398,8 +398,8 @@ func (r *NetworkResource) Update(ctx context.Context, req resource.UpdateRequest
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 			return
 		}
-		if err = r.client.Action.WaitFor(ctx, action); err != nil {
-			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+		resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+		if resp.Diagnostics.HasError() {
 			return
 		}
 	}
@@ -479,8 +479,8 @@ func (r *NetworkResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	if err = r.client.Action.WaitFor(ctx, action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }

--- a/internal/util/hcloudutil/actions.go
+++ b/internal/util/hcloudutil/actions.go
@@ -2,7 +2,9 @@ package hcloudutil
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -14,40 +16,48 @@ type ActionWaiter interface {
 	WaitForFunc(ctx context.Context, handleUpdate func(update *hcloud.Action) error, actions ...*hcloud.Action) error
 }
 
-func SettleActions(ctx context.Context, client ActionWaiter, actions ...*hcloud.Action) diag.Diagnostics {
-	var diags diag.Diagnostics
-
+func SettleActions(ctx context.Context, client ActionWaiter, actions ...*hcloud.Action) (diags diag.Diagnostics) {
+	runningActions := make([]*hcloud.Action, len(actions))
+	copy(runningActions, actions)
 	failedActions := make([]*hcloud.Action, 0)
 
+	// Make sure we always report failed actions, even if an API calls fails for other reasons and we return early
+	defer func() {
+		if len(failedActions) > 0 {
+			for _, action := range failedActions {
+				diags.Append(ActionErrorDiagnostic(action))
+			}
+		}
+	}()
+
 	err := client.WaitForFunc(ctx, func(update *hcloud.Action) error {
-		switch update.Status {
-		case hcloud.ActionStatusError:
-			failedActions = append(failedActions, update)
-		default:
-			// Do nothing
+		if update.Status == hcloud.ActionStatusSuccess || update.Status == hcloud.ActionStatusError {
+			// Remove from runningActions
+			runningActions = slices.DeleteFunc(runningActions, func(action *hcloud.Action) bool {
+				return action.ID == update.ID
+			})
+
+			if update.Status == hcloud.ActionStatusError {
+				failedActions = append(failedActions, update)
+			}
 		}
 
 		return nil
 	}, actions...)
 	if err != nil {
-		return APIErrorDiagnostics(err)
-	}
-
-	if len(failedActions) > 0 {
-		for _, action := range failedActions {
-			diags.Append(ActionErrorDiagnostic(action))
+		if (errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) && len(runningActions) > 0 {
+			diags.Append(ActionWaitTimeoutDiagnostic(runningActions...))
+			return
 		}
+
+		diags.Append(APIErrorDiagnostics(err)...)
+		return
 	}
 
-	return diags
+	return
 }
 
 func ActionErrorDiagnostic(action *hcloud.Action) diag.Diagnostic {
-	resources := make([]string, 0, len(action.Resources))
-	for _, resource := range action.Resources {
-		resources = append(resources, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
-	}
-
 	return diag.NewErrorDiagnostic("Action failed", fmt.Sprintf(
 		"An API action for the resource failed.\n\n"+
 			"%s\n\n"+
@@ -55,6 +65,27 @@ func ActionErrorDiagnostic(action *hcloud.Action) diag.Diagnostic {
 			"Command: %s\n"+
 			"ID: %d\n"+
 			"Resources: %s\n",
-		action.ErrorMessage, action.ErrorCode, action.Command, action.ID, strings.Join(resources, ", "),
+		action.ErrorMessage, action.ErrorCode, action.Command, action.ID, actionResourceDescription(action),
 	))
+}
+
+func ActionWaitTimeoutDiagnostic(actions ...*hcloud.Action) diag.Diagnostic {
+	descriptions := make([]string, 0, len(actions))
+	for _, action := range actions {
+		descriptions = append(descriptions, fmt.Sprintf("- Command: %s | ID: %d | Progress: %d%% | Resources: %s", action.Command, action.ID, action.Progress, actionResourceDescription(action)))
+	}
+
+	return diag.NewErrorDiagnostic(
+		"Timeout while waiting on action(s)",
+		fmt.Sprintf("The request was cancelled while we were waiting on actions to complete.\n\n"+
+			"Actions that are still running:\n%s\n", strings.Join(descriptions, "\n")))
+}
+
+func actionResourceDescription(action *hcloud.Action) string {
+	resources := make([]string, 0, len(action.Resources))
+	for _, resource := range action.Resources {
+		resources = append(resources, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
+	}
+
+	return strings.Join(resources, ", ")
 }

--- a/internal/util/hcloudutil/actions.go
+++ b/internal/util/hcloudutil/actions.go
@@ -1,0 +1,60 @@
+package hcloudutil
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+type ActionWaiter interface {
+	WaitForFunc(ctx context.Context, handleUpdate func(update *hcloud.Action) error, actions ...*hcloud.Action) error
+}
+
+func SettleActions(ctx context.Context, client ActionWaiter, actions ...*hcloud.Action) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	failedActions := make([]*hcloud.Action, 0)
+
+	err := client.WaitForFunc(ctx, func(update *hcloud.Action) error {
+		switch update.Status {
+		case hcloud.ActionStatusError:
+			failedActions = append(failedActions, update)
+		default:
+			// Do nothing
+		}
+
+		return nil
+	}, actions...)
+	if err != nil {
+		return APIErrorDiagnostics(err)
+	}
+
+	if len(failedActions) > 0 {
+		for _, action := range failedActions {
+			diags.Append(ActionErrorDiagnostic(action))
+		}
+	}
+
+	return diags
+}
+
+func ActionErrorDiagnostic(action *hcloud.Action) diag.Diagnostic {
+	resources := make([]string, 0, len(action.Resources))
+	for _, resource := range action.Resources {
+		resources = append(resources, fmt.Sprintf("%s: %d", resource.Type, resource.ID))
+	}
+
+	return diag.NewErrorDiagnostic("Action failed", fmt.Sprintf(
+		"An API action for the resource failed.\n\n"+
+			"%s\n\n"+
+			"Error code: %s\n"+
+			"Command: %s\n"+
+			"ID: %d\n"+
+			"Resources: %s\n",
+		action.ErrorMessage, action.ErrorCode, action.Command, action.ID, strings.Join(resources, ", "),
+	))
+}

--- a/internal/util/hcloudutil/actions_test.go
+++ b/internal/util/hcloudutil/actions_test.go
@@ -1,0 +1,164 @@
+package hcloudutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+type mockActionWaiter struct {
+	t       *testing.T
+	err     error
+	actions []*hcloud.Action
+}
+
+func (a *mockActionWaiter) WaitForFunc(_ context.Context, handleUpdate func(update *hcloud.Action) error, actions ...*hcloud.Action) error {
+	require.Equal(a.t, a.actions, actions)
+
+	if a.err != nil {
+		return a.err
+	}
+
+	for _, action := range a.actions {
+		require.NoError(a.t, handleUpdate(action))
+	}
+
+	return nil
+}
+
+func TestSettleActions(t *testing.T) {
+	failedAction1 := &hcloud.Action{
+		ID:           1337,
+		Status:       hcloud.ActionStatusError,
+		Command:      "do_thing",
+		ErrorCode:    "failed_thing",
+		ErrorMessage: "Thing failed",
+	}
+
+	failedAction2 := &hcloud.Action{
+		ID:           1338,
+		Status:       hcloud.ActionStatusError,
+		Command:      "create_server",
+		ErrorCode:    "spooky_error",
+		ErrorMessage: "Something spooky happened",
+	}
+
+	successAction1 := &hcloud.Action{
+		ID:      1,
+		Status:  hcloud.ActionStatusSuccess,
+		Command: "delete_server",
+	}
+
+	successAction2 := &hcloud.Action{
+		ID:      2,
+		Status:  hcloud.ActionStatusSuccess,
+		Command: "delete_server",
+	}
+
+	for _, tc := range []struct {
+		name     string
+		mock     *mockActionWaiter
+		expected diag.Diagnostics
+	}{
+		{
+			name: "success when all actions are successful",
+			mock: &mockActionWaiter{
+				actions: []*hcloud.Action{successAction1, successAction2},
+			},
+			expected: nil,
+		},
+		{
+			name: "API Error Diagnostics when ActionClient.WaitForFunc fails",
+			mock: &mockActionWaiter{
+				actions: []*hcloud.Action{successAction1, successAction2},
+				err:     hcloud.Error{Code: "server_error", Details: "Internal server error"},
+			},
+			expected: APIErrorDiagnostics(hcloud.Error{Code: "server_error", Details: "Internal server error"}),
+		},
+		{
+			name: "complete diagnostics with failed actions",
+			mock: &mockActionWaiter{
+				actions: []*hcloud.Action{failedAction1, successAction1, failedAction2, successAction2},
+			},
+			expected: diag.Diagnostics{ActionErrorDiagnostic(failedAction1), ActionErrorDiagnostic(failedAction2)},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.mock.t = t
+			diags := SettleActions(t.Context(), tc.mock, tc.mock.actions...)
+
+			assert.Equal(t, tc.expected, diags)
+		})
+	}
+}
+
+func TestActionErrorDiagnostic(t *testing.T) {
+	for _, testCase := range []struct {
+		name     string
+		action   *hcloud.Action
+		expected diag.Diagnostic
+	}{
+		{
+			name: "action with single resource",
+			action: &hcloud.Action{
+				ID:           int64(1337),
+				Status:       hcloud.ActionStatusError,
+				Command:      "create_server",
+				ErrorCode:    "spooky_error",
+				ErrorMessage: "Something spooky happened",
+				Resources: []*hcloud.ActionResource{
+					{
+						ID:   int64(42),
+						Type: hcloud.ActionResourceTypeServer,
+					},
+				},
+			},
+			expected: diag.NewErrorDiagnostic("Action failed", `An API action for the resource failed.
+
+Something spooky happened
+
+Error code: spooky_error
+Command: create_server
+ID: 1337
+Resources: server: 42
+`),
+		},
+		{
+			name: "action with multiple resources",
+			action: &hcloud.Action{
+				ID:           int64(1338),
+				Status:       hcloud.ActionStatusError,
+				Command:      "attach_floating_ip",
+				ErrorCode:    "server_error",
+				ErrorMessage: "Unexpected server error",
+				Resources: []*hcloud.ActionResource{
+					{
+						ID:   int64(42),
+						Type: hcloud.ActionResourceTypeServer,
+					}, {
+						ID:   int64(7),
+						Type: hcloud.ActionResourceTypeFloatingIP,
+					},
+				},
+			},
+			expected: diag.NewErrorDiagnostic("Action failed", `An API action for the resource failed.
+
+Unexpected server error
+
+Error code: server_error
+Command: attach_floating_ip
+ID: 1338
+Resources: server: 42, floating_ip: 7
+`),
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, ActionErrorDiagnostic(testCase.action))
+		})
+	}
+}

--- a/internal/zone/resource.go
+++ b/internal/zone/resource.go
@@ -241,8 +241,8 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		actions = append(actions, action)
 	}
 
-	if err := r.client.Action.WaitFor(ctx, actions...); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, actions...)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -358,8 +358,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		actions = append(actions, action)
 	}
 
-	if err := r.client.Action.WaitFor(ctx, actions...); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, actions...)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -407,8 +407,8 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		return
 	}
 
-	if err := r.client.Action.WaitFor(ctx, result.Action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, result.Action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 }

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -223,8 +223,8 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		actions = append(actions, action)
 	}
 
-	if err := r.client.Action.WaitFor(ctx, actions...); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, actions...)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -300,10 +300,11 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			return
 		}
 
-		if err := r.client.Action.WaitFor(ctx, action); err != nil {
-			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+		resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+		if resp.Diagnostics.HasError() {
 			return
 		}
+
 	}
 
 	actions := make([]*hcloud.Action, 0)
@@ -346,8 +347,8 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		actions = append(actions, action)
 	}
 
-	if err := r.client.Action.WaitFor(ctx, actions...); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, actions...)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -426,10 +427,11 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 		return
 	}
 
-	if err := r.client.Action.WaitFor(ctx, result.Action); err != nil {
-		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+	resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, result.Action)...)
+	if resp.Diagnostics.HasError() {
 		return
 	}
+
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {


### PR DESCRIPTION
Adds a new `hcloudutil.SettleActions()` helper that uses `ActionClient.WaitForFunc` to wait until all actions have failed or completed.

Any actions that have failed are then presented as nice error diagnostics, similar to how we already do it with synchronous API errors.

If the error returned from `ActionClient.WaitForFunc` matches a cancelled context, we log the actions that we are still waiting for.

I refactored all framework resources to use this. As its is using the framework `diag.Diagnostics` type, it is not easily compatible with SDKv2 resources.
