### PR TITLE
fix(zone): using variable for primary nameservers causes error

### DIFF
--- a/internal/zone/resource.go
+++ b/internal/zone/resource.go
@@ -166,7 +166,7 @@ func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConf
 			)
 		}
 	case string(hcloud.ZoneModeSecondary):
-		if data.PrimaryNameservers.IsUnknown() || data.PrimaryNameservers.IsNull() {
+		if data.PrimaryNameservers.IsNull() {
 			resp.Diagnostics.AddAttributeError(
 				path.Root("primary_nameservers"),
 				"Required attribute",


### PR DESCRIPTION
When evaluating the plan, terraform does multiple rounds of validation, with more and more of the resource attributes known. At first, the variable is unknown, so our custom validation shows `Error: Required attribute`, even though the variable is actually configured.

We can skip checking for unknown, and rely on terraform calling us again once the variable is actually known to validate if it is null or not.

Fixes #1302