### PR TITLE
chore: use local tofu install instead of docker image for pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           python-version: 3.x
 
+      - uses: opentofu/setup-opentofu@v1
+        with:
+          tofu_wrapper: false
+
       - uses: pre-commit/action@v3.0.1
 
   lint:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,8 @@ repos:
       - id: opentofu_fmt
         name: opentofu_fmt
         description: Format all .tf files to a canonical format.
-        language: docker_image
-        entry: ghcr.io/opentofu/opentofu fmt
+        language: system
+        entry: tofu fmt
         files: \.tf$
 
   - repo: local


### PR DESCRIPTION
Remove the dependency on docker for our pre-commit hooks.

Users must install opentofu into the current PATH for the hook to work.