### PR TITLE
feat: deprecate datacenter in primary ips and servers

### DIFF
--- a/docs/data-sources/primary_ip.md
+++ b/docs/data-sources/primary_ip.md
@@ -15,6 +15,16 @@ Side note:
 If a server is getting created, it has to have a primary ip. If a server is getting created without defining primary ips, two of them (one ipv4 and one ipv6) getting created & attached.
 Currently, Primary IPs can be only attached to servers.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer returns the `datacenter` attribute.
+
 ## Example Usage
 
 # Data Source: hcloud_primary_ip
@@ -63,7 +73,8 @@ resource "hcloud_server" "server_test" {
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string) The datacenter name of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string) The location of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, deprecated) The datacenter name of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).
 - `ip_address` - (string) IP Address of the Primary IP.

--- a/docs/data-sources/server.md
+++ b/docs/data-sources/server.md
@@ -9,6 +9,16 @@ description: |-
 Provides details about a Hetzner Cloud Server.
 This resource is useful if you want to use a non-terraform managed server.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer returns the `datacenter` attribute.
+
 ## Example Usage
 
 ```terraform
@@ -37,7 +47,7 @@ data "hcloud_server" "s_3" {
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
 - `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (string, deprecated) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image. Architecture of ISO must equal the server (type) architecture.

--- a/docs/resources/primary_ip.md
+++ b/docs/resources/primary_ip.md
@@ -11,6 +11,19 @@ Provides a Hetzner Cloud Primary IP to represent a publicly-accessible static IP
 If a server is getting created, it has to have a primary ip. If a server is getting created without defining primary ips, two of them (one ipv4 and one ipv6) getting created & attached.
 Currently, Primary IPs can be only attached to servers.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer accepts
+and returns the `datacenter` attribute. This version of the provider remains backward compatible by preserving
+the `datacenter` value in the state and by extracting the `location` name from the `datacenter` attribute when
+communicating with the API.
+
 ## Example Usage
 
 ```terraform
@@ -44,7 +57,8 @@ resource "hcloud_server" "server_test" {
 
 - `type` - (string) Type of the Primary IP. `ipv4` or `ipv6`
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string, optional) The datacenter name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string, optional) The location name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, optional, deprecated) The datacenter name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (map, optional) User-defined labels (key-value pairs).
@@ -52,13 +66,14 @@ resource "hcloud_server" "server_test" {
 - `assignee_type` - (string) The type of the assigned resource. Currently supported: `server`
 - `delete_protection` - (bool, optional) Whether delete protection is enabled. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
-Note: At least one of `datacenter` or `assignee_id` is required.
+Note: At least one of `location`, `datacenter` or `assignee_id` is required.
 
 ## Attributes Reference
 
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
-- `datacenter` - (string) The datacenter of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string) The location of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, deprecated) The datacenter of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `name` - (string) Name of the Primary IP.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -8,6 +8,19 @@ description: |-
 
 Provides an Hetzner Cloud server resource. This can be used to create, modify, and delete servers. Servers also support [provisioning](https://www.terraform.io/docs/provisioners/index.html).
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer accepts
+and returns the `datacenter` attribute. This version of the provider remains backward compatible by preserving
+the `datacenter` value in the state and by extracting the `location` name from the `datacenter` attribute when
+communicating with the API.
+
 ## Example Usage
 
 ### Basic server creation
@@ -29,7 +42,7 @@ resource "hcloud_server" "node1" {
 ### Server creation with one linked primary ip (ipv4)
 resource "hcloud_primary_ip" "primary_ip_1" {
 name          = "primary_ip_test"
-datacenter    = "fsn1-dc14"
+location      = "hel1"
 type          = "ipv4"
 assignee_type = "server"
 auto_delete   = true
@@ -42,7 +55,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "hel1"
   labels = {
     "test" : "tessst1"
   }
@@ -162,7 +175,7 @@ The following arguments are supported:
 - `server_type` - (Required, string) Name of the server type this server should be created with.
 - `image` - (Required, string) Name or ID of the image the server is created from. **Note** the `image` property is only required when using the resource to create servers. As the Hetzner Cloud API may return servers without an image ID set it is not marked as required in the Terraform Provider itself. Thus, users will get an error from the underlying client library if they forget to set the property and try to create a server.
 - `location` - (Optional, string) The location name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (Optional, string) The datacenter name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (Optional, string, deprecated) The datacenter name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation
 - `ssh_keys` - (Optional, list) SSH key IDs or names which should be injected into the server at creation time. Once the server is created, you can not update the list of SSH Keys. If you do change this, you will be prompted to destroy and recreate the server. You can avoid this by setting [lifecycle.ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) to `[ ssh_keys ]`.
 - `public_net` - (Optional, block) In this block you can either enable / disable ipv4 and ipv6 or link existing primary IPs (checkout the examples).
@@ -202,7 +215,7 @@ The following attributes are exported:
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
 - `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (string, deprecated) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image.

