### PR TITLE
refactor: allow multiple key=value for not found diagnostics

### DIFF
--- a/internal/util/hcloudutil/error_framework.go
+++ b/internal/util/hcloudutil/error_framework.go
@@ -78,9 +78,26 @@ func APIErrorIsNotFound(err error) bool {
 	return false
 }
 
-func NotFoundDiagnostic(resourceName string, key string, value any) diag.Diagnostic {
-	return diag.NewErrorDiagnostic(
-		"Resource not found",
-		fmt.Sprintf("Resource (%s) was not found: %s=%s", resourceName, key, fmt.Sprint(value)),
-	)
+func NotFoundDiagnostic(resourceName string, values ...any) diag.Diagnostic {
+	b := &strings.Builder{}
+
+	fmt.Fprintf(b, "Resource (%s) was not found", resourceName)
+
+	if len(values) > 0 {
+		fmt.Fprint(b, ":")
+		// len(values) == 1: value
+		// len(values) == 2: key=value
+		// len(values) == 3: value key=value
+		// len(values) == 4: key=value key=value
+		offset := 0
+		if len(values)%2 != 0 {
+			offset = 1
+			fmt.Fprintf(b, " %v", values[0])
+		}
+		for i := offset; i < len(values); i += 2 {
+			fmt.Fprintf(b, " %s=%v", values[i], values[i+1])
+		}
+	}
+
+	return diag.NewErrorDiagnostic("Resource not found", b.String())
 }

--- a/internal/util/hcloudutil/error_framework_test.go
+++ b/internal/util/hcloudutil/error_framework_test.go
@@ -152,6 +152,26 @@ func TestNotFoundDiagnostics(t *testing.T) {
 			actual:   NotFoundDiagnostic("ssh_key", "name", "my-ssh-key"),
 			expected: diag.NewErrorDiagnostic("Resource not found", "Resource (ssh_key) was not found: name=my-ssh-key"),
 		},
+		{
+			name:     "ssh key with 1 arg",
+			actual:   NotFoundDiagnostic("ssh_key", "arg1"),
+			expected: diag.NewErrorDiagnostic("Resource not found", "Resource (ssh_key) was not found: arg1"),
+		},
+		{
+			name:     "ssh key with 2 args",
+			actual:   NotFoundDiagnostic("ssh_key", "arg1", "arg2"),
+			expected: diag.NewErrorDiagnostic("Resource not found", "Resource (ssh_key) was not found: arg1=arg2"),
+		},
+		{
+			name:     "ssh key with 3 args",
+			actual:   NotFoundDiagnostic("ssh_key", "arg1", "arg2", "arg3"),
+			expected: diag.NewErrorDiagnostic("Resource not found", "Resource (ssh_key) was not found: arg1 arg2=arg3"),
+		},
+		{
+			name:     "ssh key with 4 args",
+			actual:   NotFoundDiagnostic("ssh_key", "arg1", "arg2", "arg3", "arg4"),
+			expected: diag.NewErrorDiagnostic("Resource not found", "Resource (ssh_key) was not found: arg1=arg2 arg3=arg4"),
+		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			assert.Equal(t, testCase.expected, testCase.actual)


### PR DESCRIPTION
Some resource are queried using more than one criteria. This allows to reuse the not found diagnostic helper and provide the users all the search criteria that resulted in a not found.