### PR TITLE
docs: Storage Box Subaccount home_directory should not starting with a /

### DIFF
--- a/docs/resources/storage_box_subaccount.md
+++ b/docs/resources/storage_box_subaccount.md
@@ -57,7 +57,7 @@ resource "hcloud_storage_box_subaccount" "team_badger" {
 
 ### Required
 
-- `home_directory` (String) Home directory of the Storage Box Subaccount. The directory will be created if it doesn't exist yet.
+- `home_directory` (String) Home directory of the Storage Box Subaccount. The directory will be created if it doesn't exist yet. Must not include a leading slash (`/`).
 - `password` (String, Sensitive) Password of the Storage Box. For more details, see the [Storage Boxes password policy](https://docs.hetzner.cloud/reference/hetzner#storage-boxes-password-policy).
 - `storage_box_id` (Number) ID of the Storage Box.
 

--- a/internal/storageboxsubaccount/resource.go
+++ b/internal/storageboxsubaccount/resource.go
@@ -116,7 +116,7 @@ See the [Storage Box Subaccounts API documentation](https://docs.hetzner.cloud/r
 			},
 		},
 		"home_directory": schema.StringAttribute{
-			MarkdownDescription: "Home directory of the Storage Box Subaccount. The directory will be created if it doesn't exist yet.",
+			MarkdownDescription: "Home directory of the Storage Box Subaccount. The directory will be created if it doesn't exist yet. Must not include a leading slash (`/`).",
 			Required:            true,
 		},
 		"password": schema.StringAttribute{


### PR DESCRIPTION
Currently that will fail in the API with a generic error message. (see #1297 for details)