### PR TITLE
refactor: add common labels schema for datasources

### DIFF
--- a/internal/sshkey/data_source.go
+++ b/internal/sshkey/data_source.go
@@ -66,11 +66,7 @@ func getCommonDataSourceSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "Public key of the SSH Key pair.",
 			Computed:            true,
 		},
-		"labels": schema.MapAttribute{
-			MarkdownDescription: "User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.",
-			ElementType:         types.StringType,
-			Computed:            true,
-		},
+		"labels": datasourceutil.LabelsSchema(),
 	}
 }
 

--- a/internal/util/datasourceutil/labels.go
+++ b/internal/util/datasourceutil/labels.go
@@ -3,7 +3,9 @@ package datasourceutil
 import (
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // GetOneResultForLabelSelector verifies that only one item is returned for a label selector. If none or >1 are returned
@@ -30,4 +32,13 @@ func GetOneResultForLabelSelector[T any](resourceName string, items []*T, labelS
 	}
 
 	return items[0], nil
+}
+
+// LabelsSchema returns a map attribute schema for the labels field shared by multiple data sources.
+func LabelsSchema() schema.MapAttribute {
+	return schema.MapAttribute{
+		MarkdownDescription: "User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.",
+		Computed:            true,
+		ElementType:         types.StringType,
+	}
 }

--- a/internal/zone/data_source.go
+++ b/internal/zone/data_source.go
@@ -39,11 +39,7 @@ func getCommonDataSourceSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "Default Time To Live (TTL) of the Zone.",
 			Computed:            true,
 		},
-		"labels": schema.MapAttribute{
-			MarkdownDescription: "User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.",
-			ElementType:         types.StringType,
-			Computed:            true,
-		},
+		"labels": datasourceutil.LabelsSchema(),
 		"delete_protection": schema.BoolAttribute{
 			MarkdownDescription: "Whether delete protection is enabled.",
 			Computed:            true,

--- a/internal/zonerrset/data_source.go
+++ b/internal/zonerrset/data_source.go
@@ -46,11 +46,7 @@ func getCommonDataSourceSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "Time To Live (TTL) of the Zone RRSet.",
 			Computed:            true,
 		},
-		"labels": schema.MapAttribute{
-			MarkdownDescription: "User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.",
-			ElementType:         types.StringType,
-			Computed:            true,
-		},
+		"labels": datasourceutil.LabelsSchema(),
 		"change_protection": schema.BoolAttribute{
 			MarkdownDescription: "Whether change protection is enabled.",
 			Computed:            true,


### PR DESCRIPTION
Similar to resourceutil.LabelsSchema, but no validation.