### PR TITLE
feat(primary-ip): `assignee_type` attribute is now optional

### DIFF
--- a/docs/resources/primary_ip.md
+++ b/docs/resources/primary_ip.md
@@ -38,28 +38,26 @@ communicating with the API.
 
 ```terraform
 resource "hcloud_primary_ip" "main" {
-  name          = "primary_ip_test"
-  location      = "fsn1"
-  type          = "ipv4"
-  assignee_type = "server"
-  auto_delete   = true
+  name        = "primary-ip"
+  location    = "fsn1"
+  type        = "ipv4"
+  auto_delete = false
+
   labels = {
-    "hallo" : "welt"
+    key = "value"
   }
 }
+
 // Link a server to a primary IP
-resource "hcloud_server" "server_test" {
-  name        = "test-server"
+resource "hcloud_server" "main" {
+  name        = "server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
   location    = "fsn1"
-  labels = {
-    "test" : "tessst1"
-  }
+
   public_net {
     ipv4 = hcloud_primary_ip.main.id
   }
-
 }
 ```
 
@@ -68,7 +66,6 @@ resource "hcloud_server" "server_test" {
 
 ### Required
 
-- `assignee_type` (String) Type of the resource the Primary IP should be assigned to.
 - `auto_delete` (Boolean) Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.
 - `name` (String) Name of the Primary IP.
 - `type` (String) Type of the Primary IP (`ipv4` or `ipv6`).
@@ -76,6 +73,7 @@ resource "hcloud_server" "server_test" {
 ### Optional
 
 - `assignee_id` (Number) ID of the resource the Primary IP should be assigned to.
+- `assignee_type` (String) Type of the resource the Primary IP should be assigned to.
 - `datacenter` (String, Deprecated) Name of the Datacenter for the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `delete_protection` (Boolean) Whether delete protection is enabled.
 - `labels` (Map of String) User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.

--- a/examples/resources/hcloud_primary_ip/resource.tf
+++ b/examples/resources/hcloud_primary_ip/resource.tf
@@ -1,24 +1,22 @@
 resource "hcloud_primary_ip" "main" {
-  name          = "primary_ip_test"
-  location      = "fsn1"
-  type          = "ipv4"
-  assignee_type = "server"
-  auto_delete   = true
+  name        = "primary-ip"
+  location    = "fsn1"
+  type        = "ipv4"
+  auto_delete = false
+
   labels = {
-    "hallo" : "welt"
+    key = "value"
   }
 }
+
 // Link a server to a primary IP
-resource "hcloud_server" "server_test" {
-  name        = "test-server"
+resource "hcloud_server" "main" {
+  name        = "server"
   image       = "ubuntu-24.04"
   server_type = "cx23"
   location    = "fsn1"
-  labels = {
-    "test" : "tessst1"
-  }
+
   public_net {
     ipv4 = hcloud_primary_ip.main.id
   }
-
 }

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -104,10 +104,11 @@ func TestAccPrimaryIPDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &primaryip.RData{
-		Name:     "main",
-		Type:     "ipv6",
-		Location: teste2e.TestLocationName,
-		Labels:   map[string]string{"key": randutil.GenerateID()},
+		Name:         "main",
+		Type:         "ipv6",
+		Location:     teste2e.TestLocationName,
+		Labels:       map[string]string{"key": randutil.GenerateID()},
+		AssigneeType: "server", // Attribute was still required in previous versions
 	}
 	res.SetRName("main")
 

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -20,11 +20,10 @@ func TestAccPrimaryIPDataSource(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &primaryip.RData{
-		Name:         "main",
-		Type:         "ipv6",
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		Labels:       map[string]string{"key": randutil.GenerateID()},
+		Name:     "main",
+		Type:     "ipv6",
+		Location: teste2e.TestLocationName,
+		Labels:   map[string]string{"key": randutil.GenerateID()},
 	}
 	res.SetRName("main")
 
@@ -105,11 +104,10 @@ func TestAccPrimaryIPDataSource_UpgradePluginFramework(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res := &primaryip.RData{
-		Name:         "main",
-		Type:         "ipv6",
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		Labels:       map[string]string{"key": randutil.GenerateID()},
+		Name:     "main",
+		Type:     "ipv6",
+		Location: teste2e.TestLocationName,
+		Labels:   map[string]string{"key": randutil.GenerateID()},
 	}
 	res.SetRName("main")
 

--- a/internal/primaryip/helpers.go
+++ b/internal/primaryip/helpers.go
@@ -11,11 +11,11 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
 )
 
-func AssignPrimaryIP(ctx context.Context, c *hcloud.Client, primaryIPID int64, serverID int64) diag.Diagnostics {
+func AssignPrimaryIP(ctx context.Context, c *hcloud.Client, primaryIPID int64, assigneeID int64, assigneeType string) diag.Diagnostics {
 	action, _, err := c.PrimaryIP.Assign(ctx, hcloud.PrimaryIPAssignOpts{
 		ID:           primaryIPID,
-		AssigneeID:   serverID,
-		AssigneeType: "server",
+		AssigneeID:   assigneeID,
+		AssigneeType: assigneeType,
 	})
 	if err != nil {
 		return hcloudutil.ErrorToDiag(err)

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -29,6 +29,7 @@ const ResourceType = "hcloud_primary_ip"
 var _ resource.Resource = (*Resource)(nil)
 var _ resource.ResourceWithConfigure = (*Resource)(nil)
 var _ resource.ResourceWithConfigValidators = (*Resource)(nil)
+var _ resource.ResourceWithValidateConfig = (*Resource)(nil)
 var _ resource.ResourceWithImportState = (*Resource)(nil)
 
 type Resource struct {
@@ -118,7 +119,8 @@ communicating with the API.
 		},
 		"assignee_type": schema.StringAttribute{
 			MarkdownDescription: "Type of the resource the Primary IP should be assigned to.",
-			Required:            true,
+			Optional:            true,
+			Computed:            true,
 		},
 		"auto_delete": schema.BoolAttribute{
 			MarkdownDescription: "Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.",
@@ -158,6 +160,33 @@ func (r *Resource) ConfigValidators(_ context.Context) []resource.ConfigValidato
 	}
 }
 
+func (r *Resource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data model
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Raise errors/warnings for the assignee_type and assignee_id attributes. We cannot
+	// leverage [resourcevalidator.RequiredTogether] without introducing a breaking
+	// change, so we raise errors/warnings here.
+	if !data.AssigneeID.IsUnknown() && !data.AssigneeID.IsNull() && (data.AssigneeType.IsUnknown() || data.AssigneeType.IsNull()) {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("assignee_id"),
+			"Invalid Attribute Combination",
+			"These attributes must be configured together: [assignee_id,assignee_type]",
+		)
+	}
+	if !data.AssigneeType.IsUnknown() && !data.AssigneeType.IsNull() && (data.AssigneeID.IsUnknown() || data.AssigneeID.IsNull()) {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("assignee_type"),
+			"Unused Attribute",
+			"This attribute is now optional and is only required together with the assignee_id attribute. Please remove it from your configuration.",
+		)
+	}
+}
+
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	var data model
 
@@ -169,8 +198,6 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	opts := hcloud.PrimaryIPCreateOpts{
 		Name: data.Name.ValueString(),
 		Type: hcloud.PrimaryIPType(data.Type.ValueString()),
-
-		AssigneeType: data.AssigneeType.ValueString(),
 
 		AutoDelete: data.AutoDelete.ValueBoolPointer(),
 	}
@@ -193,6 +220,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		opts.Location = parts[0]
 	case !data.AssigneeID.IsUnknown() && !data.AssigneeID.IsNull():
 		opts.AssigneeID = data.AssigneeID.ValueInt64Pointer()
+		opts.AssigneeType = data.AssigneeType.ValueString()
 	}
 
 	if resp.Diagnostics.HasError() {
@@ -317,7 +345,10 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	}
 
 	// Action: Assignee ID
-	if !plan.AssigneeID.IsUnknown() && !plan.AssigneeID.Equal(data.AssigneeID) {
+	if !plan.AssigneeID.IsUnknown() &&
+		!plan.AssigneeID.Equal(data.AssigneeID) ||
+		!plan.AssigneeType.Equal(data.AssigneeType) {
+
 		if data.AssigneeID.ValueInt64() == 0 { // This handles assignee_id=null
 			action, _, err := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
 			if err != nil {
@@ -346,7 +377,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 				action, _, err := r.client.PrimaryIP.Assign(ctx, hcloud.PrimaryIPAssignOpts{
 					ID:           primaryIP.ID,
 					AssigneeID:   plan.AssigneeID.ValueInt64(),
-					AssigneeType: "server",
+					AssigneeType: plan.AssigneeType.ValueString(),
 				})
 				if err != nil {
 					resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
@@ -419,41 +450,52 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 
 	// Unassign Primary IP before deletion
 	if data.AssigneeID.ValueInt64() != 0 {
-		server, _, err := r.client.Server.GetByID(ctx, data.AssigneeID.ValueInt64())
-		if err == nil && server != nil {
-			// The server does not have this primary ip assigned anymore, no need to try to detach it before deleting
-			// Workaround for https://github.com/hashicorp/terraform/issues/35568
-			if server.PublicNet.IPv4.ID == primaryIP.ID ||
-				server.PublicNet.IPv6.ID == primaryIP.ID {
+		switch data.AssigneeType.ValueString() {
+		case "server":
+			server, _, err := r.client.Server.GetByID(ctx, data.AssigneeID.ValueInt64())
+			if err == nil && server != nil {
+				// The server does not have this primary ip assigned anymore, no need to try to detach it before deleting
+				// Workaround for https://github.com/hashicorp/terraform/issues/35568
+				if server.PublicNet.IPv4.ID == primaryIP.ID ||
+					server.PublicNet.IPv6.ID == primaryIP.ID {
 
-				{ // Power off
-					action, _, _ := r.client.Server.Poweroff(ctx, server)
-					// No error handling
+					{ // Power off
+						action, _, _ := r.client.Server.Poweroff(ctx, server)
+						// No error handling
 
-					resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
-					if resp.Diagnostics.HasError() {
-						return
+						resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+						if resp.Diagnostics.HasError() {
+							return
+						}
+					}
+					{ // Unassign
+						action, _, _ := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
+						// No error handling, because its possible that the primary IP got
+						// already unassigned on server destroy
+
+						resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+						if resp.Diagnostics.HasError() {
+							return
+						}
+					}
+					{ // Power on
+						action, _, _ := r.client.Server.Poweron(ctx, server)
+						// No error handling
+
+						resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+						if resp.Diagnostics.HasError() {
+							return
+						}
 					}
 				}
-				{ // Unassign
-					action, _, _ := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
-					// No error handling, because its possible that the primary IP got
-					// already unassigned on server destroy
+			}
+		default:
+			action, _, _ := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
+			// No error handling, because it could already be unassigned from elsewhere
 
-					resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
-					if resp.Diagnostics.HasError() {
-						return
-					}
-				}
-				{ // Power on
-					action, _, _ := r.client.Server.Poweron(ctx, server)
-					// No error handling
-
-					resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
-					if resp.Diagnostics.HasError() {
-						return
-					}
-				}
+			resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 		}
 	}

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -349,7 +349,9 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		!plan.AssigneeID.Equal(data.AssigneeID) ||
 		!plan.AssigneeType.Equal(data.AssigneeType) {
 
-		if data.AssigneeID.ValueInt64() == 0 { // This handles assignee_id=null
+		// The outer condition guarantees the assignee changed. Unassign the old
+		// assignee first (if any), then assign the new one (if any).
+		if data.AssigneeID.ValueInt64() != 0 {
 			action, _, err := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
 			if err != nil {
 				resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
@@ -360,34 +362,22 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			if resp.Diagnostics.HasError() {
 				return
 			}
-		} else {
-			{
-				action, _, err := r.client.PrimaryIP.Unassign(ctx, primaryIP.ID)
-				if err != nil {
-					resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
-					return
-				}
+		}
 
-				resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
+		if plan.AssigneeID.ValueInt64() != 0 {
+			action, _, err := r.client.PrimaryIP.Assign(ctx, hcloud.PrimaryIPAssignOpts{
+				ID:           primaryIP.ID,
+				AssigneeID:   plan.AssigneeID.ValueInt64(),
+				AssigneeType: plan.AssigneeType.ValueString(),
+			})
+			if err != nil {
+				resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+				return
 			}
-			{
-				action, _, err := r.client.PrimaryIP.Assign(ctx, hcloud.PrimaryIPAssignOpts{
-					ID:           primaryIP.ID,
-					AssigneeID:   plan.AssigneeID.ValueInt64(),
-					AssigneeType: plan.AssigneeType.ValueString(),
-				})
-				if err != nil {
-					resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
-					return
-				}
 
-				resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
-				if resp.Diagnostics.HasError() {
-					return
-				}
+			resp.Diagnostics.Append(hcloudutil.SettleActions(ctx, &r.client.Action, action)...)
+			if resp.Diagnostics.HasError() {
+				return
 			}
 		}
 	}

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -28,7 +28,6 @@ func TestAccPrimaryIPResource(t *testing.T) {
 		Name:             "primary-ip",
 		Type:             "ipv6",
 		Location:         teste2e.TestLocationName,
-		AssigneeType:     "server",
 		AutoDelete:       false,
 		DeleteProtection: true,
 		Labels:           map[string]string{"key": "value"},
@@ -102,6 +101,36 @@ func TestAccPrimaryIPResource(t *testing.T) {
 	})
 }
 
+func TestAccPrimaryIPResource_ConfigValidation(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	var hcPrimaryIP hcloud.PrimaryIP
+
+	res1 := &primaryip.RData{
+		Name:       "primary-ip",
+		Type:       "ipv6",
+		Location:   teste2e.TestLocationName,
+		AssigneeID: "1",
+		// Test missing assignee_type
+	}
+	res1.SetRName("main")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: teste2e.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(primaryip.ResourceType, primaryip.ByID(t, &hcPrimaryIP)),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_primary_ip", res1,
+				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`These attributes must be configured together: \[assignee_id,assignee_type\]`),
+			},
+		},
+	})
+}
+
 func TestAccPrimaryIPResource_WithServer(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
@@ -114,29 +143,26 @@ func TestAccPrimaryIPResource_WithServer(t *testing.T) {
 
 	// Step 1
 	res1A := &primaryip.RData{
-		Name:         "a",
-		Type:         "ipv4",
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		AutoDelete:   false,
+		Name:       "a",
+		Type:       "ipv4",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
 	}
 	res1A.SetRName("a")
 
 	res1B := &primaryip.RData{
-		Name:         "b",
-		Type:         "ipv6",
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		AutoDelete:   false,
+		Name:       "b",
+		Type:       "ipv6",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
 	}
 	res1B.SetRName("b")
 
 	res1C := &primaryip.RData{
-		Name:         "c",
-		Type:         "ipv4",
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		AutoDelete:   false,
+		Name:       "c",
+		Type:       "ipv4",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
 	}
 	res1C.SetRName("c")
 
@@ -311,8 +337,8 @@ func TestAccPrimaryIPResource_Reassign(t *testing.T) {
 	res2 := &primaryip.RData{
 		Name:         "primary-ip",
 		Type:         "ipv4",
-		AssigneeType: "server",
 		AssigneeID:   res1ServerA.TFID() + ".id",
+		AssigneeType: "server",
 		AutoDelete:   false,
 	}
 	res2.SetRName("main")
@@ -409,7 +435,6 @@ func TestAccPrimaryIPResource_DeleteProtection(t *testing.T) {
 		Name:             "main",
 		Type:             "ipv6",
 		Location:         teste2e.TestLocationName,
-		AssigneeType:     "server",
 		DeleteProtection: false,
 	}
 	unprotected.SetRName("main")
@@ -465,10 +490,9 @@ func TestAccPrimaryIPResource_DatacenterToLocation(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 
 	res1 := &primaryip.RData{
-		Name:         "datacenter-to-location",
-		Type:         "ipv6",
-		Datacenter:   teste2e.TestDataCenter,
-		AssigneeType: "server",
+		Name:       "datacenter-to-location",
+		Type:       "ipv6",
+		Datacenter: teste2e.TestDataCenter,
 	}
 	res1.SetRName("main")
 
@@ -512,13 +536,14 @@ func TestAccPrimaryIPResource_DatacenterToLocationForceNew(t *testing.T) {
 		Name:         "datacenter-to-location",
 		Type:         "ipv6",
 		Datacenter:   teste2e.TestDataCenter,
-		AssigneeType: "server",
+		AssigneeType: "server", // Attribute was still required in previous versions
 	}
 	res1.SetRName("main")
 
 	res2 := testtemplate.DeepCopy(t, res1)
 	res2.Datacenter = ""
 	res2.Location = teste2e.TestLocationName
+	res2.AssigneeType = ""
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: teste2e.PreCheck(t),

--- a/internal/rdns/resource_test.go
+++ b/internal/rdns/resource_test.go
@@ -119,10 +119,9 @@ func TestAccRDNSResource_PrimaryIP(t *testing.T) {
 
 			tmplMan := testtemplate.Manager{}
 			restPrimaryIP := &primaryip.RData{
-				Name:         tt.name,
-				Type:         tt.primaryIPType,
-				AssigneeType: "server",
-				Location:     teste2e.TestLocationName,
+				Name:     tt.name,
+				Type:     tt.primaryIPType,
+				Location: teste2e.TestLocationName,
 			}
 			restPrimaryIP.SetRName(tt.name)
 			resRDNS := rdns.NewRDataPrimaryIP(t, tt.name, restPrimaryIP.TFID()+".id", restPrimaryIP.TFID()+".ip_address", tt.dns)

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -846,7 +846,7 @@ func publicNetUpdateDecision(ctx context.Context,
 				}
 			}
 		}
-		if err := primaryip.AssignPrimaryIP(ctx, c, ipID, server.ID); err != nil {
+		if err := primaryip.AssignPrimaryIP(ctx, c, ipID, server.ID, "server"); err != nil {
 			if err := powerOnServer(ctx, c, server); err != nil {
 				return hcloudutil.ErrorToDiag(err)
 			}

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -721,22 +721,18 @@ func TestAccServerResource_PrimaryIPNetworkTests(t *testing.T) {
 	snwRes.SetRName("test-network-subnet")
 
 	primaryIPv4Res := &primaryip.RData{
-		Name:         "primaryip-v4-test",
-		Type:         "ipv4",
-		Labels:       nil,
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		AutoDelete:   false,
+		Name:       "primaryip-v4-test",
+		Type:       "ipv4",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
 	}
 	primaryIPv4Res.SetRName("primary-ip-v4")
 
 	primaryIPv6Res := &primaryip.RData{
-		Name:         "primaryip-v6-test",
-		Type:         "ipv6",
-		Labels:       nil,
-		Location:     teste2e.TestLocationName,
-		AssigneeType: "server",
-		AutoDelete:   false,
+		Name:       "primaryip-v6-test",
+		Type:       "ipv6",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
 	}
 	primaryIPv6Res.SetRName("primary-ip-v6")
 


### PR DESCRIPTION
- Raise warning if `assignee_type` is configured without `assignee_id`
- Raise error if `assignee_id` is configured without `assignee_type`

#### Primary IPs `assignee_type` behavior change

As of 1 August 2026, the behavior of the Primary IP `assignee_type` property will change, and will return `unassigned` when the Primary IP is not assigned (when `assignee_id` is `null`). The goal is to eventually assign Primary IPs to other resource types, not only to `server`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-will-return-unassigned) for more details.

In addition, the Primary IP request body `assignee_type` property of the operation [`POST /v1/primary_ips`](https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip) is now optional. Primary IPs created without `assignee_type` return `server` until 1 August 2026, after this date, its value will be `unassigned`.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-27-primary-ips-make-assignee_type-optional) for more details.
