### PR TITLE
fix(storage-box): retry snapshot+subaccount create when locked

### DIFF
--- a/internal/storageboxsnapshot/data_source_list_test.go
+++ b/internal/storageboxsnapshot/data_source_list_test.go
@@ -48,8 +48,6 @@ func TestAccStorageBoxSnapshotDataSourceList(t *testing.T) {
 		Labels: map[string]string{
 			"key": randutil.GenerateID(),
 		},
-		// Only one snapshot may be created at the same time
-		Raw: fmt.Sprintf(`depends_on = [%s]`, res1.TFID()),
 	}
 	res2.SetRName("default2")
 

--- a/internal/storageboxsnapshot/resource.go
+++ b/internal/storageboxsnapshot/resource.go
@@ -134,7 +134,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// Create in API
 	// For a single storage box, only a single snapshot can be created simultaneously, all others fail with `locked` error.
 	var result hcloud.StorageBoxSnapshotCreateResult
-	err := control.Retry(control.DefaultRetries, func() error {
+	err := control.Retry(2*control.DefaultRetries, func() error {
 		var err error
 
 		result, _, err = r.client.StorageBox.CreateSnapshot(ctx, storageBox, opts)

--- a/internal/storageboxsnapshot/resource.go
+++ b/internal/storageboxsnapshot/resource.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/control"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/experimental"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/resourceutil"
@@ -131,7 +132,23 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	// Create in API
-	result, _, err := r.client.StorageBox.CreateSnapshot(ctx, storageBox, opts)
+	// For a single storage box, only a single snapshot can be created simultaneously, all others fail with `locked` error.
+	var result hcloud.StorageBoxSnapshotCreateResult
+	err := control.Retry(control.DefaultRetries, func() error {
+		var err error
+
+		result, _, err = r.client.StorageBox.CreateSnapshot(ctx, storageBox, opts)
+		if err != nil {
+			if hcloud.IsError(err,
+				hcloud.ErrorCodeLocked,
+			) {
+				return err
+			}
+
+			return control.AbortRetry(err)
+		}
+		return nil
+	})
 	if err != nil {
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return

--- a/internal/storageboxsubaccount/data_source_list_test.go
+++ b/internal/storageboxsubaccount/data_source_list_test.go
@@ -60,7 +60,7 @@ func TestAccStorageBoxSubaccountDataSourceList(t *testing.T) {
 		Labels: map[string]string{
 			"key": randutil.GenerateID(),
 		},
-		Raw: fmt.Sprintf(`
+		Raw: `
 			access_settings = {
 				reachable_externally = false
 				samba_enabled = true
@@ -68,8 +68,7 @@ func TestAccStorageBoxSubaccountDataSourceList(t *testing.T) {
 				webdav_enabled = true
 				readonly = false
 			}
-
-			depends_on = [%s]`, res1.TFID()), // Only one subaccount may be created at the same time
+		`,
 	}
 	res2.SetRName("default2")
 

--- a/internal/storageboxsubaccount/resource.go
+++ b/internal/storageboxsubaccount/resource.go
@@ -230,7 +230,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	// Create in API
 	// For a single storage box, only a single subaccount can be created simultaneously, all others fail with `locked` error.
 	var result hcloud.StorageBoxSubaccountCreateResult
-	err := control.Retry(control.DefaultRetries, func() error {
+	err := control.Retry(2*control.DefaultRetries, func() error {
 		var err error
 
 		result, _, err = r.client.StorageBox.CreateSubaccount(ctx, storageBox, opts)

--- a/internal/storageboxsubaccount/resource.go
+++ b/internal/storageboxsubaccount/resource.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/control"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/experimental"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/merge"
@@ -227,7 +228,23 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	// Create in API
-	result, _, err := r.client.StorageBox.CreateSubaccount(ctx, storageBox, opts)
+	// For a single storage box, only a single subaccount can be created simultaneously, all others fail with `locked` error.
+	var result hcloud.StorageBoxSubaccountCreateResult
+	err := control.Retry(control.DefaultRetries, func() error {
+		var err error
+
+		result, _, err = r.client.StorageBox.CreateSubaccount(ctx, storageBox, opts)
+		if err != nil {
+			if hcloud.IsError(err,
+				hcloud.ErrorCodeLocked,
+			) {
+				return err
+			}
+
+			return control.AbortRetry(err)
+		}
+		return nil
+	})
 	if err != nil {
 		resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
 		return


### PR DESCRIPTION
The API only allows users to create a single snapshot or subaccount for any storage box at the same time. While it may be uncommon to create multiple snapshots at the same time, I can see creating many subaccounts at the same time being a common thing.

This uses the default exponential backoff and limit of 5 retries each, so if many resources are "queued", the user may still run into issues.