--- a/examples/resources/hcloud_server/example_2.tf
+++ b/examples/resources/hcloud_server/example_2.tf
@@ -1,7 +1,7 @@
 ### Server creation with one linked primary ip (ipv4)
 resource "hcloud_primary_ip" "primary_ip_1" {
   name          = "primary_ip_test"
-  datacenter    = "fsn1-dc14"
+  location      = "hel1"
   type          = "ipv4"
   assignee_type = "server"
   auto_delete   = true
@@ -14,7 +14,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "hel1"
   labels = {
     "test" : "tessst1"
   }

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.21.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/hetznercloud/hcloud-go/v2 v2.32.0
+	github.com/hetznercloud/hcloud-go/v2 v2.33.0
 	github.com/joho/godotenv v1.5.1
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/net v0.48.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,8 @@ github.com/hetznercloud/hcloud-go/v2 v2.31.0 h1:JCVO8ZXn1y02YXmQb4xghXPvuINh6743
 github.com/hetznercloud/hcloud-go/v2 v2.31.0/go.mod h1:CeYYkuK5M5P/pWjhQRCcIz3d/61vmn4YHlsk3+ckk+o=
 github.com/hetznercloud/hcloud-go/v2 v2.32.0 h1:BRe+k7ESdYv3xQLBGdKUfk+XBFRJNGKzq70nJI24ciM=
 github.com/hetznercloud/hcloud-go/v2 v2.32.0/go.mod h1:hAanyyfn9M0cMmZ68CXzPCF54KRb9EXd8eiE2FHKGIE=
+github.com/hetznercloud/hcloud-go/v2 v2.33.0 h1:g9hwuo60IXbupXJCYMlO4xDXgxxMPuFk31iOpLXDCV4=
+github.com/hetznercloud/hcloud-go/v2 v2.33.0/go.mod h1:GzYEl7slIGKc6Ttt08hjiJvGj8/PbWzcQf6IUi02dIs=
 github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.15 h1:M8XP7IuFNsqUx6VPK2P9OSmsYsI/YFaGil0uD21V3dM=

--- a/internal/firewall/attachment_resource_test.go
+++ b/internal/firewall/attachment_resource_test.go
@@ -21,10 +21,10 @@ func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 
 	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
 	srvRes := &server.RData{
-		Name:       "test-server",
-		Type:       teste2e.TestServerType,
-		Image:      teste2e.TestImage,
-		Datacenter: teste2e.TestDataCenter,
+		Name:         "test-server",
+		Type:         teste2e.TestServerType,
+		Image:        teste2e.TestImage,
+		LocationName: teste2e.TestLocationName,
 	}
 	srvRes.SetRName("test_server")
 
@@ -73,10 +73,10 @@ func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 
 	fwRes := firewall.NewRData(t, "basic_firewall", nil, nil)
 	srvRes := &server.RData{
-		Name:       "test-server",
-		Type:       teste2e.TestServerType,
-		Image:      teste2e.TestImage,
-		Datacenter: teste2e.TestDataCenter,
+		Name:         "test-server",
+		Type:         teste2e.TestServerType,
+		Image:        teste2e.TestImage,
+		LocationName: teste2e.TestLocationName,
 		Labels: map[string]string{
 			"firewall-attachment": "test-server",
 		},

--- a/internal/primaryip/data_source.go
+++ b/internal/primaryip/data_source.go
@@ -37,9 +37,14 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 		},
-		"datacenter": {
+		"location": {
 			Type:     schema.TypeString,
 			Computed: true,
+		},
+		"datacenter": {
+			Type:       schema.TypeString,
+			Computed:   true,
+			Deprecated: "The datacenter attribute is deprecated and will be removed after 1 July 2026. Please use the location attribute instead. See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.",
 		},
 		"assignee_id": {
 			Type:     schema.TypeInt,

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -23,7 +23,7 @@ func TestAccPrimaryIPDataSource(t *testing.T) {
 		Labels: map[string]string{
 			"key": strconv.Itoa(acctest.RandInt()),
 		},
-		Datacenter:   "fsn1-dc14",
+		Location:     teste2e.TestLocationName,
 		AssigneeType: "server",
 	}
 	res.SetRName("primaryip-ds-test")
@@ -68,15 +68,18 @@ func TestAccPrimaryIPDataSource(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(primaryIPByName.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(primaryIPByName.TFID(), "datacenter", res.Datacenter),
+					resource.TestCheckResourceAttr(primaryIPByName.TFID(), "location", teste2e.TestLocationName),
+					resource.TestCheckResourceAttr(primaryIPByName.TFID(), "datacenter", teste2e.TestDataCenter),
 
 					resource.TestCheckResourceAttr(primaryIPByID.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(primaryIPByID.TFID(), "datacenter", res.Datacenter),
+					resource.TestCheckResourceAttr(primaryIPByID.TFID(), "location", teste2e.TestLocationName),
+					resource.TestCheckResourceAttr(primaryIPByID.TFID(), "datacenter", teste2e.TestDataCenter),
 
 					resource.TestCheckResourceAttr(primaryIPBySel.TFID(),
 						"name", fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt)),
-					resource.TestCheckResourceAttr(primaryIPBySel.TFID(), "datacenter", res.Datacenter),
+					resource.TestCheckResourceAttr(primaryIPBySel.TFID(), "location", teste2e.TestLocationName),
+					resource.TestCheckResourceAttr(primaryIPBySel.TFID(), "datacenter", teste2e.TestDataCenter),
 				),
 			},
 		},
@@ -90,7 +93,7 @@ func TestAccPrimaryIPDataSourceList(t *testing.T) {
 		Labels: map[string]string{
 			"key": strconv.Itoa(acctest.RandInt()),
 		},
-		Datacenter:   "fsn1-dc14",
+		Location:     teste2e.TestLocationName,
 		AssigneeType: "server",
 	}
 	res.SetRName("primary-ds-test")
@@ -125,14 +128,16 @@ func TestAccPrimaryIPDataSourceList(t *testing.T) {
 					resource.TestCheckTypeSetElemNestedAttrs(primaryipBySel.TFID(), "primary_ips.*",
 						map[string]string{
 							"name":       fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt),
-							"datacenter": res.Datacenter,
+							"location":   teste2e.TestLocationName,
+							"datacenter": teste2e.TestDataCenter,
 						},
 					),
 
 					resource.TestCheckTypeSetElemNestedAttrs(allPrimaryIPsSel.TFID(), "primary_ips.*",
 						map[string]string{
 							"name":       fmt.Sprintf("%s--%d", res.Name, tmplMan.RandInt),
-							"datacenter": res.Datacenter,
+							"location":   teste2e.TestLocationName,
+							"datacenter": teste2e.TestDataCenter,
 						},
 					),
 				),

--- a/internal/primaryip/testing.go
+++ b/internal/primaryip/testing.go
@@ -60,6 +60,7 @@ type RData struct {
 
 	Name             string
 	Type             string
+	Location         string
 	Datacenter       string
 	AssigneeType     string
 	AssigneeID       string

--- a/internal/rdns/resource_test.go
+++ b/internal/rdns/resource_test.go
@@ -122,7 +122,7 @@ func TestAccRDNSResource_PrimaryIP(t *testing.T) {
 				Name:         tt.name,
 				Type:         tt.primaryIPType,
 				AssigneeType: "server",
-				Datacenter:   teste2e.TestDataCenter,
+				Location:     teste2e.TestLocationName,
 			}
 			restPrimaryIP.SetRName(tt.name)
 			resRDNS := rdns.NewRDataPrimaryIP(t, tt.name, restPrimaryIP.TFID()+".id", restPrimaryIP.TFID()+".ip_address", tt.dns)

--- a/internal/server/data_source.go
+++ b/internal/server/data_source.go
@@ -47,8 +47,9 @@ func getCommonDataSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"datacenter": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:       schema.TypeString,
+			Computed:   true,
+			Deprecated: "The datacenter attribute is deprecated and will be removed after 1 July 2026. Please use the location attribute instead. See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.",
 		},
 		"backup_window": {
 			Type:     schema.TypeString,

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -70,10 +70,11 @@ func Resource() *schema.Resource {
 				Computed: true,
 			},
 			"datacenter": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Computed:   true,
+				Deprecated: "The datacenter attribute is deprecated and will be removed after 1 July 2026. Please use the location attribute instead. See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters.",
 			},
 			"user_data": {
 				Type:             schema.TypeString,
@@ -284,10 +285,10 @@ func userDataDiffSuppress(k, oldValue, newValue string, d *schema.ResourceData) 
 	return strings.TrimSpace(oldValue) == strings.TrimSpace(newValue)
 }
 
-const ChangeDeprecatedServerTypeMessage = (`Existing servers of that plan will ` +
+const ChangeDeprecatedServerTypeMessage = `Existing servers of that plan will ` +
 	`continue to work as before and no action is required on your part. ` +
 	`It is possible to migrate this Server to another Server Type by using ` +
-	`the "hcloud server change-type" command.`)
+	`the "hcloud server change-type" command.`
 
 func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interface{}) (diags diag.Diagnostics) {
 	c := m.(*hcloud.Client)
@@ -339,21 +340,28 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		UserData: d.Get("user_data").(string),
 	}
 
