### PR TITLE
test: drop terraform v1.13 and add terraform v1.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,9 +54,9 @@ jobs:
           - tool: opentofu
             version: v1.11.x
           - tool: terraform
-            version: v1.13.x
-          - tool: terraform
             version: v1.14.x
+          - tool: terraform
+            version: v1.15.x
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
```rp-commits
feat: drop support for terraform v1.13 (#1418)
feat: add support for terraform v1.15 (#1418)
```

Update test matrix to use the latest terraform versions.