### PR TITLE
ci: move gitlab-ci.yml config to internal `gitlab-ci` branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,40 +1,4 @@
 include:
-  - project: cloud/integrations/ci
-    file:
-      - default.yml
-      - workflows/feature-branches.yml
-
-stages:
-  - build
-  - test
-
-variables:
-  GOMODCACHE: $CI_PROJECT_DIR/.cache/go-mod
-  GOCACHE: $CI_PROJECT_DIR/.cache/go-build
-
-cache:
-  key:
-    files:
-      - go.mod
-      - go.sum
-  paths:
-    - $GOMODCACHE
-
-build:
-  stage: build
-  image: golang:1.25
-  script:
-    - go env
-    - go mod download
-
-test:lint:
-  stage: test
-  image: golangci/golangci-lint:v2.11.3
-  script:
-    - golangci-lint run -v
-
-test:unit:
-  stage: test
-  image: golang:1.25
-  script:
-    - make test
+  - project: $CI_PROJECT_PATH
+    ref: gitlab-ci
+    file: template.gitlab-ci.yml


### PR DESCRIPTION
Moves our internal gitlab ci configuration to an internal branch. 
- Removes the need to go through GitHub to update our internal pipeline.
- Faster feedback loop for maintaining our Gitlab CI pipeline.

