### PR TITLE
feat(datacenter, server_type): move available and recommended to server_type

### DIFF
--- a/docs/data-sources/datacenter.md
+++ b/docs/data-sources/datacenter.md
@@ -35,7 +35,7 @@ data "hcloud_datacenter" "by_name" {
 
 ### Read-Only
 
-- `available_server_type_ids` (List of Number) List of currently available Server Types in the Datacenter.
+- `available_server_type_ids` (List of Number, Deprecated) List of currently available Server Types in the Datacenter.
 - `description` (String) Description of the Datacenter.
 - `location` (Map of String) Location of the Datacenter. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
-- `supported_server_type_ids` (List of Number) List of supported Server Types in the Datacenter.
+- `supported_server_type_ids` (List of Number, Deprecated) List of supported Server Types in the Datacenter.

--- a/docs/data-sources/datacenters.md
+++ b/docs/data-sources/datacenters.md
@@ -44,9 +44,9 @@ resource "hcloud_server" "workers" {
 
 Read-Only:
 
-- `available_server_type_ids` (List of Number) List of currently available Server Types in the Datacenter.
+- `available_server_type_ids` (List of Number, Deprecated) List of currently available Server Types in the Datacenter.
 - `description` (String) Description of the Datacenter.
 - `id` (Number) ID of the Datacenter.
 - `location` (Map of String) Location of the Datacenter. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-locations-are-there) for more details about locations.
 - `name` (String) Name of the Datacenter.
-- `supported_server_type_ids` (List of Number) List of supported Server Types in the Datacenter.
+- `supported_server_type_ids` (List of Number, Deprecated) List of supported Server Types in the Datacenter.

--- a/docs/data-sources/server_type.md
+++ b/docs/data-sources/server_type.md
@@ -61,8 +61,10 @@ resource "hcloud_server" "main" {
 
 Read-Only:
 
+- `available` (Boolean) Whether the Server Type is temporarily unavailable in this Location.
 - `deprecation_announced` (String) Date of the Server Type deprecation announcement.
 - `id` (Number) ID of the Location.
 - `is_deprecated` (Boolean) Whether the Server Type is deprecated.
 - `name` (String) Name of the Location.
+- `recommended` (Boolean) Whether the Server Type is recommended in this Location.
 - `unavailable_after` (String) Date of the Server Type removal. After this date, the Server Type cannot be used anymore.

--- a/docs/data-sources/server_types.md
+++ b/docs/data-sources/server_types.md
@@ -53,8 +53,10 @@ Read-Only:
 
 Read-Only:
 
+- `available` (Boolean) Whether the Server Type is temporarily unavailable in this Location.
 - `deprecation_announced` (String) Date of the Server Type deprecation announcement.
 - `id` (Number) ID of the Location.
 - `is_deprecated` (Boolean) Whether the Server Type is deprecated.
 - `name` (String) Name of the Location.
+- `recommended` (Boolean) Whether the Server Type is recommended in this Location.
 - `unavailable_after` (String) Date of the Server Type removal. After this date, the Server Type cannot be used anymore.

--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -110,13 +110,13 @@ func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "List of supported Server Types in the Datacenter.",
 			ElementType:         types.Int64Type,
 			Computed:            true,
-			DeprecationMessage:  "This field is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[] instead.",
+			DeprecationMessage:  "This attribute is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[] instead.",
 		},
 		"available_server_type_ids": schema.ListAttribute{
 			MarkdownDescription: "List of currently available Server Types in the Datacenter.",
 			ElementType:         types.Int64Type,
 			Computed:            true,
-			DeprecationMessage:  "This field is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[].available instead.",
+			DeprecationMessage:  "This attribute is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[].available instead.",
 		},
 	}
 }

--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -110,11 +110,13 @@ func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "List of supported Server Types in the Datacenter.",
 			ElementType:         types.Int64Type,
 			Computed:            true,
+			DeprecationMessage:  "This field is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[] instead.",
 		},
 		"available_server_type_ids": schema.ListAttribute{
 			MarkdownDescription: "List of currently available Server Types in the Datacenter.",
 			ElementType:         types.Int64Type,
 			Computed:            true,
+			DeprecationMessage:  "This field is deprecated and will be dropped after 2026-10-01. Use hcloud_server_types[].locations[].available instead.",
 		},
 	}
 }

--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -202,11 +202,11 @@ func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
 								Computed:            true,
 							},
 							"available": schema.BoolAttribute{
-								MarkdownDescription: "True if currently available in this Location.",
+								MarkdownDescription: "Whether the Server Type is temporarily unavailable in this Location.",
 								Computed:            true,
 							},
 							"recommended": schema.BoolAttribute{
-								MarkdownDescription: "True if currently recommended in this Location.",
+								MarkdownDescription: "Whether the Server Type is recommended in this Location.",
 								Computed:            true,
 							},
 						},

