### PR TITLE
fix(storage-box): subaccount name was ignored

### DIFF
--- a/internal/storageboxsubaccount/resource.go
+++ b/internal/storageboxsubaccount/resource.go
@@ -203,6 +203,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	}
 
 	opts := hcloud.StorageBoxSubaccountCreateOpts{
+		Name:          data.Name.ValueString(),
 		HomeDirectory: data.HomeDirectory.ValueString(),
 		Password:      data.Password.ValueString(),
 		Description:   data.Description.ValueString(),
@@ -382,6 +383,10 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 
 	// Update fields on resource
 	opts := hcloud.StorageBoxSubaccountUpdateOpts{}
+
+	if !data.Name.Equal(plan.Name) {
+		opts.Name = plan.Name.ValueString()
+	}
 
 	if !data.Description.Equal(plan.Description) {
 		opts.Description = plan.Description.ValueStringPointer()

--- a/internal/storageboxsubaccount/resource_test.go
+++ b/internal/storageboxsubaccount/resource_test.go
@@ -45,6 +45,7 @@ func TestAccStorageBoxSubaccountResource(t *testing.T) {
 	res.SetRName("subaccount")
 
 	resOptional := testtemplate.DeepCopy(t, res)
+	resOptional.Name = "tf-e2e-subaccount"
 	resOptional.HomeDirectory = "updated"
 	resOptional.Password = storagebox.GeneratePassword(t)
 	resOptional.Description = "tf-e2e-subaccount"
@@ -80,6 +81,7 @@ func TestAccStorageBoxSubaccountResource(t *testing.T) {
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("storage_box_id"), testsupport.Int64ExactFromFunc(func() int64 { return storageBox.ID })),
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("id"), testsupport.Int64ExactFromFunc(func() int64 { return subaccount.ID })),
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("username"), testsupport.StringExactFromFunc(func() string { return subaccount.Username })),
+					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("name"), testsupport.StringExactFromFunc(func() string { return subaccount.Username })),
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("server"), testsupport.StringExactFromFunc(func() string { return subaccount.Server })),
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("description"), knownvalue.StringExact("")),
 					statecheck.ExpectKnownValue(res.TFID(), tfjsonpath.New("home_directory"), knownvalue.StringExact("test")),
@@ -132,7 +134,8 @@ func TestAccStorageBoxSubaccountResource(t *testing.T) {
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("username"), testsupport.StringExactFromFunc(func() string { return subaccount.Username })),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("server"), testsupport.StringExactFromFunc(func() string { return subaccount.Server })),
 
-					// Changed (or will be changed in Actions PR)
+					// Changed
+					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("name"), knownvalue.StringExact("tf-e2e-subaccount")),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("description"), knownvalue.StringExact("tf-e2e-subaccount")),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("home_directory"), knownvalue.StringExact("updated")),
 					statecheck.ExpectSensitiveValue(resOptional.TFID(), tfjsonpath.New("password")),
@@ -162,6 +165,7 @@ func TestAccStorageBoxSubaccountResource(t *testing.T) {
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("id"), testsupport.Int64ExactFromFunc(func() int64 { return subaccount.ID })),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("username"), testsupport.StringExactFromFunc(func() string { return subaccount.Username })),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("server"), testsupport.StringExactFromFunc(func() string { return subaccount.Server })),
+					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("name"), knownvalue.StringExact("tf-e2e-subaccount")),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("description"), knownvalue.StringExact("tf-e2e-subaccount")),
 					statecheck.ExpectKnownValue(resOptional.TFID(), tfjsonpath.New("home_directory"), knownvalue.StringExact("updated")),
 					statecheck.ExpectSensitiveValue(resOptional.TFID(), tfjsonpath.New("password")),

--- a/internal/storageboxsubaccount/testing.go
+++ b/internal/storageboxsubaccount/testing.go
@@ -61,6 +61,7 @@ type RData struct {
 
 	StorageBox    string
 	HomeDirectory string
+	Name          string
 	Password      string
 	Description   string
 	Labels        map[string]string

--- a/internal/testdata/r/hcloud_storage_box_subaccount.tf.tmpl
+++ b/internal/testdata/r/hcloud_storage_box_subaccount.tf.tmpl
@@ -6,6 +6,10 @@ resource "hcloud_storage_box_subaccount" "{{ .RName }}" {
   home_directory = "{{ .HomeDirectory }}"
   password       = "{{ .Password }}"
 
+  {{ if .Name -}}
+  name = "{{ .Name }}"
+  {{- end }}
+
   {{ if .Description -}}
   description = "{{ .Description }}"
   {{- end }}


### PR DESCRIPTION
While the `storage_box_subaccount.name` was added in #1323, it was not actually passed on to the API. This causes the following error in case the user configured the field, as the API returned a different value:

    Error: Provider produced inconsistent result after apply

    When applying changes to hcloud_storage_box_subaccount.test, provider "provider[\"registry.opentofu.org/hetznercloud/hcloud\"]" produced an unexpected new value: .name: was
    cty.StringVal("badger"), but now cty.StringVal("u545557-sub1").

The field is now being passed to the API in "Create" and "Update", and there is a test that verifies the functionality.

Closes #1333