### PR TITLE
test: add testing blueprints

### DIFF
--- a/internal/network/testing.go
+++ b/internal/network/testing.go
@@ -102,3 +102,67 @@ type RDataRoute struct {
 func (d *RDataRoute) TFID() string {
 	return fmt.Sprintf("%s.%s", RouteResourceType, d.RName())
 }
+
+type Blueprint struct {
+	NetworkA *RData
+	SubnetA1 *RDataSubnet
+	SubnetA2 *RDataSubnet
+
+	NetworkB *RData
+	SubnetB1 *RDataSubnet
+	SubnetB2 *RDataSubnet
+}
+
+func NewBlueprint(t *testing.T) *Blueprint {
+	t.Helper()
+
+	b := &Blueprint{}
+
+	// Network A
+	b.NetworkA = &RData{
+		Name:    "a",
+		IPRange: "10.0.0.0/16",
+	}
+	b.NetworkA.SetRName("network_a")
+
+	b.SubnetA1 = &RDataSubnet{
+		NetworkID:   b.NetworkA.TFID() + ".id",
+		NetworkZone: "eu-central",
+		IPRange:     "10.0.1.0/24",
+		Type:        "cloud",
+	}
+	b.SubnetA1.SetRName("subnet_a1")
+
+	b.SubnetA2 = &RDataSubnet{
+		NetworkID:   b.NetworkA.TFID() + ".id",
+		NetworkZone: "eu-central",
+		IPRange:     "10.0.2.0/24",
+		Type:        "cloud",
+	}
+	b.SubnetA2.SetRName("subnet_a2")
+
+	// Network B
+	b.NetworkB = &RData{
+		Name:    "b",
+		IPRange: "172.16.0.0/16",
+	}
+	b.NetworkB.SetRName("network_b")
+
+	b.SubnetB1 = &RDataSubnet{
+		NetworkID:   b.NetworkB.TFID() + ".id",
+		NetworkZone: "eu-central",
+		IPRange:     "172.16.1.0/24",
+		Type:        "cloud",
+	}
+	b.SubnetB1.SetRName("subnet_b1")
+
+	b.SubnetB2 = &RDataSubnet{
+		NetworkID:   b.NetworkB.TFID() + ".id",
+		NetworkZone: "eu-central",
+		IPRange:     "172.16.2.0/24",
+		Type:        "cloud",
+	}
+	b.SubnetB2.SetRName("subnet_b2")
+
+	return b
+}

--- a/internal/primaryip/testing.go
+++ b/internal/primaryip/testing.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
 )
@@ -87,4 +88,51 @@ type RData struct {
 // TFID returns the resource identifier.
 func (d *RData) TFID() string {
 	return fmt.Sprintf("%s.%s", ResourceType, d.RName())
+}
+
+type Blueprint struct {
+	PrimaryIPv4A *RData
+	PrimaryIPv4B *RData
+	PrimaryIPv6C *RData
+	PrimaryIPv6D *RData
+}
+
+func NewBlueprint(t *testing.T) *Blueprint {
+	t.Helper()
+
+	b := &Blueprint{}
+
+	b.PrimaryIPv4A = &RData{
+		Name:       "a-ipv4",
+		Type:       "ipv4",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
+	}
+	b.PrimaryIPv4A.SetRName("primary_ipv4_a")
+
+	b.PrimaryIPv4B = &RData{
+		Name:       "b-ipv4",
+		Type:       "ipv4",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
+	}
+	b.PrimaryIPv4B.SetRName("primary_ipv4_b")
+
+	b.PrimaryIPv6C = &RData{
+		Name:       "c-ipv6",
+		Type:       "ipv6",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
+	}
+	b.PrimaryIPv6C.SetRName("primary_ipv6_c")
+
+	b.PrimaryIPv6D = &RData{
+		Name:       "d-ipv6",
+		Type:       "ipv6",
+		Location:   teste2e.TestLocationName,
+		AutoDelete: false,
+	}
+	b.PrimaryIPv6D.SetRName("primary_ipv6_d")
+
+	return b
 }


### PR DESCRIPTION
Blueprints are tests building blocks for quickly setting up a set of resources without having to duplicate the code to define them over and over.

For example, a network resource always needs a subnet to connect resource to it. The network blueprint includes the network resource and the subnets resources already configured and linked together.

 