### PR TITLE
test: remove unused test sweepers

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -14,6 +14,7 @@ linters:
     - errchkjson
     - errorlint
     - exhaustive
+    - forbidigo
     - gocheckcompilerdirectives
     - gochecksumtype
     - gocritic
@@ -43,6 +44,14 @@ linters:
       default-signifies-exhaustive: true
     staticcheck:
       checks: ["all", "-QF1008", "-S1016"]
+    forbidigo:
+      forbid:
+        # These are not set up and used in our repository,
+        # so we do not have to spend time implementing them and keeping them up to date.
+        - pattern: resource\.AddTestSweepers
+          pkg: github.com/hashicorp/terraform-plugin-testing/helper/resource
+          msg: "Do not implement unused test sweepers"
+      analyze-types: true
 
   exclusions:
     generated: lax

--- a/internal/certificate/testing.go
+++ b/internal/certificate/testing.go
@@ -7,42 +7,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(UploadedResourceType, &resource.Sweeper{
-		Name:         UploadedResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all certificates from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	certificates, err := client.Certificate.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, cert := range certificates {
-		if _, err := client.Certificate.Delete(ctx, cert); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a certificate by its ID.
 func ByID(t *testing.T, cert *hcloud.Certificate) func(*hcloud.Client, int64) bool {

--- a/internal/firewall/testing.go
+++ b/internal/firewall/testing.go
@@ -7,42 +7,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all firewalls from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	firewalls, err := client.Firewall.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, firewall := range firewalls {
-		if _, err := client.Firewall.Delete(ctx, firewall); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a firewall by its ID.
 func ByID(t *testing.T, firewall *hcloud.Firewall) func(*hcloud.Client, int64) bool {

--- a/internal/floatingip/testing.go
+++ b/internal/floatingip/testing.go
@@ -5,42 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all Floating IPs from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	servers, err := client.FloatingIP.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, srv := range servers {
-		if _, err := client.FloatingIP.Delete(ctx, srv); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a Floating IP by its ID.
 func ByID(t *testing.T, fl *hcloud.FloatingIP) func(*hcloud.Client, int64) bool {

--- a/internal/loadbalancer/testing.go
+++ b/internal/loadbalancer/testing.go
@@ -5,49 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/certificate"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/network"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name: ResourceType,
-		Dependencies: []string{
-			certificate.ResourceType,
-			server.ResourceType,
-			network.ResourceType,
-		},
-		F: Sweep,
-	})
-}
-
-// Sweep removes all Load Balancers from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	loadBalancers, err := client.LoadBalancer.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, loadBalancer := range loadBalancers {
-		if _, err := client.LoadBalancer.Delete(ctx, loadBalancer); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a loadbalancer by its ID.
 func ByID(t *testing.T, lb *hcloud.LoadBalancer) func(*hcloud.Client, int64) bool {
@@ -80,7 +40,7 @@ func (d *DData) TFID() string {
 	return fmt.Sprintf("data.%s.%s", DataSourceType, d.RName())
 }
 
-// DData defines the fields for the "testdata/d/hcloud_load_balancers" template.
+// DDataList defines the fields for the "testdata/d/hcloud_load_balancers" template.
 type DDataList struct {
 	testtemplate.DataCommon
 

--- a/internal/network/testing.go
+++ b/internal/network/testing.go
@@ -5,41 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name: ResourceType,
-		F:    Sweep,
-	})
-}
-
-// Sweep removes all Networks from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	networks, err := client.Network.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, nw := range networks {
-		if _, err := client.Network.Delete(ctx, nw); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a network by its ID.
 func ByID(t *testing.T, nw *hcloud.Network) func(*hcloud.Client, int64) bool {

--- a/internal/primaryip/testing.go
+++ b/internal/primaryip/testing.go
@@ -5,42 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all primary IPs from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	servers, err := client.PrimaryIP.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, srv := range servers {
-		if _, err := client.PrimaryIP.Delete(ctx, srv); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a primary IP by its ID.
 func ByID(t *testing.T, fl *hcloud.PrimaryIP) func(*hcloud.Client, int64) bool {

--- a/internal/rdns/testing.go
+++ b/internal/rdns/testing.go
@@ -1,45 +1,11 @@
 package rdns
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all sshkeys from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	sshkeys, err := client.SSHKey.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, cert := range sshkeys {
-		if _, err := client.SSHKey.Delete(ctx, cert); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // RData defines the fields for the "testdata/r/hcloud_rdns"
 // template.

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -5,42 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all Servers from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	servers, err := client.Server.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, srv := range servers {
-		if _, _, err = client.Server.DeleteWithResult(ctx, srv); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a server by its ID.
 func ByID(t *testing.T, srv *hcloud.Server) func(*hcloud.Client, int64) bool {

--- a/internal/snapshot/testing.go
+++ b/internal/snapshot/testing.go
@@ -5,42 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all Snapshots from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	images, err := client.Image.AllWithOpts(ctx, hcloud.ImageListOpts{Type: []hcloud.ImageType{hcloud.ImageTypeSnapshot}})
-	if err != nil {
-		return err
-	}
-
-	for _, img := range images {
-		if _, err := client.Image.Delete(ctx, img); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a image by its ID.
 func ByID(t *testing.T, img *hcloud.Image) func(*hcloud.Client, int64) bool {

--- a/internal/sshkey/testing.go
+++ b/internal/sshkey/testing.go
@@ -7,42 +7,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all sshkeys from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	sshkeys, err := client.SSHKey.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, cert := range sshkeys {
-		if _, err := client.SSHKey.Delete(ctx, cert); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // GetAPIResource returns a [testsupport.GetAPIResourceFunc] for [hcloud.SSHKey].
 func GetAPIResource() testsupport.GetAPIResourceFunc[hcloud.SSHKey] {

--- a/internal/storagebox/testing.go
+++ b/internal/storagebox/testing.go
@@ -6,50 +6,11 @@ import (
 	"math/rand/v2"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all Storage Boxes from the Hetzner API.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	storageBoxes, err := client.StorageBox.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	actions := make([]*hcloud.Action, 0, len(storageBoxes))
-	for _, o := range storageBoxes {
-		result, _, err := client.StorageBox.Delete(ctx, o)
-		if err != nil {
-			return err
-		}
-		actions = append(actions, result.Action)
-	}
-
-	if err := client.Action.WaitFor(ctx, actions...); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // GetAPIResource returns a [testsupport.GetAPIResourceFunc] for [hcloud.StorageBox].
 func GetAPIResource() testsupport.GetAPIResourceFunc[hcloud.StorageBox] {

--- a/internal/volume/testing.go
+++ b/internal/volume/testing.go
@@ -5,42 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
-	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all Volumes from the Hetzner Cloud backend.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	servers, err := client.Volume.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	for _, srv := range servers {
-		if _, err := client.Volume.Delete(ctx, srv); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
 
 // ByID returns a function that obtains a Volume by its ID.
 func ByID(t *testing.T, fl *hcloud.Volume) func(*hcloud.Client, int64) bool {

--- a/internal/zone/testing.go
+++ b/internal/zone/testing.go
@@ -4,50 +4,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-func init() {
-	resource.AddTestSweepers(ResourceType, &resource.Sweeper{
-		Name:         ResourceType,
-		Dependencies: []string{},
-		F:            Sweep,
-	})
-}
-
-// Sweep removes all zones from the Hetzner Cloud API.
-func Sweep(r string) error {
-	client, err := testsupport.CreateClient()
-	if err != nil {
-		return err
-	}
-
-	ctx := context.Background()
-	zones, err := client.Zone.All(ctx)
-	if err != nil {
-		return err
-	}
-
-	actions := make([]*hcloud.Action, 0, len(zones))
-	for _, o := range zones {
-		result, _, err := client.Zone.Delete(ctx, o)
-		if err != nil {
-			return err
-		}
-		actions = append(actions, result.Action)
-	}
-
-	if err := client.Action.WaitFor(ctx, actions...); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // GetAPIResource returns a [testsupport.GetAPIResourceFunc] for [hcloud.Zone].
 func GetAPIResource() testsupport.GetAPIResourceFunc[hcloud.Zone] {


### PR DESCRIPTION
The terraform test sweeper framework allows us to define functions that can "clean up" a project after tests, making sure that all temporary resources are deleted. This is only necessary if the actual tests failed to delete the resources.

While we previously had sweepers implementated for most resources, they were never actually used/called. This would require us to add a test main to every package:

```go
import (
  "testing"

  "github.com/hashicorp/terraform-plugin-testing/helper/resource"
)

func TestMain(m *testing.M) {
  resource.TestMain(m)
}
```

And only then are the sweeper flags defined. As we never added this to any of our packages, the sweepers are unused.

The alternative to removing these would be to add the above code, but as no one has used this so far I have opted to remove the sweepers instead.