### PR TITLE
feat: wait for storage box running actions before retrying

### DIFF
--- a/internal/storageboxsnapshot/resource.go
+++ b/internal/storageboxsnapshot/resource.go
@@ -142,6 +142,14 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 			if hcloud.IsError(err,
 				hcloud.ErrorCodeLocked,
 			) {
+				// Wait for running actions to complete before trying again
+				actions, actionsErr := r.client.StorageBox.Action.AllFor(ctx,
+					storageBox,
+					hcloud.ActionListOpts{Status: []hcloud.ActionStatus{hcloud.ActionStatusRunning}},
+				)
+				if actionsErr == nil {
+					resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, actions...)...)
+				}
 				return err
 			}
 


### PR DESCRIPTION
Wait for running actions for the storage box to complete before trying to trigger a new action.

