### PR TITLE
feat(load-balancer): support `timeout_idle` http service attribute

### DIFF
--- a/docs/resources/load_balancer_service.md
+++ b/docs/resources/load_balancer_service.md
@@ -93,7 +93,6 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `cookie_name` - (string) Name of the cookie for sticky session.
 - `cookie_lifetime` - (int) Lifetime of the cookie for sticky session (in seconds).
 - `certificates` - (list[int]) List of IDs from certificates which the Load Balancer has.
-- `timeout_idle` - (int) Idle timeout for HTTP connections in seconds.
 
 `health_check` supports the following fields:
 

--- a/docs/resources/load_balancer_service.md
+++ b/docs/resources/load_balancer_service.md
@@ -60,6 +60,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `cookie_lifetime` - (Optional, int) Lifetime of the cookie for sticky session (in seconds). Default: `300`
 - `certificates` - (Optional, list[int]) List of IDs from certificates which the Load Balancer has.
 - `redirect_http` - (Optional, bool) Redirect HTTP to HTTPS traffic. Only supported for services with `protocol` `https` using the default HTTP port `80`.
+- `timeout_idle` - (Optional, int) Idle timeout for HTTP connections in seconds. Must be between `30` and `300`.
 
 `health_check` supports the following fields:
 
@@ -92,6 +93,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 - `cookie_name` - (string) Name of the cookie for sticky session.
 - `cookie_lifetime` - (int) Lifetime of the cookie for sticky session (in seconds).
 - `certificates` - (list[int]) List of IDs from certificates which the Load Balancer has.
+- `timeout_idle` - (int) Idle timeout for HTTP connections in seconds.
 
 `health_check` supports the following fields:
 

--- a/internal/loadbalancer/data_source.go
+++ b/internal/loadbalancer/data_source.go
@@ -148,6 +148,10 @@ func getCommonDataSchema() map[string]*schema.Schema {
 									Type:     schema.TypeBool,
 									Computed: true,
 								},
+								"timeout_idle": {
+									Type:     schema.TypeInt,
+									Computed: true,
+								},
 							},
 						},
 					},

--- a/internal/loadbalancer/resource_service.go
+++ b/internal/loadbalancer/resource_service.go
@@ -102,6 +102,12 @@ func ServiceResource() *schema.Resource {
 							Optional: true,
 							Computed: true,
 						},
+						"timeout_idle": {
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Computed:     true,
+							ValidateFunc: validation.IntBetween(30, 300),
+						},
 					},
 				},
 			},
