### PR TITLE
fix(firewall): apply_to update removes firewall from state when target resource is not found

### DIFF
--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -379,12 +379,11 @@ func syncApplyTo(ctx context.Context, d *schema.ResourceData, client *hcloud.Cli
 	if len(removeResources) > 0 {
 		actions, _, err := client.Firewall.RemoveResources(ctx, firewall, removeResources)
 		if err != nil {
-			if resourceFirewallIsNotFound(err, d) {
-				return nil
+			if !hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+				return hcloudutil.ErrorToDiag(err)
 			}
-			return hcloudutil.ErrorToDiag(err)
-		}
-		if err := waitForFirewallActions(ctx, client, actions, firewall); err != nil {
+			log.Printf("[WARN] firewall (%s) resource not found, skipping remove: %v", d.Id(), err)
+		} else if err := waitForFirewallActions(ctx, client, actions, firewall); err != nil {
 			return hcloudutil.ErrorToDiag(err)
 		}
 	}
@@ -392,9 +391,6 @@ func syncApplyTo(ctx context.Context, d *schema.ResourceData, client *hcloud.Cli
 	if len(addResources) > 0 {
 		actions, _, err := client.Firewall.ApplyResources(ctx, firewall, addResources)
 		if err != nil {
-			if resourceFirewallIsNotFound(err, d) {
-				return nil
-			}
 			return hcloudutil.ErrorToDiag(err)
 		}
 		if err := waitForFirewallActions(ctx, client, actions, firewall); err != nil {

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -379,7 +379,7 @@ func syncApplyTo(ctx context.Context, d *schema.ResourceData, client *hcloud.Cli
 	if len(removeResources) > 0 {
 		actions, _, err := client.Firewall.RemoveResources(ctx, firewall, removeResources)
 		if err != nil {
-			if !hcloud.IsError(err, hcloud.ErrorCodeFirewallResourceNotFound, hcloud.ErrorCodeNotFound) {
+			if !hcloud.IsError(err, hcloud.ErrorCodeFirewallResourceNotFound) {
 				return hcloudutil.ErrorToDiag(err)
 			}
 			log.Printf("[WARN] resource that firewall (%s) was applied to not found, skipping remove: %v", d.Id(), err)

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -379,10 +379,10 @@ func syncApplyTo(ctx context.Context, d *schema.ResourceData, client *hcloud.Cli
 	if len(removeResources) > 0 {
 		actions, _, err := client.Firewall.RemoveResources(ctx, firewall, removeResources)
 		if err != nil {
-			if !hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			if !hcloud.IsError(err, hcloud.ErrorCodeFirewallResourceNotFound, hcloud.ErrorCodeNotFound) {
 				return hcloudutil.ErrorToDiag(err)
 			}
-			log.Printf("[WARN] firewall (%s) resource not found, skipping remove: %v", d.Id(), err)
+			log.Printf("[WARN] resource that firewall (%s) was applied to not found, skipping remove: %v", d.Id(), err)
 		} else if err := waitForFirewallActions(ctx, client, actions, firewall); err != nil {
 			return hcloudutil.ErrorToDiag(err)
 		}

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
-
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/firewall"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/server"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
+
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
@@ -171,6 +173,62 @@ func TestAccFirewallResource_ApplyTo(t *testing.T) {
 					testsupport.LiftTCF(hasFirewallRule(t, &f, "in", "80", "tcp", []string{"0.0.0.0/0", "::/0"}, []string{}, "allow http in")),
 					testsupport.LiftTCF(hasLabelSelectorResource(t, &f, "key=value")),
 					testsupport.LiftTCF(hasLabelSelectorResource(t, &f, "another=value")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccFireWallResource_bug1379(t *testing.T) {
+	var (
+		fw  hcloud.Firewall
+		srv hcloud.Server
+	)
+
+	srvRes := &server.RData{
+		Name:         "applyto-server",
+		Type:         teste2e.TestServerType,
+		Image:        teste2e.TestImage,
+		LocationName: teste2e.TestLocationName,
+	}
+	srvRes.SetRName("applyto_server")
+
+	fwRes := firewall.NewRData(t, "applyto-firewall", nil, []firewall.RDataApplyTo{
+		{
+			Server: srvRes.TFID() + ".id",
+		},
+	})
+
+	tmplMan := testtemplate.Manager{}
+	config := tmplMan.Render(t,
+		"testdata/r/hcloud_server", srvRes,
+		"testdata/r/hcloud_firewall", fwRes,
+	)
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy: resource.ComposeAggregateTestCheckFunc(
+			testsupport.CheckResourcesDestroyed(server.ResourceType, server.ByID(t, &srv)),
+			testsupport.CheckResourcesDestroyed(firewall.ResourceType, firewall.ByID(t, &fw)),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(srvRes.TFID(), server.ByID(t, &srv)),
+					testsupport.CheckResourceExists(fwRes.TFID(), firewall.ByID(t, &fw)),
+					testsupport.LiftTCF(hasServerResource(t, &fw, &srv)),
+				),
+			},
+			// Taint the server to force replacement.
+			// Check that the firewall is updated to point to the new server.
+			{
+				Taint:  []string{srvRes.TFID()},
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(srvRes.TFID(), server.ByID(t, &srv)),
+					testsupport.CheckResourceExists(fwRes.TFID(), firewall.ByID(t, &fw)),
+					testsupport.LiftTCF(hasServerResource(t, &fw, &srv)),
 				),
 			},
 		},

--- a/internal/firewall/resource_test.go
+++ b/internal/firewall/resource_test.go
@@ -179,7 +179,7 @@ func TestAccFirewallResource_ApplyTo(t *testing.T) {
 	})
 }
 
-func TestAccFireWallResource_bug1379(t *testing.T) {
+func TestAccFirewallResource_ApplyToServerReplace(t *testing.T) {
 	var (
 		fw  hcloud.Firewall
 		srv hcloud.Server

--- a/internal/testdata/r/hcloud_firewall.tf.tmpl
+++ b/internal/testdata/r/hcloud_firewall.tf.tmpl
@@ -34,7 +34,7 @@ resource "hcloud_firewall" "{{ .RName }}" {
 {{- range $v := .ApplyTo }}
    apply_to {
 {{- if $v.Server }}
-        server = "{{ $v.Server }}"
+        server = {{ $v.Server }}
 {{- end }}
 {{- if $v.LabelSelector }}
         label_selector = "{{ $v.LabelSelector }}"


### PR DESCRIPTION
In `syncApplyTo`, replace the `resourceFirewallIsNotFound` call with a direct `hcloud.IsError(err, hcloud.ErrorCodeNotFound)` check that logs a warning and continues execution instead of removing the firewall from state and returning early.

Closes #1379 