### PR TITLE
fix(primary-ip): reassigning fails as IP needs to be unassigned first

### DIFF
--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -226,6 +226,9 @@ func resourcePrimaryIPUpdate(ctx context.Context, d *schema.ResourceData, m inte
 				return err
 			}
 		} else {
+			if err := UnassignPrimaryIP(ctx, client, primaryIP.ID); err != nil {
+				return err
+			}
 			if err := AssignPrimaryIP(ctx, client, primaryIP.ID, serverID); err != nil {
 				return err
 			}

--- a/internal/testdata/r/hcloud_primary_ip.tf.tmpl
+++ b/internal/testdata/r/hcloud_primary_ip.tf.tmpl
@@ -13,6 +13,9 @@ resource "hcloud_primary_ip" "{{ .RName }}" {
   {{- if .AssigneeType }}
   assignee_type       = "{{ .AssigneeType }}"
   {{ end }}
+  {{- if .AssigneeID }}
+  assignee_id       = {{ .AssigneeID }}
+  {{ end }}
 
   {{- if .Labels }}
   labels = {{ .Labels | toPrettyJson }}


### PR DESCRIPTION
It is not allowed to assign an already-assigned primary IP. It first needs to be detached from its current target.

Without this, users see a [`primary_ip_already_assigned`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ip-actions/assign_primary_ip) error.