-	var serverTypeLocationName string
-	if datacenter, ok := d.GetOk("datacenter"); ok {
-		opts.Datacenter = &hcloud.Datacenter{Name: datacenter.(string)}
-		if parts := strings.SplitN(opts.Datacenter.Name, "-", 2); len(parts) == 2 {
-			serverTypeLocationName = parts[0]
-		}
-	}
-
 	if location, ok := d.GetOk("location"); ok {
 		opts.Location = &hcloud.Location{Name: location.(string)}
-		serverTypeLocationName = opts.Location.Name
+	} else if datacenter, ok := d.GetOk("datacenter"); ok {
+		// Backward compatible datacenter argument.
+		// datacenter hel1-dc2 => location hel1
+		parts := strings.SplitN(datacenter.(string), "-", 2)
+
+		if len(parts) != 2 {
+			diags = append(diags, diag.Errorf("Datacenter name is not valid, expected format $LOCATION-$DATACENTER, but got: %s", datacenter.(string))...)
+			return
+		}
+
+		locationName := parts[0]
+		opts.Location = &hcloud.Location{Name: locationName}
+	}
+	locationName := ""
+	if opts.Location != nil {
+		locationName = opts.Location.Name
 	}
 
 	serverTypeDeprecationPrinted := false
-	if message, isUnavailable := deprecationutil.ServerTypeMessage(serverType, serverTypeLocationName); message != "" {
+	if message, isUnavailable := deprecationutil.ServerTypeMessage(serverType, locationName); message != "" {
 		serverTypeDeprecationPrinted = true
 		deprecationDiag := diag.Diagnostic{
 			Severity: diag.Warning,
@@ -437,7 +445,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 	if !serverTypeDeprecationPrinted {
 		// We now know the server location and can check the server type deprecation again.
-		if message, _ := deprecationutil.ServerTypeMessage(res.Server.ServerType, res.Server.Datacenter.Location.Name); message != "" {
+		if message, _ := deprecationutil.ServerTypeMessage(res.Server.ServerType, res.Server.Location.Name); message != "" {
 			deprecationDiag := diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  message,
@@ -1197,8 +1205,7 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server, forceSetNetwo
 	res := map[string]interface{}{
 		"id":                 s.ID,
 		"name":               s.Name,
-		"datacenter":         s.Datacenter.Name,
-		"location":           s.Datacenter.Location.Name,
+		"location":           s.Location.Name,
 		"status":             s.Status,
 		"server_type":        s.ServerType.Name,
 		"ipv6_network":       s.PublicNet.IPv6.Network.String(),
@@ -1251,6 +1258,18 @@ func getServerAttributes(d *schema.ResourceData, s *hcloud.Server, forceSetNetwo
 		res["placement_group_id"] = util.CastInt(s.PlacementGroup.ID)
 	} else {
 		res["placement_group_id"] = nil
+	}
+
+	// Pass through datacenter name as long as it is returned from the API.
+	//
+	// If the attribute is not returned from the API, we never set the attribute,
+	// so whatever is in the state or user config is kept.
+	//
+	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
+	//nolint:staticcheck // Backwards-compatibility
+	if s.Datacenter != nil {
+		//nolint:staticcheck // Backwards-compatibility
+		res["datacenter"] = s.Datacenter.Name
 	}
 
 	return res

--- a/internal/server/resource_network_test.go
+++ b/internal/server/resource_network_test.go
@@ -57,18 +57,18 @@ func makeServerNetworkBlueprint(t *testing.T) *ServerNetworkBlueprint {
 	b.subnet2.SetRName("subnet2")
 
 	b.server1 = &server.RData{
-		Name:       "server1",
-		Type:       teste2e.TestServerType,
-		Datacenter: teste2e.TestDataCenter,
-		Image:      teste2e.TestImage,
+		Name:         "server1",
+		Type:         teste2e.TestServerType,
+		LocationName: teste2e.TestLocationName,
+		Image:        teste2e.TestImage,
 	}
 	b.server1.SetRName("server1")
 
 	b.server2 = &server.RData{
-		Name:       "server2",
-		Type:       teste2e.TestServerType,
-		Datacenter: teste2e.TestDataCenter,
-		Image:      teste2e.TestImage,
+		Name:         "server2",
+		Type:         teste2e.TestServerType,
+		LocationName: teste2e.TestLocationName,
+		Image:        teste2e.TestImage,
 	}
 	b.server2.SetRName("server2")
 

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -721,7 +724,7 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 		Name:         "primaryip-v4-test",
 		Type:         "ipv4",
 		Labels:       nil,
-		Datacenter:   teste2e.TestDataCenter,
+		Location:     teste2e.TestLocationName,
 		AssigneeType: "server",
 		AutoDelete:   false,
 	}
@@ -731,18 +734,18 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 		Name:         "primaryip-v6-test",
 		Type:         "ipv6",
 		Labels:       nil,
-		Datacenter:   teste2e.TestDataCenter,
+		Location:     teste2e.TestLocationName,
 		AssigneeType: "server",
 		AutoDelete:   false,
 	}
 	primaryIPv6Res.SetRName("primary-ip-v6")
 
 	sResWithNetAndPublicNet := &server.RData{
-		Name:       "server-primaryIP-network-test",
-		Type:       teste2e.TestServerType,
-		Datacenter: teste2e.TestDataCenter,
-		Image:      teste2e.TestImage,
-		SSHKeys:    []string{sk.TFID() + ".id"},
+		Name:         "server-primaryIP-network-test",
+		Type:         teste2e.TestServerType,
+		LocationName: teste2e.TestLocationName,
+		Image:        teste2e.TestImage,
+		SSHKeys:      []string{sk.TFID() + ".id"},
 		Networks: []server.RDataInlineNetwork{{
 			NetworkID: nwRes.TFID() + ".id",
 			IP:        "10.0.1.5",
@@ -757,12 +760,12 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	sResWithNetAndPublicNet.SetRName(sResWithNetAndPublicNet.Name)
 
 	sResWithoutPublicNet := &server.RData{
-		Name:       sResWithNetAndPublicNet.Name,
-		Type:       sResWithNetAndPublicNet.Type,
-		Datacenter: sResWithNetAndPublicNet.Datacenter,
-		Image:      sResWithNetAndPublicNet.Image,
-		SSHKeys:    sResWithNetAndPublicNet.SSHKeys,
-		Networks:   sResWithNetAndPublicNet.Networks,
+		Name:         sResWithNetAndPublicNet.Name,
+		Type:         sResWithNetAndPublicNet.Type,
+		LocationName: sResWithNetAndPublicNet.LocationName,
+		Image:        sResWithNetAndPublicNet.Image,
+		SSHKeys:      sResWithNetAndPublicNet.SSHKeys,
+		Networks:     sResWithNetAndPublicNet.Networks,
 		PublicNet: map[string]interface{}{
 			"ipv4_enabled": false,
 			"ipv6_enabled": false,
@@ -772,12 +775,12 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	sResWithoutPublicNet.SetRName(sResWithoutPublicNet.Name)
 
 	sResWithPrimaryIP := &server.RData{
-		Name:       sResWithoutPublicNet.Name,
-		Type:       sResWithoutPublicNet.Type,
-		Datacenter: sResWithoutPublicNet.Datacenter,
-		Image:      sResWithoutPublicNet.Image,
-		SSHKeys:    sResWithoutPublicNet.SSHKeys,
-		Networks:   sResWithoutPublicNet.Networks,
+		Name:         sResWithoutPublicNet.Name,
+		Type:         sResWithoutPublicNet.Type,
+		LocationName: sResWithoutPublicNet.LocationName,
+		Image:        sResWithoutPublicNet.Image,
+		SSHKeys:      sResWithoutPublicNet.SSHKeys,
+		Networks:     sResWithoutPublicNet.Networks,
 		PublicNet: map[string]interface{}{
 			"ipv4_enabled": true,
 			"ipv4":         primaryIPv4Res.TFID() + ".id",
@@ -789,12 +792,12 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	sResWithPrimaryIP.SetRName(sResWithPrimaryIP.Name)
 
 	sResWithTwoPrimaryIPs := &server.RData{
-		Name:       sResWithPrimaryIP.Name,
-		Type:       sResWithPrimaryIP.Type,
-		Datacenter: sResWithPrimaryIP.Datacenter,
-		Image:      sResWithPrimaryIP.Image,
-		SSHKeys:    sResWithPrimaryIP.SSHKeys,
-		Networks:   sResWithPrimaryIP.Networks,
+		Name:         sResWithPrimaryIP.Name,
+		Type:         sResWithPrimaryIP.Type,
+		LocationName: sResWithPrimaryIP.LocationName,
+		Image:        sResWithPrimaryIP.Image,
+		SSHKeys:      sResWithPrimaryIP.SSHKeys,
+		Networks:     sResWithPrimaryIP.Networks,
 		PublicNet: map[string]interface{}{
 			"ipv4_enabled": true,
 			"ipv4":         primaryIPv4Res.TFID() + ".id",
@@ -806,24 +809,24 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	sResWithTwoPrimaryIPs.SetRName(sResWithTwoPrimaryIPs.Name)
 
 	sResWithNoPublicNet := &server.RData{
-		Name:       sResWithTwoPrimaryIPs.Name,
-		Type:       sResWithTwoPrimaryIPs.Type,
-		Datacenter: sResWithTwoPrimaryIPs.Datacenter,
-		Image:      sResWithTwoPrimaryIPs.Image,
-		SSHKeys:    sResWithTwoPrimaryIPs.SSHKeys,
-		Networks:   sResWithTwoPrimaryIPs.Networks,
-		DependsOn:  sResWithTwoPrimaryIPs.DependsOn,
+		Name:         sResWithTwoPrimaryIPs.Name,
+		Type:         sResWithTwoPrimaryIPs.Type,
+		LocationName: sResWithTwoPrimaryIPs.LocationName,
+		Image:        sResWithTwoPrimaryIPs.Image,
+		SSHKeys:      sResWithTwoPrimaryIPs.SSHKeys,
+		Networks:     sResWithTwoPrimaryIPs.Networks,
+		DependsOn:    sResWithTwoPrimaryIPs.DependsOn,
 	}
 
 	sResWithNoPublicNet.SetRName(sResWithNoPublicNet.Name)
 
 	sResWithOnlyIPv6 := &server.RData{
-		Name:       sResWithNoPublicNet.Name,
-		Type:       sResWithNoPublicNet.Type,
-		Datacenter: sResWithNoPublicNet.Datacenter,
-		Image:      sResWithNoPublicNet.Image,
-		SSHKeys:    sResWithNoPublicNet.SSHKeys,
-		Networks:   sResWithNoPublicNet.Networks,
+		Name:         sResWithNoPublicNet.Name,
+		Type:         sResWithNoPublicNet.Type,
+		LocationName: sResWithNoPublicNet.LocationName,
+		Image:        sResWithNoPublicNet.Image,
+		SSHKeys:      sResWithNoPublicNet.SSHKeys,
+		Networks:     sResWithNoPublicNet.Networks,
 		PublicNet: map[string]interface{}{
 			"ipv4_enabled": false,
 			"ipv6_enabled": true,
@@ -835,12 +838,12 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	sResWithOnlyIPv6.SetRName(sResWithOnlyIPv6.Name)
 
 	sResWithOnlyIPv6AutoGenerated := &server.RData{
-		Name:       sResWithOnlyIPv6.Name,
-		Type:       sResWithOnlyIPv6.Type,
-		Datacenter: sResWithOnlyIPv6.Datacenter,
-		Image:      sResWithOnlyIPv6.Image,
-		SSHKeys:    sResWithOnlyIPv6.SSHKeys,
-		Networks:   sResWithOnlyIPv6.Networks,
+		Name:         sResWithOnlyIPv6.Name,
+		Type:         sResWithOnlyIPv6.Type,
+		LocationName: sResWithOnlyIPv6.LocationName,
+		Image:        sResWithOnlyIPv6.Image,
+		SSHKeys:      sResWithOnlyIPv6.SSHKeys,
+		Networks:     sResWithOnlyIPv6.Networks,
 		PublicNet: map[string]interface{}{
 			"ipv4_enabled": false,
 			"ipv6_enabled": true,
@@ -1387,6 +1390,51 @@ func TestAccServerResource_EmptySSHKey(t *testing.T) {
 					"testdata/r/hcloud_server", srvRes,
 				),
 				ExpectError: regexp.MustCompile("Invalid ssh key passed"),
+			},
+		},
+	})
+}
+
+func TestAccServerResource_DatacenterToLocation(t *testing.T) {
+	// Test for the "datacenter" deprecation, to make sure that its possible to move to "location" attribute
+	// See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters
+
+	resDC := &server.RData{
+		Name:       "server-dc-to-location",
+		Type:       teste2e.TestServerType,
+		Image:      teste2e.TestImage,
+		Datacenter: teste2e.TestDataCenter,
+	}
+	resDC.SetRName("dc_to_location")
+
+	resLocation := testtemplate.DeepCopy(t, resDC)
+	resLocation.Datacenter = ""
+	resLocation.LocationName = teste2e.TestLocationName
+
+	tmplMan := testtemplate.Manager{}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				// Create server in Datacenter.
+				Config: tmplMan.Render(t, "testdata/r/hcloud_server", resDC),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resDC.TFID(), tfjsonpath.New("datacenter"), knownvalue.StringExact(teste2e.TestDataCenter)),
+					statecheck.ExpectKnownValue(resDC.TFID(), tfjsonpath.New("location"), knownvalue.StringExact(teste2e.TestLocationName)),
+				},
+			},
+			{
+				// Change config to Location.
+				Config: tmplMan.Render(t, "testdata/r/hcloud_server", resLocation),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{plancheck.ExpectEmptyPlan()},
+				},
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(resLocation.TFID(), tfjsonpath.New("datacenter"), knownvalue.StringExact(teste2e.TestDataCenter)),
+					statecheck.ExpectKnownValue(resLocation.TFID(), tfjsonpath.New("location"), knownvalue.StringExact(teste2e.TestLocationName)),
+				},
 			},
 		},
 	})

--- a/internal/testdata/r/hcloud_primary_ip.tf.tmpl
+++ b/internal/testdata/r/hcloud_primary_ip.tf.tmpl
@@ -4,6 +4,9 @@ resource "hcloud_primary_ip" "{{ .RName }}" {
   {{/* Required properties */ -}}
   name        = "{{ .Name }}--{{ .RInt }}"
   type = "{{ .Type }}"
+  {{- if .Location }}
+  location       = "{{ .Location }}"
+  {{ end }}
   {{- if .Datacenter }}
   datacenter       = "{{ .Datacenter }}"
   {{ end }}

--- a/templates/data-sources/primary_ip.md.tmpl
+++ b/templates/data-sources/primary_ip.md.tmpl
@@ -15,6 +15,16 @@ Side note:
 If a server is getting created, it has to have a primary ip. If a server is getting created without defining primary ips, two of them (one ipv4 and one ipv6) getting created & attached.
 Currently, Primary IPs can be only attached to servers.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer returns the `datacenter` attribute.
+
 ## Example Usage
 
 # Data Source: hcloud_primary_ip
@@ -38,7 +48,8 @@ This resource can be useful when you need to determine a Primary IP ID based on 
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string) The datacenter name of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string) The location of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, deprecated) The datacenter name of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).
 - `ip_address` - (string) IP Address of the Primary IP.

--- a/templates/data-sources/server.md.tmpl
+++ b/templates/data-sources/server.md.tmpl
@@ -9,6 +9,16 @@ description: |-
 Provides details about a Hetzner Cloud Server.
 This resource is useful if you want to use a non-terraform managed server.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer returns the `datacenter` attribute.
+
 ## Example Usage
 
 {{ tffile .ExampleFile }}
@@ -27,7 +37,7 @@ This resource is useful if you want to use a non-terraform managed server.
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
 - `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (string, deprecated) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image. Architecture of ISO must equal the server (type) architecture.

--- a/templates/resources/primary_ip.md.tmpl
+++ b/templates/resources/primary_ip.md.tmpl
@@ -11,6 +11,19 @@ Provides a Hetzner Cloud Primary IP to represent a publicly-accessible static IP
 If a server is getting created, it has to have a primary ip. If a server is getting created without defining primary ips, two of them (one ipv4 and one ipv6) getting created & attached.
 Currently, Primary IPs can be only attached to servers.
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer accepts
+and returns the `datacenter` attribute. This version of the provider remains backward compatible by preserving
+the `datacenter` value in the state and by extracting the `location` name from the `datacenter` attribute when
+communicating with the API.
+
 ## Example Usage
 
 {{ tffile .ExampleFile }}
@@ -19,7 +32,8 @@ Currently, Primary IPs can be only attached to servers.
 
 - `type` - (string) Type of the Primary IP. `ipv4` or `ipv6`
 - `name` - (string) Name of the Primary IP.
-- `datacenter` - (string, optional) The datacenter name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string, optional) The location name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, optional, deprecated) The datacenter name to create the resource in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `auto_delete` - (bool) Whether auto delete is enabled.
   `Important note:`It is recommended to set `auto_delete` to `false`, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the TF state.
 - `labels` - (map, optional) User-defined labels (key-value pairs).
@@ -27,13 +41,14 @@ Currently, Primary IPs can be only attached to servers.
 - `assignee_type` - (string) The type of the assigned resource. Currently supported: `server`
 - `delete_protection` - (bool, optional) Whether delete protection is enabled. See ["Delete Protection"](../index.html.markdown#delete-protection) in the Provider Docs for details.
 
-Note: At least one of `datacenter` or `assignee_id` is required.
+Note: At least one of `location`, `datacenter` or `assignee_id` is required.
 
 ## Attributes Reference
 
 - `id` - (int) Unique ID of the Primary IP.
 - `type` - (string) Type of the Primary IP.
-- `datacenter` - (string) The datacenter of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `location` - (string) The location of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
+- `datacenter` - (string, deprecated) The datacenter of the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `name` - (string) Name of the Primary IP.
 - `auto_delete` - (bool) Whether auto delete is enabled.
 - `labels` - (map) User-defined labels (key-value pairs).

--- a/templates/resources/server.md.tmpl
+++ b/templates/resources/server.md.tmpl
@@ -8,6 +8,19 @@ description: |-
 
 Provides an Hetzner Cloud server resource. This can be used to create, modify, and delete servers. Servers also support [provisioning](https://www.terraform.io/docs/provisioners/index.html).
 
+## Deprecations
+
+### `datacenter` attribute
+
+The `datacenter` attribute is deprecated, use the `location` attribute instead.
+
+See our the [API changelog](https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters) for more details.
+
+-> Please upgrade to `v1.58.0+` of the provider to avoid issues once the Hetzner Cloud API no longer accepts
+and returns the `datacenter` attribute. This version of the provider remains backward compatible by preserving
+the `datacenter` value in the state and by extracting the `location` name from the `datacenter` attribute when
+communicating with the API.
+
 ## Example Usage
 
 ### Basic server creation
@@ -29,7 +42,7 @@ resource "hcloud_server" "node1" {
 ### Server creation with one linked primary ip (ipv4)
 resource "hcloud_primary_ip" "primary_ip_1" {
 name          = "primary_ip_test"
-datacenter    = "fsn1-dc14"
+location      = "hel1"
 type          = "ipv4"
 assignee_type = "server"
 auto_delete   = true
@@ -42,7 +55,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "hel1"
   labels = {
     "test" : "tessst1"
   }
@@ -162,7 +175,7 @@ The following arguments are supported:
 - `server_type` - (Required, string) Name of the server type this server should be created with.
 - `image` - (Required, string) Name or ID of the image the server is created from. **Note** the `image` property is only required when using the resource to create servers. As the Hetzner Cloud API may return servers without an image ID set it is not marked as required in the Terraform Provider itself. Thus, users will get an error from the underlying client library if they forget to set the property and try to create a server.
 - `location` - (Optional, string) The location name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (Optional, string) The datacenter name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (Optional, string, deprecated) The datacenter name to create the server in. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `user_data` - (Optional, string) Cloud-Init user data to use during server creation
 - `ssh_keys` - (Optional, list) SSH key IDs or names which should be injected into the server at creation time. Once the server is created, you can not update the list of SSH Keys. If you do change this, you will be prompted to destroy and recreate the server. You can avoid this by setting [lifecycle.ignore_changes](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) to `[ ssh_keys ]`.
 - `public_net` - (Optional, block) In this block you can either enable / disable ipv4 and ipv6 or link existing primary IPs (checkout the examples).
@@ -202,7 +215,7 @@ The following attributes are exported:
 - `server_type` - (string) Name of the server type.
 - `image` - (string) Name or ID of the image the server was created from.
 - `location` - (string) The location name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `datacenter` - (string) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
+- `datacenter` - (string, deprecated) The datacenter name. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `backup_window` - (string) The backup window of the server, if enabled.
 - `backups` - (bool) Whether backups are enabled.
 - `iso` - (string) ID or Name of the mounted ISO image.


### PR DESCRIPTION
The `datacenter` attributes is deprecated in `Primary IPs` and `Servers` API resources and will be removed after 1 July 2026. See https://docs.hetzner.cloud/changelog#2025-12-16-phasing-out-datacenters for more details.

Therefor `datacenter` attributes is deprecated in favor of the `location` attribute in the following Terraform resources/datasources:

- `hcloud_server`
- `data.hcloud_server`
- `data.hcloud_servers`
- `hcloud_primary_ip`
- `data.hcloud_primary_ip`
- `data.hcloud_primary_ips`

The `location` attribute already exists for Servers, and was added for Primary IPs.

The `datacenter` attribute will not be updated anymore after it is no longer returned by the API. For existing resources this will keep the previous value, for new resources this will result in an empty string.

Please make sure to upgrade to `v1.58.0+` before the removal date to avoid potential crashes in the provider.

---

Also includes the bump for `hcloud-go/v2` to `v2.33.0`, as that markes the `Datacenter` fields as deprecated.

Replaces #1305