@@ -363,6 +369,9 @@ func setLoadBalancerServiceSchema(d *schema.ResourceData, lb *hcloud.LoadBalance
 		if svc.HTTP.CookieLifetime > 0 {
 			httpMap["cookie_lifetime"] = int(svc.HTTP.CookieLifetime.Seconds())
 		}
+		if svc.HTTP.TimeoutIdle > 0 {
+			httpMap["timeout_idle"] = int(svc.HTTP.TimeoutIdle.Seconds())
+		}
 		if len(svc.HTTP.Certificates) > 0 {
 			certIDs := make([]int, len(svc.HTTP.Certificates))
 			for i := 0; i < len(svc.HTTP.Certificates); i++ {
@@ -451,6 +460,9 @@ func parseTFHTTP(tfHTTP []any) *hcloud.LoadBalancerAddServiceOptsHTTP {
 	if redirectHTTP, ok := httpMap["redirect_http"]; ok {
 		http.RedirectHTTP = hcloud.Ptr(redirectHTTP.(bool))
 	}
+	if timeoutIdle, ok := httpMap["timeout_idle"]; ok && timeoutIdle != 0 {
+		http.TimeoutIdle = hcloud.Ptr(timeutil.DurationFromSeconds(timeoutIdle.(int)))
+	}
 	return http
 }
 
@@ -478,6 +490,9 @@ func parseUpdateTFHTTP(tfHTTP []any) *hcloud.LoadBalancerUpdateServiceOptsHTTP {
 	}
 	if redirectHTTP, ok := httpMap["redirect_http"]; ok {
 		http.RedirectHTTP = hcloud.Ptr(redirectHTTP.(bool))
+	}
+	if timeoutIdle, ok := httpMap["timeout_idle"]; ok && timeoutIdle != 0 {
+		http.TimeoutIdle = hcloud.Ptr(timeutil.DurationFromSeconds(timeoutIdle.(int)))
 	}
 	return http
 }

--- a/internal/loadbalancer/resource_service_test.go
+++ b/internal/loadbalancer/resource_service_test.go
@@ -142,6 +142,7 @@ func TestAccLoadBalancerServiceResource_HTTP(t *testing.T) {
 						HTTP: loadbalancer.RDataServiceHTTP{
 							CookieName:     "TESTCOOKIE",
 							CookieLifeTime: 800,
+							TimeoutIdle:    60,
 						},
 					},
 				),
@@ -156,6 +157,7 @@ func TestAccLoadBalancerServiceResource_HTTP(t *testing.T) {
 					resource.TestCheckResourceAttr(svcResName, "destination_port", "8080"),
 					resource.TestCheckResourceAttr(svcResName, "http.0.cookie_name", "TESTCOOKIE"),
 					resource.TestCheckResourceAttr(svcResName, "http.0.cookie_lifetime", "800"),
+					resource.TestCheckResourceAttr(svcResName, "http.0.timeout_idle", "60"),
 				),
 			},
 			{

--- a/internal/loadbalancer/testing.go
+++ b/internal/loadbalancer/testing.go
@@ -104,6 +104,7 @@ type RDataServiceHTTP struct {
 	Certificates   []string
 	RedirectHTTP   bool
 	StickySessions bool
+	TimeoutIdle    int
 }
 
 // RDataServiceHealthCheck contains data for a load balancer service

--- a/internal/testdata/r/hcloud_load_balancer_service.tf.tmpl
+++ b/internal/testdata/r/hcloud_load_balancer_service.tf.tmpl
@@ -20,6 +20,7 @@ resource "hcloud_load_balancer_service" "{{ .Name }}" {
     {{ if .HTTP.RedirectHTTP -}}  redirect_http    = {{ .HTTP.RedirectHTTP }}{{ end }}
     {{ if .HTTP.Certificates -}}  certificates     = [{{ .HTTP.Certificates | join ", " }}]{{ end }}
     {{ if .HTTP.StickySessions -}} sticky_sessions = "{{ .HTTP.StickySessions }}"{{ end }}
+    {{ if .HTTP.TimeoutIdle -}}   timeout_idle    = {{ .HTTP.TimeoutIdle }}{{ end }}
   }
   {{ end }}
   {{- if .AddHealthCheck }}

--- a/templates/resources/load_balancer_service.md.tmpl
+++ b/templates/resources/load_balancer_service.md.tmpl
@@ -29,6 +29,7 @@ Define services for Hetzner Cloud Load Balancers.
 - `cookie_lifetime` - (Optional, int) Lifetime of the cookie for sticky session (in seconds). Default: `300`
 - `certificates` - (Optional, list[int]) List of IDs from certificates which the Load Balancer has.
 - `redirect_http` - (Optional, bool) Redirect HTTP to HTTPS traffic. Only supported for services with `protocol` `https` using the default HTTP port `80`.
+- `timeout_idle` - (Optional, int) Idle timeout for HTTP connections in seconds. Must be between `30` and `300`.
 
 `health_check` supports the following fields:
 


### PR DESCRIPTION
`timeout_idle` controls the time a http connection is allowed to idle before the load balancer drops the connection.

See the [changelog](https://docs.hetzner.cloud/changelog#2026-04-30-load-balancers-http-idle-timeout-can-now-be-configured) for more information.