### PR TITLE
fix(primary-ip): unassign before deleting a primary ip

### DIFF
--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -279,7 +279,8 @@ func resourcePrimaryIPDelete(ctx context.Context, d *schema.ResourceData, m inte
 		if server, _, err := client.Server.GetByID(ctx, assigneeID); err == nil && server != nil {
 			// The server does not have this primary ip assigned anymore, no need to try to detach it before deleting
 			// Workaround for https://github.com/hashicorp/terraform/issues/35568
-			if server.PublicNet.IPv4.ID == assigneeID || server.PublicNet.IPv6.ID == assigneeID {
+			if server.PublicNet.IPv4.ID == primaryIPID ||
+				server.PublicNet.IPv6.ID == primaryIPID {
 				offAction, _, _ := client.Server.Poweroff(ctx, server)
 				// if offErr != nil {
 				// 	return hcloudutil.ErrorToDiag(offErr)


### PR DESCRIPTION
https://github.com/hetznercloud/terraform-provider-hcloud/pull/994 introduced an invalid logic: A primary IP ID must not be compared to an assignee ID, as they are referring to 2 different resource.

This change implements the initially desired behavior.

This was noticed when one of our e2e test was timing out trying to delete a primary that was still assigned.