### PR TITLE
fix: include response correlation id in api error diagnostics

### DIFF
--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -435,12 +435,9 @@ func TestAccPrimaryIPResource_DeleteProtection(t *testing.T) {
 			},
 			{
 				// Delete protected primary IP.
-				Config:  tmplMan.Render(t, "testdata/r/hcloud_primary_ip", protected),
-				Destroy: true,
-				ExpectError: regexp.MustCompile(`Primary IP deletion is protected
-
-Error code: protected
-Status code: 423`),
+				Config:      tmplMan.Render(t, "testdata/r/hcloud_primary_ip", protected),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile(`Error code: protected`),
 			},
 			{
 				// Change primary IP protection.

--- a/internal/util/hcloudutil/error_framework.go
+++ b/internal/util/hcloudutil/error_framework.go
@@ -52,7 +52,7 @@ func APIErrorDiagnostics(err error) diag.Diagnostics {
 					"%s\n\n"+
 					"Error code: %s\n"+
 					"%s",
-				hcloudErr.Message, hcloudErr.Code, statusCodeMessage,
+				hcloudErr.Error(), hcloudErr.Code, statusCodeMessage,
 			),
 		)
 		return diagnostics

--- a/internal/util/hcloudutil/error_framework_test.go
+++ b/internal/util/hcloudutil/error_framework_test.go
@@ -72,7 +72,7 @@ Status code: 400
 					"API request failed",
 					`An unexpected error was encountered during an API request.
 
-rate limit exceeded
+rate limit exceeded (rate_limit_exceeded)
 
 Error code: rate_limit_exceeded
 Status code: 429


### PR DESCRIPTION
The correlation id was left out from the generic api error diagnostics.