### PR TITLE
feat(primary-ip): make `auto_delete` attribute optional

### DIFF
--- a/docs/resources/primary_ip.md
+++ b/docs/resources/primary_ip.md
@@ -73,7 +73,7 @@ resource "hcloud_server" "main" {
 
 - `assignee_id` (Number) ID of the resource the Primary IP should be assigned to.
 - `assignee_type` (String) Type of the resource the Primary IP should be assigned to.
-- `auto_delete` (Boolean) Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.
+- `auto_delete` (Boolean) Whether auto delete is enabled. Setting `auto_delete` to `true` is not recommended, because if a server assigned to the managed ip is deleted, it will also delete the primary IP which will break the terraform state.
 - `datacenter` (String, Deprecated) Name of the Datacenter for the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `delete_protection` (Boolean) Whether delete protection is enabled.
 - `labels` (Map of String) User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.

--- a/docs/resources/primary_ip.md
+++ b/docs/resources/primary_ip.md
@@ -66,7 +66,6 @@ resource "hcloud_server" "main" {
 
 ### Required
 
-- `auto_delete` (Boolean) Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.
 - `name` (String) Name of the Primary IP.
 - `type` (String) Type of the Primary IP (`ipv4` or `ipv6`).
 
@@ -74,6 +73,7 @@ resource "hcloud_server" "main" {
 
 - `assignee_id` (Number) ID of the resource the Primary IP should be assigned to.
 - `assignee_type` (String) Type of the resource the Primary IP should be assigned to.
+- `auto_delete` (Boolean) Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.
 - `datacenter` (String, Deprecated) Name of the Datacenter for the Primary IP. See the [Hetzner Docs](https://docs.hetzner.com/cloud/general/locations/#what-datacenters-are-there) for more details about datacenters.
 - `delete_protection` (Boolean) Whether delete protection is enabled.
 - `labels` (Map of String) User-defined [labels](https://docs.hetzner.cloud/reference/cloud#labels) (key-value pairs) for the resource.

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -126,6 +126,7 @@ communicating with the API.
 			MarkdownDescription: "Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.",
 			Optional:            true,
 			Computed:            true,
+			Default:             booldefault.StaticBool(false),
 		},
 		"labels": resourceutil.LabelsSchema(),
 		"delete_protection": schema.BoolAttribute{

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -123,7 +123,7 @@ communicating with the API.
 			Computed:            true,
 		},
 		"auto_delete": schema.BoolAttribute{
-			MarkdownDescription: "Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.",
+			MarkdownDescription: "Whether auto delete is enabled. Setting `auto_delete` to `true` is not recommended, because if a server assigned to the managed ip is deleted, it will also delete the primary IP which will break the terraform state.",
 			Optional:            true,
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),

--- a/internal/primaryip/resource.go
+++ b/internal/primaryip/resource.go
@@ -124,7 +124,8 @@ communicating with the API.
 		},
 		"auto_delete": schema.BoolAttribute{
 			MarkdownDescription: "Whether auto delete is enabled. Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip is getting deleted, it will also delete the primary IP which will break the terraform state.",
-			Required:            true,
+			Optional:            true,
+			Computed:            true,
 		},
 		"labels": resourceutil.LabelsSchema(),
 		"delete_protection": schema.BoolAttribute{
@@ -198,8 +199,10 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	opts := hcloud.PrimaryIPCreateOpts{
 		Name: data.Name.ValueString(),
 		Type: hcloud.PrimaryIPType(data.Type.ValueString()),
+	}
 
-		AutoDelete: data.AutoDelete.ValueBoolPointer(),
+	if !data.AutoDelete.IsUnknown() && !data.AutoDelete.IsNull() {
+		opts.AutoDelete = data.AutoDelete.ValueBoolPointer()
 	}
 
 	resp.Diagnostics.Append(hcloudutil.TerraformLabelsToHCloud(ctx, data.Labels, &opts.Labels)...)

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -29,7 +29,6 @@ func TestAccPrimaryIPResource(t *testing.T) {
 		Name:             "primary-ip",
 		Type:             "ipv6",
 		Location:         teste2e.TestLocationName,
-		AutoDelete:       false,
 		DeleteProtection: true,
 		Labels:           map[string]string{"key": "value"},
 	}
@@ -38,7 +37,7 @@ func TestAccPrimaryIPResource(t *testing.T) {
 	res3 := testtemplate.DeepCopy(t, res1)
 	res3.Name = res1.Name + "-changed"
 	res3.Labels = map[string]string{"key": "changed"}
-	res3.AutoDelete = true
+	res3.AutoDelete = hcloud.Ptr(true)
 	res3.DeleteProtection = false
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -144,26 +143,23 @@ func TestAccPrimaryIPResource_WithServer(t *testing.T) {
 
 	// Step 1
 	res1A := &primaryip.RData{
-		Name:       "a",
-		Type:       "ipv4",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "a",
+		Type:     "ipv4",
+		Location: teste2e.TestLocationName,
 	}
 	res1A.SetRName("a")
 
 	res1B := &primaryip.RData{
-		Name:       "b",
-		Type:       "ipv6",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "b",
+		Type:     "ipv6",
+		Location: teste2e.TestLocationName,
 	}
 	res1B.SetRName("b")
 
 	res1C := &primaryip.RData{
-		Name:       "c",
-		Type:       "ipv4",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "c",
+		Type:     "ipv4",
+		Location: teste2e.TestLocationName,
 	}
 	res1C.SetRName("c")
 
@@ -340,7 +336,7 @@ func TestAccPrimaryIPResource_Reassign(t *testing.T) {
 		Type:         "ipv4",
 		AssigneeID:   res1ServerA.TFID() + ".id",
 		AssigneeType: "server",
-		AutoDelete:   false,
+		AutoDelete:   hcloud.Ptr(false),
 	}
 	res2.SetRName("main")
 

--- a/internal/primaryip/testing.go
+++ b/internal/primaryip/testing.go
@@ -79,7 +79,7 @@ type RData struct {
 	AssigneeType     string
 	AssigneeID       string
 	Labels           map[string]string
-	AutoDelete       bool
+	AutoDelete       *bool
 	DeleteProtection bool
 
 	Raw string
@@ -103,34 +103,30 @@ func NewBlueprint(t *testing.T) *Blueprint {
 	b := &Blueprint{}
 
 	b.PrimaryIPv4A = &RData{
-		Name:       "a-ipv4",
-		Type:       "ipv4",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "a-ipv4",
+		Type:     "ipv4",
+		Location: teste2e.TestLocationName,
 	}
 	b.PrimaryIPv4A.SetRName("primary_ipv4_a")
 
 	b.PrimaryIPv4B = &RData{
-		Name:       "b-ipv4",
-		Type:       "ipv4",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "b-ipv4",
+		Type:     "ipv4",
+		Location: teste2e.TestLocationName,
 	}
 	b.PrimaryIPv4B.SetRName("primary_ipv4_b")
 
 	b.PrimaryIPv6C = &RData{
-		Name:       "c-ipv6",
-		Type:       "ipv6",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "c-ipv6",
+		Type:     "ipv6",
+		Location: teste2e.TestLocationName,
 	}
 	b.PrimaryIPv6C.SetRName("primary_ipv6_c")
 
 	b.PrimaryIPv6D = &RData{
-		Name:       "d-ipv6",
-		Type:       "ipv6",
-		Location:   teste2e.TestLocationName,
-		AutoDelete: false,
+		Name:     "d-ipv6",
+		Type:     "ipv6",
+		Location: teste2e.TestLocationName,
 	}
 	b.PrimaryIPv6D.SetRName("primary_ipv6_d")
 

--- a/internal/testdata/r/hcloud_primary_ip.tf.tmpl
+++ b/internal/testdata/r/hcloud_primary_ip.tf.tmpl
@@ -21,7 +21,9 @@ resource "hcloud_primary_ip" "{{ .RName }}" {
   labels = {{ .Labels | toPrettyJson }}
   {{- end }}
 
+  {{- if ne .AutoDelete nil }}
   auto_delete       = {{ .AutoDelete }}
+  {{- end }}
   {{- if .DeleteProtection }}
   delete_protection = {{ .DeleteProtection }}
   {{ end }}


### PR DESCRIPTION
The `auto_delete` attribute is currently required, but we recommend always setting its value to `false`:

     Setting `auto_delete` to `false` is recommended, because if a server assigned to the managed ip
     is getting deleted, it will also delete the primary IP which will break the terraform state.

This change makes the `auto_delete` attribute optional, and defaults to false. Simplifying user's configurations and using a recommended default.

https://docs.hetzner.cloud/reference/cloud#tag/primary-ips/create_primary_ip