### PR TITLE
docs(s3): add reference to S3 guide

### DIFF
--- a/docs/guides/s3-object-storage.md
+++ b/docs/guides/s3-object-storage.md
@@ -1,0 +1,13 @@
+---
+subcategory: ""
+page_title: "Use Hetzner Object Storage (S3)"
+---
+
+# Use Hetzner Object Storage (S3)
+
+As of today, there's no native Hetzner Cloud API to manage the S3 buckets and credentials.
+Therefore, the only supported method for managing the resources of a Hetzner Object Storage is via third-party providers.
+
+We provide an [example workflow for creating buckets in the Hetzner documentation](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket-minio-terraform/).
+
+More information about the missing support can be found in [GitHub issue #1005](https://github.com/hetznercloud/terraform-provider-hcloud/issues/1005).

--- a/templates/guides/s3-object-storage.md
+++ b/templates/guides/s3-object-storage.md
@@ -1,0 +1,11 @@
+---
+subcategory: ""
+page_title: "Use Hetzner Object Storage (S3)"
+---
+
+As of today, there's no native Hetzner Cloud API to manage the S3 buckets and credentials.
+Therefore, the only supported method for managing the resources of a Hetzner Object Storage is via third-party providers.
+
+We provide an [example workflow for creating new buckets using the `aminueza/minio` provider in the Hetzner documentation](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket-minio-terraform/).
+
+More information about the missing support can be found in [GitHub issue #1005](https://github.com/hetznercloud/terraform-provider-hcloud/issues/1005).

--- a/templates/guides/s3-object-storage.md
+++ b/templates/guides/s3-object-storage.md
@@ -3,9 +3,11 @@ subcategory: ""
 page_title: "Use Hetzner Object Storage (S3)"
 ---
 
+# Use Hetzner Object Storage (S3)
+
 As of today, there's no native Hetzner Cloud API to manage the S3 buckets and credentials.
 Therefore, the only supported method for managing the resources of a Hetzner Object Storage is via third-party providers.
 
-We provide an [example workflow for creating new buckets using the `aminueza/minio` provider in the Hetzner documentation](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket-minio-terraform/).
+We provide an [example workflow for creating buckets in the Hetzner documentation](https://docs.hetzner.com/storage/object-storage/getting-started/creating-a-bucket-minio-terraform/).
 
 More information about the missing support can be found in [GitHub issue #1005](https://github.com/hetznercloud/terraform-provider-hcloud/issues/1005).


### PR DESCRIPTION
By adding a reference to the existing guide on docs.hetzner.com, customers that want to manage the S3 buckets declaratively no longer have to search for #1005 or for said documentation via their preferred search engine.

## Open dicussion points

1. Should we add a reference to the GitHub issue?
2. Should we write down more details about why the feature isn't there, effectively duplicating some of the information in the GitHub issue for broader transparency?