### PR TITLE
feat: Add declarative power management for hcloud_server

### DIFF
--- a/docs/resources/server_power_state.md
+++ b/docs/resources/server_power_state.md
@@ -1,0 +1,49 @@
+---
+page_title: "hcloud_server_power_state Resource - hcloud"
+subcategory: ""
+description: |-
+  Manages the power state of a Hetzner Cloud Server.
+---
+
+# hcloud_server_power_state
+
+Manages the power state of a Hetzner Cloud Server.
+
+This resource only manages whether the server is running or off. Destroying this resource removes power state management from Terraform/OpenTofu state and does not power off, power on, or delete the server.
+
+## Example Usage
+
+```terraform
+resource "hcloud_server" "example" {
+  name        = "example"
+  server_type = "cx22"
+  image       = "debian-12"
+}
+
+resource "hcloud_server_power_state" "example" {
+  server_id = hcloud_server.example.id
+  state     = "off"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `server_id` - (Required, int) ID of the server whose power state should be managed.
+- `state` - (Required, string) Desired power state of the server. Valid values are `running` and `off`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - (int) ID of the server whose power state is managed.
+- `status` - (string) Raw status returned by the Hetzner Cloud API.
+
+## Import
+
+Server power state management can be imported using the server ID:
+
+```shell
+terraform import hcloud_server_power_state.example <server_id>
+```

--- a/examples/resources/hcloud_server_power_state/import.sh
+++ b/examples/resources/hcloud_server_power_state/import.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+terraform import hcloud_server_power_state.example <server_id>

--- a/examples/resources/hcloud_server_power_state/resource.tf
+++ b/examples/resources/hcloud_server_power_state/resource.tf
@@ -1,0 +1,10 @@
+resource "hcloud_server" "example" {
+  name        = "example"
+  server_type = "cx22"
+  image       = "debian-12"
+}
+
+resource "hcloud_server_power_state" "example" {
+  server_id = hcloud_server.example.id
+  state     = "off"
+}

--- a/hcloud/provider.go
+++ b/hcloud/provider.go
@@ -91,6 +91,7 @@ func Provider() *schema.Provider {
 			network.RouteResourceType:         network.RouteResource(),
 			network.SubnetResourceType:        network.SubnetResource(),
 			rdns.ResourceType:                 rdns.Resource(),
+			server.PowerStateResourceType:     server.PowerStateResource(),
 			server.ResourceType:               server.Resource(),
 			snapshot.ResourceType:             snapshot.Resource(),
 			volume.AttachmentResourceType:     volume.AttachmentResource(),

--- a/hcloud/provider_test.go
+++ b/hcloud/provider_test.go
@@ -41,6 +41,7 @@ func TestProvider_Resources(t *testing.T) {
 		network.RouteResourceType,
 		network.SubnetResourceType,
 		rdns.ResourceType,
+		server.PowerStateResourceType,
 		server.ResourceType,
 		snapshot.ResourceType,
 		volume.AttachmentResourceType,

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -26,6 +26,11 @@ import (
 // ResourceType is the type name of the Hetzner Cloud Server resource.
 const ResourceType = "hcloud_server"
 
+const (
+	serverPowerStateRunning = "running"
+	serverPowerStateOff     = "off"
+)
+
 // Resource creates a Terraform schema for the hcloud_server resource.
 func Resource() *schema.Resource {
 	return &schema.Resource{
@@ -1469,6 +1474,47 @@ func powerOnServer(ctx context.Context, c *hcloud.Client, server *hcloud.Server)
 		return err
 	}
 	return nil
+}
+
+func powerStateFromServerStatus(status hcloud.ServerStatus) string {
+	switch status {
+	case hcloud.ServerStatusRunning, hcloud.ServerStatusStarting:
+		return serverPowerStateRunning
+	case hcloud.ServerStatusOff, hcloud.ServerStatusStopping:
+		return serverPowerStateOff
+	default:
+		return string(status)
+	}
+}
+
+func setPowerState(ctx context.Context, c *hcloud.Client, server *hcloud.Server, powerState string) error {
+	serverID := server.ID
+	server, _, err := c.Server.GetByID(ctx, serverID)
+	if err != nil {
+		return err
+	}
+	if server == nil {
+		return fmt.Errorf("server not found: %d", serverID)
+	}
+
+	switch powerState {
+	case serverPowerStateRunning:
+		if server.Status == hcloud.ServerStatusRunning || server.Status == hcloud.ServerStatusStarting {
+			return nil
+		}
+		return powerOnServer(ctx, c, server)
+	case serverPowerStateOff:
+		if server.Status == hcloud.ServerStatusOff || server.Status == hcloud.ServerStatusStopping {
+			return nil
+		}
+		action, _, err := c.Server.Poweroff(ctx, server)
+		if err != nil {
+			return err
+		}
+		return c.Action.WaitFor(ctx, action)
+	default:
+		return fmt.Errorf("unsupported power_state %q", powerState)
+	}
 }
 
 func publicNetRemovedDecision(ctx context.Context,

--- a/internal/server/resource_power_state.go
+++ b/internal/server/resource_power_state.go
@@ -1,0 +1,123 @@
+package server
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
+)
+
+// PowerStateResourceType is the type name of the Hetzner Cloud Server Power State resource.
+const PowerStateResourceType = "hcloud_server_power_state"
+
+// PowerStateResource creates a Terraform schema for the hcloud_server_power_state resource.
+func PowerStateResource() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceServerPowerStateCreate,
+		ReadContext:   resourceServerPowerStateRead,
+		UpdateContext: resourceServerPowerStateUpdate,
+		DeleteContext: resourceServerPowerStateDelete,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"server_id": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+				Description: "ID of the server whose power state should be managed.",
+			},
+			"state": {
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "Desired power state of the server. Valid values are \"running\" and \"off\".",
+				ValidateFunc: validation.StringInSlice([]string{
+					serverPowerStateRunning,
+					serverPowerStateOff,
+				}, false),
+			},
+			"status": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "Raw status returned by the Hetzner Cloud API.",
+			},
+		},
+	}
+}
+
+func resourceServerPowerStateCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	client := m.(*hcloud.Client)
+	serverID := util.CastInt64(d.Get("server_id"))
+	d.SetId(util.FormatID(serverID))
+
+	if err := setPowerState(ctx, client, &hcloud.Server{ID: serverID}, d.Get("state").(string)); err != nil {
+		return hcloudutil.ErrorToDiag(err)
+	}
+
+	return resourceServerPowerStateRead(ctx, d, m)
+}
+
+func resourceServerPowerStateRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	client := m.(*hcloud.Client)
+
+	serverID, err := util.ParseID(d.Id())
+	if err != nil {
+		log.Printf("[WARN] invalid server power state id (%s), removing from state: %v", d.Id(), err)
+		d.SetId("")
+		return nil
+	}
+
+	server, _, err := client.Server.GetByID(ctx, serverID)
+	if err != nil {
+		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
+			log.Printf("[WARN] Server (%s) not found, removing power state resource from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return hcloudutil.ErrorToDiag(err)
+	}
+	if server == nil {
+		d.SetId("")
+		return nil
+	}
+
+	util.SetSchemaFromAttributes(d, map[string]any{
+		"server_id": server.ID,
+		"state":     powerStateFromServerStatus(server.Status),
+		"status":    server.Status,
+	})
+
+	return nil
+}
+
+func resourceServerPowerStateUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
+	client := m.(*hcloud.Client)
+
+	serverID, err := util.ParseID(d.Id())
+	if err != nil {
+		log.Printf("[WARN] invalid server power state id (%s), removing from state: %v", d.Id(), err)
+		d.SetId("")
+		return nil
+	}
+
+	if d.HasChange("state") {
+		if err := setPowerState(ctx, client, &hcloud.Server{ID: serverID}, d.Get("state").(string)); err != nil {
+			return hcloudutil.ErrorToDiag(err)
+		}
+	}
+
+	return resourceServerPowerStateRead(ctx, d, m)
+}
+
+func resourceServerPowerStateDelete(_ context.Context, d *schema.ResourceData, _ any) diag.Diagnostics {
+	d.SetId("")
+	return nil
+}

--- a/internal/server/testing.go
+++ b/internal/server/testing.go
@@ -124,6 +124,19 @@ func (d *RDataNetwork) TFID() string {
 	return fmt.Sprintf("%s.%s", NetworkResourceType, d.RName())
 }
 
+// RDataPowerState defines the fields for the "testdata/r/hcloud_server_power_state" template.
+type RDataPowerState struct {
+	testtemplate.DataCommon
+
+	ServerID string
+	State    string
+}
+
+// TFID returns the resource identifier.
+func (d *RDataPowerState) TFID() string {
+	return fmt.Sprintf("%s.%s", PowerStateResourceType, d.RName())
+}
+
 // AData defines the fields for the "testdata/a/hcloud_server"
 // template.
 type AData struct {

--- a/internal/testdata/r/hcloud_server_power_state.tf.tmpl
+++ b/internal/testdata/r/hcloud_server_power_state.tf.tmpl
@@ -1,0 +1,6 @@
+{{- /* vim: set ft=terraform: */ -}}
+
+resource "hcloud_server_power_state" "{{ .RName }}" {
+  server_id = {{ .ServerID }}
+  state     = "{{ .State }}"
+}

--- a/templates/resources/server_power_state.md.tmpl
+++ b/templates/resources/server_power_state.md.tmpl
@@ -1,0 +1,49 @@
+---
+page_title: "hcloud_server_power_state Resource - hcloud"
+subcategory: ""
+description: |-
+  Manages the power state of a Hetzner Cloud Server.
+---
+
+# hcloud_server_power_state
+
+Manages the power state of a Hetzner Cloud Server.
+
+This resource only manages whether the server is running or off. Destroying this resource removes power state management from Terraform/OpenTofu state and does not power off, power on, or delete the server.
+
+## Example Usage
+
+```terraform
+resource "hcloud_server" "example" {
+  name        = "example"
+  server_type = "cx22"
+  image       = "debian-12"
+}
+
+resource "hcloud_server_power_state" "example" {
+  server_id = hcloud_server.example.id
+  state     = "off"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `server_id` - (Required, int) ID of the server whose power state should be managed.
+- `state` - (Required, string) Desired power state of the server. Valid values are `running` and `off`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+- `id` - (int) ID of the server whose power state is managed.
+- `status` - (string) Raw status returned by the Hetzner Cloud API.
+
+## Import
+
+Server power state management can be imported using the server ID:
+
+```shell
+terraform import hcloud_server_power_state.example <server_id>
+```


### PR DESCRIPTION
Adds a new `hcloud_server_power_state` SDK resource to manage Hetzner Cloud server power state declaratively through normal plan/apply workflows.

This enables OpenTofu-compatible power on/off management without relying on Terraform actions, while keeping the existing action-based resources unchanged. The new resource supports `state = "running"` and `state ="off"`,  reports the raw server status, and removes only power-state management on destroy without changing the server.