### PR TITLE
test(server): improve test coverage 

### DIFF
--- a/internal/server/resource_network_test.go
+++ b/internal/server/resource_network_test.go
@@ -21,6 +21,11 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
+// Need new tests for:
+// - Any updates
+// - Alias IPs
+// - ErrorCodeServerAlreadyAttached
+
 type ServerNetworkBlueprint struct {
 	network *network.RData
 	subnet1 *network.RDataSubnet

--- a/internal/server/resource_network_test.go
+++ b/internal/server/resource_network_test.go
@@ -21,11 +21,6 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
 
-// Need new tests for:
-// - Any updates
-// - Alias IPs
-// - ErrorCodeServerAlreadyAttached
-
 type ServerNetworkBlueprint struct {
 	network *network.RData
 	subnet1 *network.RDataSubnet

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -103,6 +103,20 @@ func TestAccServerResource(t *testing.T) {
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "backups", "true"),
 				),
 			},
+			{
+				// Revert the server to the original state to test the other direction for various options
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "name", fmt.Sprintf("server-basic--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "server_type", res.Type),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "image", res.Image),
+					resource.TestCheckNoResourceAttr(resRenamed.TFID(), "labels.foo"),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "backups", "false"),
+				),
+			},
 		},
 	})
 }

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -27,13 +27,13 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
 )
 
