### PR TITLE
feat(floating-ip): unassign from server before deleting it

### DIFF
--- a/internal/floatingip/resource_assignment.go
+++ b/internal/floatingip/resource_assignment.go
@@ -194,8 +194,12 @@ func resourceFloatingIPAssignmentDelete(ctx context.Context, d *schema.ResourceD
 		return nil
 	}
 	if floatingIP.Server != nil {
-		_, _, err = client.FloatingIP.Unassign(ctx, floatingIP)
+		action, _, err := client.FloatingIP.Unassign(ctx, floatingIP)
 		if err != nil {
+			return hcloudutil.ErrorToDiag(err)
+		}
+
+		if err = client.Action.WaitFor(ctx, action); err != nil {
 			return hcloudutil.ErrorToDiag(err)
 		}
 	}

--- a/internal/floatingip/resource_assignment_test.go
+++ b/internal/floatingip/resource_assignment_test.go
@@ -67,8 +67,7 @@ func TestAccFloatingIPAssignmentResource(t *testing.T) {
 		CheckDestroy:             testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &s)),
 		Steps: []resource.TestStep{
 			{
-				// Create a new RDNS using the required values
-				// only.
+				// Create a new Floating IP Assignment
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_ssh_key", resSSHKey,
 					"testdata/r/hcloud_server", resServer,


### PR DESCRIPTION
Similar to the behaviour of Primary IPs, make sure that the Floating IP is correctly unassigned before deleting it.