### PR TITLE
fix: support importing storage box without forced replacement

### DIFF
--- a/internal/storagebox/resource.go
+++ b/internal/storagebox/resource.go
@@ -604,8 +604,12 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 }
 
 func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Not setting the `ssh_keys` value during import will trigger a replacement of the resource, even if the
+	// user configured `lifecycle { ignore_changes = [ssh_keys]}`.
+
 	if id, err := strconv.ParseInt(req.ID, 10, 64); err == nil {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), id)...)
+		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("ssh_keys"), []string{})...)
 		return
 	}
 
@@ -621,4 +625,5 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 	}
 
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), in.ID)...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("ssh_keys"), []string{})...)
 }


### PR DESCRIPTION
Not setting the `ssh_keys` value during import will trigger a replacement of the resource, even if the user configured `lifecycle { ignore_changes = [ssh_keys]}`.

This may be caused by the value never being written during `Read`, and not being copied from the config to the state when using the import code path.

Fixes an issue reported in https://github.com/hetznercloud/terraform-provider-hcloud/issues/1287#issuecomment-3712227946