-// Need new tests for:
-// - Primary IP Migrations (to and from explicit resources)
-
 func TestAccServerResource(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-basic")
+
 	res := &server.RData{
 		Name:                   "server-basic",
 		Type:                   teste2e.TestServerType,
@@ -42,17 +42,18 @@ func TestAccServerResource(t *testing.T) {
 		ShutdownBeforeDeletion: true,
 	}
 	res.SetRName("server-basic")
+
 	resRenamed := &server.RData{
 		Name:                   res.Name + "-renamed",
 		Type:                   res.Type,
-		Image:                  res.Image, // TODO: Other Image => new test?
+		Image:                  res.Image,
 		SSHKeys:                res.SSHKeys,
 		ShutdownBeforeDeletion: res.ShutdownBeforeDeletion,
 		Labels:                 map[string]string{"foo": "bar"},
 		Backups:                true,
 	}
 	resRenamed.SetRName(res.Name)
-	tmplMan := testtemplate.Manager{}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -187,9 +188,12 @@ func TestAccServerResource_ImageID(t *testing.T) {
 }
 
 func TestAccServerResource_Resize(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-resize")
+
 	res := &server.RData{
 		Name:    "server-resize",
 		Type:    teste2e.TestServerType,
@@ -197,6 +201,7 @@ func TestAccServerResource_Resize(t *testing.T) {
 		SSHKeys: []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-resize")
+
 	resResized := &server.RData{
 		Name:     res.Name,
 		Type:     teste2e.TestServerTypeUpgrade,
@@ -205,7 +210,7 @@ func TestAccServerResource_Resize(t *testing.T) {
 		SSHKeys:  res.SSHKeys,
 	}
 	resResized.SetRName(res.Name)
-	tmplMan := testtemplate.Manager{}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -243,9 +248,12 @@ func TestAccServerResource_Resize(t *testing.T) {
 }
 
 func TestAccServerResource_ChangeUserData(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var s, s2 hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-userdata")
+
 	res := &server.RData{
 		Name:     "server-userdata",
 		Type:     teste2e.TestServerType,
@@ -254,9 +262,15 @@ func TestAccServerResource_ChangeUserData(t *testing.T) {
 		SSHKeys:  []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-userdata")
-	resChangedUserdata := &server.RData{Name: res.Name, Type: res.Type, Image: res.Image, UserData: "updated stuff"}
+
+	resChangedUserdata := &server.RData{
+		Name:     res.Name,
+		Type:     res.Type,
+		Image:    res.Image,
+		UserData: "updated stuff",
+	}
 	resChangedUserdata.SetRName(res.Name)
-	tmplMan := testtemplate.Manager{}
+
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -298,9 +312,12 @@ func TestAccServerResource_ChangeUserData(t *testing.T) {
 }
 
 func TestAccServerResource_ISO(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-iso")
+
 	res := &server.RData{
 		Name:     "server-iso",
 		Type:     teste2e.TestServerType,
@@ -321,7 +338,6 @@ func TestAccServerResource_ISO(t *testing.T) {
 	}
 	resUpdatedISO.SetRName(res.RName())
 
-	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -364,9 +380,12 @@ func TestAccServerResource_ISO(t *testing.T) {
 }
 
 func TestAccServerResource_Rescue(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-rescue")
+
 	res := &server.RData{
 		Name:    "server-rescue",
 		Type:    teste2e.TestServerType,
@@ -374,6 +393,7 @@ func TestAccServerResource_Rescue(t *testing.T) {
 		SSHKeys: []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-rescue")
+
 	resRescue := &server.RData{
 		Name:    res.Name,
 		Type:    res.Type,
@@ -383,7 +403,6 @@ func TestAccServerResource_Rescue(t *testing.T) {
 	}
 	resRescue.SetRName(res.RName())
 
-	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -427,6 +446,8 @@ func TestAccServerResource_Rescue(t *testing.T) {
 }
 
 func TestAccServerResource_DirectAttachToNetwork(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var (
 		nw  hcloud.Network
 		nw2 hcloud.Network
@@ -534,7 +555,6 @@ func TestAccServerResource_DirectAttachToNetwork(t *testing.T) {
 	}
 	sResWithTwoNets.SetRName(sResWithTwoNets.Name)
 
-	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
 		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
@@ -1148,6 +1168,8 @@ func TestAccServerResource_Firewalls(t *testing.T) {
 }
 
 func TestAccServerResource_PlacementGroup(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var (
 		pg  hcloud.PlacementGroup
 		srv hcloud.Server
@@ -1169,8 +1191,6 @@ func TestAccServerResource_PlacementGroup(t *testing.T) {
 		Image: srvRes.Image,
 	}
 	srvResNoPG.SetRName("server-placement-group")
-
-	tmplMan := testtemplate.Manager{}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
@@ -1251,6 +1271,8 @@ func TestAccServerResource_PlacementGroup(t *testing.T) {
 }
 
 func TestAccServerResource_Protection(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	var (
 		srv hcloud.Server
 
@@ -1269,8 +1291,6 @@ func TestAccServerResource_Protection(t *testing.T) {
 		RebuildProtection: true,
 	}
 	srvRes.SetRName("server-protection")
-
-	tmplMan := testtemplate.Manager{}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
@@ -1308,6 +1328,8 @@ func TestAccServerResource_Protection(t *testing.T) {
 }
 
 func TestAccServerResource_EmptySSHKey(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
 	// Regression Test for https://github.com/hetznercloud/terraform-provider-hcloud/issues/727
 	var srv hcloud.Server
 
@@ -1318,8 +1340,6 @@ func TestAccServerResource_EmptySSHKey(t *testing.T) {
 		SSHKeys: []string{"\"\""},
 	}
 	srvRes.SetRName("server-empty-ssh-key")
-
-	tmplMan := testtemplate.Manager{}
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -97,6 +97,11 @@ func TestAccServerResource(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resRenamed,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resRenamed.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "name", fmt.Sprintf("server-basic-renamed--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "server_type", resRenamed.Type),
@@ -111,6 +116,11 @@ func TestAccServerResource(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", res,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(res.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "name", fmt.Sprintf("server-basic--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(resRenamed.TFID(), "server_type", res.Type),
@@ -237,6 +247,11 @@ func TestAccServerResource_Resize(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resResized,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resResized.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resResized.TFID(), "name", fmt.Sprintf("server-resize--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(resResized.TFID(), "server_type", resResized.Type),
@@ -298,6 +313,11 @@ func TestAccServerResource_ChangeUserData(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resChangedUserdata,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resChangedUserdata.TFID(), plancheck.ResourceActionReplace),
+					},
+				},
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s2)),
 					resource.TestCheckResourceAttr(resChangedUserdata.TFID(), "name", fmt.Sprintf("server-userdata--%d", tmplMan.RandInt)),
@@ -425,6 +445,11 @@ func TestAccServerResource_Rescue(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", res,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(res.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "rescue", ""),
@@ -436,6 +461,11 @@ func TestAccServerResource_Rescue(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resRescue,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(resRescue.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "rescue", resRescue.Rescue),
@@ -1147,13 +1177,16 @@ func TestAccServerResource_Firewalls(t *testing.T) {
 				),
 			},
 			{
-				// Create a new Server using the required values
-				// only.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_firewall", fw,
 					"testdata/r/hcloud_firewall", fw2,
 					"testdata/r/hcloud_server", res2,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(res2.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "name",
@@ -1248,6 +1281,11 @@ func TestAccServerResource_PlacementGroup(t *testing.T) {
 					"testdata/r/hcloud_placement_group", pgRes,
 					"testdata/r/hcloud_server", srvResNoPG,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(srvResNoPG.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(srvResNoPG.TFID(), "status", "off"),
 					resource.TestCheckResourceAttr(srvResNoPG.TFID(), "placement_group_id", "0"),
@@ -1259,6 +1297,11 @@ func TestAccServerResource_PlacementGroup(t *testing.T) {
 					"testdata/r/hcloud_placement_group", pgRes,
 					"testdata/r/hcloud_server", srvRes,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(srvRes.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(srvResNoPG.TFID(), "status", "running"),
 					testsupport.CheckResourceAttrFunc(srvRes.TFID(), "placement_group_id", func() string {

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -28,26 +28,27 @@ import (
 
 // Need new tests for:
 // - Primary IP Migrations (to and from explicit resources)
-// - Delete with `shutdown_before_deletion`
 
 func TestAccServerResource(t *testing.T) {
 	var s hcloud.Server
 
 	sk := sshkey.NewRData(t, "server-basic")
 	res := &server.RData{
-		Name:    "server-basic",
-		Type:    teste2e.TestServerType,
-		Image:   teste2e.TestImage,
-		SSHKeys: []string{sk.TFID() + ".id"},
+		Name:                   "server-basic",
+		Type:                   teste2e.TestServerType,
+		Image:                  teste2e.TestImage,
+		SSHKeys:                []string{sk.TFID() + ".id"},
+		ShutdownBeforeDeletion: true,
 	}
 	res.SetRName("server-basic")
 	resRenamed := &server.RData{
-		Name:    res.Name + "-renamed",
-		Type:    res.Type,
-		Image:   res.Image, // TODO: Other Image => new test?
-		SSHKeys: []string{sk.TFID() + ".id"},
-		Labels:  map[string]string{"foo": "bar"},
-		Backups: true,
+		Name:                   res.Name + "-renamed",
+		Type:                   res.Type,
+		Image:                  res.Image, // TODO: Other Image => new test?
+		SSHKeys:                res.SSHKeys,
+		ShutdownBeforeDeletion: res.ShutdownBeforeDeletion,
+		Labels:                 map[string]string{"foo": "bar"},
+		Backups:                true,
 	}
 	resRenamed.SetRName(res.Name)
 	tmplMan := testtemplate.Manager{}

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -309,12 +310,14 @@ func TestAccServerResource_ISO(t *testing.T) {
 		SSHKeys:  []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-iso")
+
 	resUpdatedISO := &server.RData{
-		Name:    res.Name,
-		Type:    res.Type,
-		Image:   res.Image,
-		ISO:     "8638", // Windows Server 2022 German
-		SSHKeys: res.SSHKeys,
+		Name:     res.Name,
+		Type:     res.Type,
+		Image:    res.Image,
+		UserData: res.UserData,
+		ISO:      "8638", // Windows Server 2022 German
+		SSHKeys:  res.SSHKeys,
 	}
 	resUpdatedISO.SetRName(res.RName())
 
@@ -346,6 +349,11 @@ func TestAccServerResource_ISO(t *testing.T) {
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resUpdatedISO,
 				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(res.TFID(), plancheck.ResourceActionUpdate),
+					},
+				},
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "iso", resUpdatedISO.ISO),

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 // Need new tests for:
-// - Setting & Updating rescue system
 // - Primary IP Migrations (to and from explicit resources)
 // - Delete with `shutdown_before_deletion`
 
@@ -335,6 +334,69 @@ func TestAccServerResource_ISO(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
 					resource.TestCheckResourceAttr(res.TFID(), "iso", resUpdatedISO.ISO),
+				),
+			},
+		},
+	})
+}
+
+func TestAccServerResource_Rescue(t *testing.T) {
+	var s hcloud.Server
+
+	sk := sshkey.NewRData(t, "server-rescue")
+	res := &server.RData{
+		Name:    "server-rescue",
+		Type:    teste2e.TestServerType,
+		Image:   teste2e.TestImage,
+		SSHKeys: []string{sk.TFID() + ".id"},
+	}
+	res.SetRName("server-rescue")
+	resRescue := &server.RData{
+		Name:    res.Name,
+		Type:    res.Type,
+		Image:   res.Image,
+		SSHKeys: res.SSHKeys,
+		Rescue:  string(hcloud.ServerRescueTypeLinux64),
+	}
+	resRescue.SetRName(res.RName())
+
+	tmplMan := testtemplate.Manager{}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &s)),
+		Steps: []resource.TestStep{
+			{
+				// Create a new Server with rescue.
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", resRescue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(resRescue.TFID(), server.ByID(t, &s)),
+					resource.TestCheckResourceAttr(resRescue.TFID(), "rescue", resRescue.Rescue),
+				),
+			},
+			{
+				// Disable server rescue.
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", res,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
+					resource.TestCheckResourceAttr(res.TFID(), "rescue", ""),
+				),
+			},
+			{
+				// Enable rescue on existing server.
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", resRescue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
+					resource.TestCheckResourceAttr(res.TFID(), "rescue", resRescue.Rescue),
 				),
 			},
 		},

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
 )
 
+// Need new tests for:
+// - Setting & Updating rescue system
+// - Primary IP Migrations (to and from explicit resources)
+// - Delete with `shutdown_before_deletion`
+
 func TestAccServerResource(t *testing.T) {
 	var s hcloud.Server
 
@@ -37,7 +42,14 @@ func TestAccServerResource(t *testing.T) {
 		SSHKeys: []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-basic")
-	resRenamed := &server.RData{Name: res.Name + "-renamed", Type: res.Type, Image: res.Image}
+	resRenamed := &server.RData{
+		Name:    res.Name + "-renamed",
+		Type:    res.Type,
+		Image:   res.Image, // TODO: Other Image => new test?
+		SSHKeys: []string{sk.TFID() + ".id"},
+		Labels:  map[string]string{"foo": "bar"},
+		Backups: true,
+	}
 	resRenamed.SetRName(res.Name)
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
@@ -46,18 +58,25 @@ func TestAccServerResource(t *testing.T) {
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &s)),
 		Steps: []resource.TestStep{
 			{
-				// Create a new Server using the required values
-				// only.
+				// Create a new Server using the required values only.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", res,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
-					resource.TestCheckResourceAttr(res.TFID(), "name",
-						fmt.Sprintf("server-basic--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(res.TFID(), "name", fmt.Sprintf("server-basic--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(res.TFID(), "server_type", res.Type),
 					resource.TestCheckResourceAttr(res.TFID(), "image", res.Image),
+					resource.TestCheckResourceAttrSet(res.TFID(), "location"),
+					resource.TestCheckResourceAttrSet(res.TFID(), "datacenter"),
+					resource.TestCheckResourceAttrPair(sk.TFID(), "id", res.TFID(), "ssh_keys.0"),
+					resource.TestCheckResourceAttrSet(res.TFID(), "ipv4_address"),
+					resource.TestCheckResourceAttrSet(res.TFID(), "ipv6_address"),
+					resource.TestCheckResourceAttrSet(res.TFID(), "ipv6_network"),
+					resource.TestCheckResourceAttr(res.TFID(), "status", string(hcloud.ServerStatusRunning)),
+					resource.TestCheckResourceAttrSet(res.TFID(), "primary_disk_size"),
+					resource.TestCheckResourceAttr(res.TFID(), "placement_group_id", "0"),
 				),
 			},
 			{
@@ -73,13 +92,15 @@ func TestAccServerResource(t *testing.T) {
 				// Update the Server created in the previous step by
 				// setting all optional fields and renaming the Server.
 				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
 					"testdata/r/hcloud_server", resRenamed,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resRenamed.TFID(), "name",
-						fmt.Sprintf("server-basic-renamed--%d", tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(resRenamed.TFID(), "server_type", res.Type),
-					resource.TestCheckResourceAttr(resRenamed.TFID(), "image", res.Image),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "name", fmt.Sprintf("server-basic-renamed--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "server_type", resRenamed.Type),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "image", resRenamed.Image),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "labels.foo", "bar"),
+					resource.TestCheckResourceAttr(resRenamed.TFID(), "backups", "true"),
 				),
 			},
 		},
@@ -274,6 +295,15 @@ func TestAccServerResource_ISO(t *testing.T) {
 		SSHKeys:  []string{sk.TFID() + ".id"},
 	}
 	res.SetRName("server-iso")
+	resUpdatedISO := &server.RData{
+		Name:    res.Name,
+		Type:    res.Type,
+		Image:   res.Image,
+		ISO:     "8638", // Windows Server 2022 German
+		SSHKeys: res.SSHKeys,
+	}
+	resUpdatedISO.SetRName(res.RName())
+
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
@@ -294,6 +324,17 @@ func TestAccServerResource_ISO(t *testing.T) {
 					resource.TestCheckResourceAttr(res.TFID(), "server_type", res.Type),
 					resource.TestCheckResourceAttr(res.TFID(), "image", res.Image),
 					resource.TestCheckResourceAttr(res.TFID(), "iso", res.ISO),
+				),
+			},
+			{
+				// Update ISO
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_ssh_key", sk,
+					"testdata/r/hcloud_server", resUpdatedISO,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(res.TFID(), server.ByID(t, &s)),
+					resource.TestCheckResourceAttr(res.TFID(), "iso", resUpdatedISO.ISO),
 				),
 			},
 		},

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -90,26 +90,27 @@ func (d *DDataList) TFID() string {
 type RData struct {
 	testtemplate.DataCommon
 
-	Name                  string
-	Type                  string
-	Image                 string
-	LocationName          string
-	Datacenter            string
-	PublicNet             map[string]interface{}
-	SSHKeys               []string
-	KeepDisk              bool
-	Rescue                string
-	Backups               bool
-	ISO                   string
-	Labels                map[string]string
-	UserData              string
-	Networks              []RDataInlineNetwork
-	FirewallIDs           []string
-	DependsOn             []string
-	PlacementGroupID      string
-	DeleteProtection      bool
-	RebuildProtection     bool
-	AllowDeprecatedImages bool
+	Name                   string
+	Type                   string
+	Image                  string
+	LocationName           string
+	Datacenter             string
+	PublicNet              map[string]interface{}
+	SSHKeys                []string
+	KeepDisk               bool
+	Rescue                 string
+	Backups                bool
+	ISO                    string
+	Labels                 map[string]string
+	UserData               string
+	Networks               []RDataInlineNetwork
+	FirewallIDs            []string
+	DependsOn              []string
+	PlacementGroupID       string
+	DeleteProtection       bool
+	RebuildProtection      bool
+	AllowDeprecatedImages  bool
+	ShutdownBeforeDeletion bool
 }
 
 // RDataInlineNetwork defines the information required to attach a server

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -98,7 +98,7 @@ type RData struct {
 	PublicNet             map[string]interface{}
 	SSHKeys               []string
 	KeepDisk              bool
-	Rescue                bool
+	Rescue                string
 	Backups               bool
 	ISO                   string
 	Labels                map[string]string

--- a/internal/testdata/r/hcloud_server.tf.tmpl
+++ b/internal/testdata/r/hcloud_server.tf.tmpl
@@ -26,7 +26,7 @@ resource "hcloud_server" "{{ .RName }}" {
   iso         = {{ .ISO }}
   {{ end }}
   {{- if .Rescue }}
-  rescue      = {{ .Rescue }}
+  rescue      = "{{ .Rescue }}"
   {{ end }}
   {{- if .Backups }}
   backups     = {{ .Backups }}

--- a/internal/testdata/r/hcloud_server.tf.tmpl
+++ b/internal/testdata/r/hcloud_server.tf.tmpl
@@ -90,4 +90,8 @@ EOF
   {{- if .RebuildProtection }}
   rebuild_protection = {{ .RebuildProtection }}
   {{ end }}
+
+  {{- if .ShutdownBeforeDeletion }}
+  shutdown_before_deletion = {{ .ShutdownBeforeDeletion }}
+  {{ end }}
 }

--- a/internal/testsupport/client.go
+++ b/internal/testsupport/client.go
@@ -2,6 +2,7 @@ package testsupport
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
@@ -15,6 +16,8 @@ func CreateClient() (*hcloud.Client, error) {
 	}
 	opts := []hcloud.ClientOption{
 		hcloud.WithToken(os.Getenv("HCLOUD_TOKEN")),
+		hcloud.WithApplication("hcloud-terraform", "testing"),
+		hcloud.WithDebugWriter(log.Writer()),
 	}
 
 	if value := os.Getenv("HCLOUD_ENDPOINT"); value != "" {


### PR DESCRIPTION
Increase the test coverage of the server module.

This is a small step towards migrating to the plugin framework, but because of the complexity of this module, we want to make sure it does not break during the migration.