--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -66,8 +66,10 @@ var resourceDataAttrTypes = merge.Maps(
 )
 
 type resourceDataLocation struct {
-	ID   types.Int64  `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
+	ID          types.Int64  `tfsdk:"id"`
+	Name        types.String `tfsdk:"name"`
+	Available   types.Bool   `tfsdk:"available"`
+	Recommended types.Bool   `tfsdk:"recommended"`
 
 	deprecation.DeprecationModel
 }
@@ -79,8 +81,10 @@ func (m *resourceDataLocation) tfType() attr.Type {
 func (m *resourceDataLocation) tfAttributesTypes() map[string]attr.Type {
 	return merge.Maps(
 		map[string]attr.Type{
-			"id":   types.Int64Type,
-			"name": types.StringType,
+			"id":          types.Int64Type,
+			"name":        types.StringType,
+			"available":   types.BoolType,
+			"recommended": types.BoolType,
 		},
 		deprecation.AttrTypes(),
 	)
@@ -110,8 +114,10 @@ func newResourceData(ctx context.Context, in *hcloud.ServerType) (resourceData, 
 		tfItems := make([]attr.Value, 0, len(in.Locations))
 		for _, hcItem := range in.Locations {
 			m := &resourceDataLocation{
-				ID:   types.Int64Value(hcItem.Location.ID),
-				Name: types.StringValue(hcItem.Location.Name),
+				ID:          types.Int64Value(hcItem.Location.ID),
+				Name:        types.StringValue(hcItem.Location.Name),
+				Available:   types.BoolValue(hcItem.Available),
+				Recommended: types.BoolValue(hcItem.Recommended),
 			}
 			m.DeprecationModel, newDiags = deprecation.NewDeprecationModel(ctx, hcItem)
 			diags.Append(newDiags...)
@@ -193,6 +199,14 @@ func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
 							},
 							"name": schema.StringAttribute{
 								MarkdownDescription: "Name of the Location.",
+								Computed:            true,
+							},
+							"available": schema.BoolAttribute{
+								MarkdownDescription: "True if currently available in this Location.",
+								Computed:            true,
+							},
+							"recommended": schema.BoolAttribute{
+								MarkdownDescription: "True if currently recommended in this Location.",
 								Computed:            true,
 							},
 						},

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -1,7 +1,6 @@
 package servertype_test
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -10,8 +9,6 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
-
-var boolRegexp = regexp.MustCompile("^(true|false)$")
 
 func TestAccServerTypeDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
@@ -46,8 +43,8 @@ func TestAccServerTypeDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.id", "1"),
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.name", "fsn1"),
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.is_deprecated", "false"),
-					resource.TestMatchResourceAttr(byName.TFID(), "locations.0.available", boolRegexp),
-					resource.TestMatchResourceAttr(byName.TFID(), "locations.0.recommended", boolRegexp),
+					resource.TestCheckResourceAttrSet(byName.TFID(), "locations.0.available"),
+					resource.TestCheckResourceAttrSet(byName.TFID(), "locations.0.recommended"),
 
 					resource.TestCheckResourceAttr(byName.TFID(), "included_traffic", "0"),
 					resource.TestCheckResourceAttr(byName.TFID(), "is_deprecated", "false"),
@@ -67,8 +64,8 @@ func TestAccServerTypeDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.id", "1"),
 					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.name", "fsn1"),
 					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.is_deprecated", "false"),
-					resource.TestMatchResourceAttr(byID.TFID(), "locations.0.available", boolRegexp),
-					resource.TestMatchResourceAttr(byID.TFID(), "locations.0.recommended", boolRegexp),
+					resource.TestCheckResourceAttrSet(byID.TFID(), "locations.0.available"),
+					resource.TestCheckResourceAttrSet(byID.TFID(), "locations.0.recommended"),
 
 					resource.TestCheckResourceAttr(byID.TFID(), "included_traffic", "0"),
 					resource.TestCheckResourceAttr(byID.TFID(), "is_deprecated", "false"),

--- a/internal/servertype/data_source_test.go
+++ b/internal/servertype/data_source_test.go
@@ -1,6 +1,7 @@
 package servertype_test
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -9,6 +10,8 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
+
+var boolRegexp = regexp.MustCompile("^(true|false)$")
 
 func TestAccServerTypeDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
@@ -43,6 +46,8 @@ func TestAccServerTypeDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.id", "1"),
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.name", "fsn1"),
 					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.is_deprecated", "false"),
+					resource.TestMatchResourceAttr(byName.TFID(), "locations.0.available", boolRegexp),
+					resource.TestMatchResourceAttr(byName.TFID(), "locations.0.recommended", boolRegexp),
 
 					resource.TestCheckResourceAttr(byName.TFID(), "included_traffic", "0"),
 					resource.TestCheckResourceAttr(byName.TFID(), "is_deprecated", "false"),
@@ -58,10 +63,12 @@ func TestAccServerTypeDataSource(t *testing.T) {
 					resource.TestCheckResourceAttr(byID.TFID(), "storage_type", "local"),
 					resource.TestCheckResourceAttr(byID.TFID(), "cpu_type", "shared"),
 					resource.TestCheckResourceAttr(byID.TFID(), "architecture", "x86"),
-					resource.TestCheckResourceAttr(byName.TFID(), "locations.#", "4"),
-					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.id", "1"),
-					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.name", "fsn1"),
-					resource.TestCheckResourceAttr(byName.TFID(), "locations.0.is_deprecated", "false"),
+					resource.TestCheckResourceAttr(byID.TFID(), "locations.#", "4"),
+					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.id", "1"),
+					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.name", "fsn1"),
+					resource.TestCheckResourceAttr(byID.TFID(), "locations.0.is_deprecated", "false"),
+					resource.TestMatchResourceAttr(byID.TFID(), "locations.0.available", boolRegexp),
+					resource.TestMatchResourceAttr(byID.TFID(), "locations.0.recommended", boolRegexp),
 
 					resource.TestCheckResourceAttr(byID.TFID(), "included_traffic", "0"),
 					resource.TestCheckResourceAttr(byID.TFID(), "is_deprecated", "false"),


### PR DESCRIPTION
See:
- https://docs.hetzner.cloud/changelog#2026-04-01-datacenter-deprecations
- https://github.com/hetznercloud/hcloud-go/pull/835