### PR TITLE
docs: prefer location over deprecated datacenter attribute

### DIFF
--- a/docs/data-sources/primary_ip.md
+++ b/docs/data-sources/primary_ip.md
@@ -50,7 +50,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "fsn1"
   labels = {
     "test" : "tessst1"
   }

--- a/docs/resources/floating_ip_assignment.md
+++ b/docs/resources/floating_ip_assignment.md
@@ -20,7 +20,7 @@ resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-12"
   server_type = "cx23"
-  datacenter  = "fsn1-dc8"
+  location    = "fsn1"
 }
 
 resource "hcloud_floating_ip" "master" {

--- a/docs/resources/primary_ip.md
+++ b/docs/resources/primary_ip.md
@@ -29,7 +29,7 @@ communicating with the API.
 ```terraform
 resource "hcloud_primary_ip" "main" {
   name          = "primary_ip_test"
-  datacenter    = "fsn1-dc14"
+  location      = "fsn1"
   type          = "ipv4"
   assignee_type = "server"
   auto_delete   = true
@@ -42,7 +42,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "fsn1"
   labels = {
     "test" : "tessst1"
   }

--- a/docs/resources/rdns.md
+++ b/docs/resources/rdns.md
@@ -30,8 +30,8 @@ For Primary IPs:
 
 ```hcl
 resource "hcloud_primary_ip" "primary1" {
-  datacenter = "nbg1-dc3"
-  type       = "ipv4"
+  location = "nbg1"
+  type     = "ipv4"
 }
 
 resource "hcloud_rdns" "primary1" {

--- a/docs/resources/volume_attachment.md
+++ b/docs/resources/volume_attachment.md
@@ -21,7 +21,7 @@ resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-12"
   server_type = "cx23"
-  datacenter  = "nbg1-dc3"
+  location    = "nbg1"
 }
 
 resource "hcloud_volume" "master" {

--- a/examples/data-sources/hcloud_primary_ip/data-source.tf
+++ b/examples/data-sources/hcloud_primary_ip/data-source.tf
@@ -13,7 +13,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "fsn1"
   labels = {
     "test" : "tessst1"
   }

--- a/examples/resources/hcloud_floating_ip_assignment/resource.tf
+++ b/examples/resources/hcloud_floating_ip_assignment/resource.tf
@@ -7,7 +7,7 @@ resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-12"
   server_type = "cx23"
-  datacenter  = "fsn1-dc8"
+  location    = "fsn1"
 }
 
 resource "hcloud_floating_ip" "master" {

--- a/examples/resources/hcloud_primary_ip/resource.tf
+++ b/examples/resources/hcloud_primary_ip/resource.tf
@@ -1,6 +1,6 @@
 resource "hcloud_primary_ip" "main" {
   name          = "primary_ip_test"
-  datacenter    = "fsn1-dc14"
+  location      = "fsn1"
   type          = "ipv4"
   assignee_type = "server"
   auto_delete   = true
@@ -13,7 +13,7 @@ resource "hcloud_server" "server_test" {
   name        = "test-server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
-  datacenter  = "fsn1-dc14"
+  location    = "fsn1"
   labels = {
     "test" : "tessst1"
   }

--- a/examples/resources/hcloud_rdns/example_2.tf
+++ b/examples/resources/hcloud_rdns/example_2.tf
@@ -1,6 +1,6 @@
 resource "hcloud_primary_ip" "primary1" {
-  datacenter = "nbg1-dc3"
-  type       = "ipv4"
+  location = "nbg1"
+  type     = "ipv4"
 }
 
 resource "hcloud_rdns" "primary1" {

--- a/examples/resources/hcloud_volume_attachment/resource.tf
+++ b/examples/resources/hcloud_volume_attachment/resource.tf
@@ -8,7 +8,7 @@ resource "hcloud_server" "node1" {
   name        = "node1"
   image       = "debian-12"
   server_type = "cx23"
-  datacenter  = "nbg1-dc3"
+  location    = "nbg1"
 }
 
 resource "hcloud_volume" "master" {

--- a/templates/resources/rdns.md.tmpl
+++ b/templates/resources/rdns.md.tmpl
@@ -30,8 +30,8 @@ For Primary IPs:
 
 ```hcl
 resource "hcloud_primary_ip" "primary1" {
-  datacenter = "nbg1-dc3"
-  type       = "ipv4"
+  location = "nbg1"
+  type     = "ipv4"
 }
 
 resource "hcloud_rdns" "primary1" {


### PR DESCRIPTION
Some examples to reference the now deprecated `datacenter` attribute.