### PR TITLE
test: drop opentofu v1.9 and add opentofu v1.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,11 @@ jobs:
       matrix:
         include:
           - tool: opentofu
-            version: v1.9.x
-          - tool: opentofu
             version: v1.10.x
           - tool: opentofu
             version: v1.11.x
+          - tool: opentofu
+            version: v1.12.x
           - tool: terraform
             version: v1.14.x
           - tool: terraform


### PR DESCRIPTION
```rp-commits
feat: drop support for opentofu v1.9 (#1420)
feat: add support for opentofu v1.12 (#1420)
```

Update test matrix to use the latest opentofu versions.