### PR TITLE
chore: upgrade go to v1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hetznercloud/terraform-provider-hcloud
 
-go 1.26.0
+go 1.26.4
 
 toolchain go1.26.3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hetznercloud/terraform-provider-hcloud
 
-go 1.25.8
+go 1.26.0
 
 toolchain go1.26.3
 

--- a/internal/firewall/resource.go
+++ b/internal/firewall/resource.go
@@ -206,11 +206,11 @@ func toHcloudRule(tfRawRule any) (hcloud.FirewallRule, bool) {
 	}
 	rawPort := tfRule["port"].(string)
 	if rawPort != "" {
-		rule.Port = hcloud.Ptr(rawPort)
+		rule.Port = new(rawPort)
 	}
 	rawDescription := tfRule["description"].(string)
 	if rawDescription != "" {
-		rule.Description = hcloud.Ptr(rawDescription)
+		rule.Description = new(rawDescription)
 	}
 	for _, sourceIP := range tfRule["source_ips"].(*schema.Set).List() {
 		// We ignore the error here, because it was already validated before

--- a/internal/floatingip/resource.go
+++ b/internal/floatingip/resource.go
@@ -84,10 +84,10 @@ func resourceFloatingIPCreate(ctx context.Context, d *schema.ResourceData, m any
 
 	opts := hcloud.FloatingIPCreateOpts{
 		Type:        hcloud.FloatingIPType(d.Get("type").(string)),
-		Description: hcloud.Ptr(d.Get("description").(string)),
+		Description: new(d.Get("description").(string)),
 	}
 	if name, ok := d.GetOk("name"); ok {
-		opts.Name = hcloud.Ptr(name.(string))
+		opts.Name = new(name.(string))
 	}
 	if serverID, ok := d.GetOk("server_id"); ok {
 		opts.Server = &hcloud.Server{ID: util.CastInt64(serverID)}

--- a/internal/loadbalancer/resource_network_test.go
+++ b/internal/loadbalancer/resource_network_test.go
@@ -97,7 +97,7 @@ func TestAccLoadBalancerNetworkResource_NetworkID(t *testing.T) {
 		LoadBalancerID:        b.loadBalancer1.TFID() + ".id",
 		NetworkID:             b.network.TFID() + ".id",
 		IP:                    "10.0.1.5",
-		EnablePublicInterface: hcloud.Ptr(false),
+		EnablePublicInterface: new(false),
 		DependsOn:             []string{b.subnet1.TFID()},
 	}
 	res1.SetRName("attachment")
@@ -107,7 +107,7 @@ func TestAccLoadBalancerNetworkResource_NetworkID(t *testing.T) {
 		LoadBalancerID:        res1.LoadBalancerID,
 		NetworkID:             res1.NetworkID,
 		IP:                    res1.IP,
-		EnablePublicInterface: hcloud.Ptr(true),
+		EnablePublicInterface: new(true),
 		DependsOn:             res1.DependsOn,
 	}
 	res2.SetRName("attachment")

--- a/internal/loadbalancer/resource_service.go
+++ b/internal/loadbalancer/resource_service.go
@@ -211,12 +211,12 @@ func resourceLoadBalancerServiceCreate(ctx context.Context, d *schema.ResourceDa
 		default:
 		}
 	}
-	opts.ListenPort = hcloud.Ptr(listenPort)
+	opts.ListenPort = new(listenPort)
 	if p, ok := d.GetOk("destination_port"); ok {
-		opts.DestinationPort = hcloud.Ptr(p.(int))
+		opts.DestinationPort = new(p.(int))
 	}
 	if pp, ok := d.GetOk("proxyprotocol"); ok {
-		opts.Proxyprotocol = hcloud.Ptr(pp.(bool))
+		opts.Proxyprotocol = new(pp.(bool))
 	}
 	if tfHTTP, ok := d.GetOk("http"); ok {
 		opts.HTTP = parseTFHTTP(tfHTTP.([]any))
@@ -275,10 +275,10 @@ func resourceLoadBalancerServiceUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 
 	pp := d.Get("proxyprotocol")
-	opts.Proxyprotocol = hcloud.Ptr(pp.(bool))
+	opts.Proxyprotocol = new(pp.(bool))
 
 	if p, ok := d.GetOk("destination_port"); ok {
-		opts.DestinationPort = hcloud.Ptr(p.(int))
+		opts.DestinationPort = new(p.(int))
 	}
 
 	if tfHTTP, ok := d.GetOk("http"); ok {
@@ -445,23 +445,23 @@ func parseTFHTTP(tfHTTP []any) *hcloud.LoadBalancerAddServiceOptsHTTP {
 	}
 	http := &hcloud.LoadBalancerAddServiceOptsHTTP{}
 	if stickySessions, ok := httpMap["sticky_sessions"]; ok {
-		http.StickySessions = hcloud.Ptr(stickySessions.(bool))
+		http.StickySessions = new(stickySessions.(bool))
 	}
 	if cookieName, ok := httpMap["cookie_name"]; ok && cookieName != "" {
-		http.CookieName = hcloud.Ptr(cookieName.(string))
+		http.CookieName = new(cookieName.(string))
 	}
 	if cookieLifetime, ok := httpMap["cookie_lifetime"]; ok && cookieLifetime != 0 {
-		http.CookieLifetime = hcloud.Ptr(timeutil.DurationFromSeconds(cookieLifetime.(int)))
+		http.CookieLifetime = new(timeutil.DurationFromSeconds(cookieLifetime.(int)))
 	}
 
 	if certificates, ok := httpMap["certificates"]; ok {
 		http.Certificates = parseTFCertificates(certificates.(*schema.Set))
 	}
 	if redirectHTTP, ok := httpMap["redirect_http"]; ok {
-		http.RedirectHTTP = hcloud.Ptr(redirectHTTP.(bool))
+		http.RedirectHTTP = new(redirectHTTP.(bool))
 	}
 	if timeoutIdle, ok := httpMap["timeout_idle"]; ok && timeoutIdle != 0 {
-		http.TimeoutIdle = hcloud.Ptr(timeutil.DurationFromSeconds(timeoutIdle.(int)))
+		http.TimeoutIdle = new(timeutil.DurationFromSeconds(timeoutIdle.(int)))
 	}
 	return http
 }
@@ -476,23 +476,23 @@ func parseUpdateTFHTTP(tfHTTP []any) *hcloud.LoadBalancerUpdateServiceOptsHTTP {
 	}
 	http := &hcloud.LoadBalancerUpdateServiceOptsHTTP{}
 	if stickySessions, ok := httpMap["sticky_sessions"]; ok {
-		http.StickySessions = hcloud.Ptr(stickySessions.(bool))
+		http.StickySessions = new(stickySessions.(bool))
 	}
 	if cookieName, ok := httpMap["cookie_name"]; ok {
-		http.CookieName = hcloud.Ptr(cookieName.(string))
+		http.CookieName = new(cookieName.(string))
 	}
 	if cookieLifetime, ok := httpMap["cookie_lifetime"]; ok {
-		http.CookieLifetime = hcloud.Ptr(timeutil.DurationFromSeconds(cookieLifetime.(int)))
+		http.CookieLifetime = new(timeutil.DurationFromSeconds(cookieLifetime.(int)))
 	}
 
 	if certificates, ok := httpMap["certificates"]; ok {
 		http.Certificates = parseTFCertificates(certificates.(*schema.Set))
 	}
 	if redirectHTTP, ok := httpMap["redirect_http"]; ok {
-		http.RedirectHTTP = hcloud.Ptr(redirectHTTP.(bool))
+		http.RedirectHTTP = new(redirectHTTP.(bool))
 	}
 	if timeoutIdle, ok := httpMap["timeout_idle"]; ok && timeoutIdle != 0 {
-		http.TimeoutIdle = hcloud.Ptr(timeutil.DurationFromSeconds(timeoutIdle.(int)))
+		http.TimeoutIdle = new(timeutil.DurationFromSeconds(timeoutIdle.(int)))
 	}
 	return http
 }
@@ -548,16 +548,16 @@ func parseTFHealthCheckAdd(tfHealthCheck []any) *hcloud.LoadBalancerAddServiceOp
 	healthCheckMap := tfHealthCheck[0].(map[string]any)
 	healthCheckOpts.Protocol = hcloud.LoadBalancerServiceProtocol(healthCheckMap["protocol"].(string))
 	if port, ok := healthCheckMap["port"]; ok {
-		healthCheckOpts.Port = hcloud.Ptr(port.(int))
+		healthCheckOpts.Port = new(port.(int))
 	}
 	if interval, ok := healthCheckMap["interval"]; ok {
-		healthCheckOpts.Interval = hcloud.Ptr(timeutil.DurationFromSeconds(interval.(int)))
+		healthCheckOpts.Interval = new(timeutil.DurationFromSeconds(interval.(int)))
 	}
 	if timeout, ok := healthCheckMap["timeout"]; ok {
-		healthCheckOpts.Timeout = hcloud.Ptr(timeutil.DurationFromSeconds(timeout.(int)))
+		healthCheckOpts.Timeout = new(timeutil.DurationFromSeconds(timeout.(int)))
 	}
 	if retries, ok := healthCheckMap["retries"]; ok {
-		healthCheckOpts.Retries = hcloud.Ptr(retries.(int))
+		healthCheckOpts.Retries = new(retries.(int))
 	}
 	if http, ok := healthCheckMap["http"]; ok {
 		healthCheckOpts.HTTP = parseTFHealthCheckHTTPAdd(http.([]any))
@@ -575,16 +575,16 @@ func parseTFHealthCheckUpdate(tfHealthCheck []any) *hcloud.LoadBalancerUpdateSer
 	healthCheckMap := tfHealthCheck[0].(map[string]any)
 	healthCheckOpts.Protocol = hcloud.LoadBalancerServiceProtocol(healthCheckMap["protocol"].(string))
 	if port, ok := healthCheckMap["port"]; ok {
-		healthCheckOpts.Port = hcloud.Ptr(port.(int))
+		healthCheckOpts.Port = new(port.(int))
 	}
 	if interval, ok := healthCheckMap["interval"]; ok {
-		healthCheckOpts.Interval = hcloud.Ptr(timeutil.DurationFromSeconds(interval.(int)))
+		healthCheckOpts.Interval = new(timeutil.DurationFromSeconds(interval.(int)))
 	}
 	if timeout, ok := healthCheckMap["timeout"]; ok {
-		healthCheckOpts.Timeout = hcloud.Ptr(timeutil.DurationFromSeconds(timeout.(int)))
+		healthCheckOpts.Timeout = new(timeutil.DurationFromSeconds(timeout.(int)))
 	}
 	if retries, ok := healthCheckMap["retries"]; ok {
-		healthCheckOpts.Retries = hcloud.Ptr(retries.(int))
+		healthCheckOpts.Retries = new(retries.(int))
 	}
 	if http, ok := healthCheckMap["http"]; ok {
 		healthCheckOpts.HTTP = parseTFHealthCheckHTTPUpdate(http.([]any))
@@ -601,16 +601,16 @@ func parseTFHealthCheckHTTPAdd(tfHealthCheckHTTP []any) *hcloud.LoadBalancerAddS
 	httpHealthCheck := &hcloud.LoadBalancerAddServiceOptsHealthCheckHTTP{}
 
 	if domain, ok := httpMap["domain"]; ok {
-		httpHealthCheck.Domain = hcloud.Ptr(domain.(string))
+		httpHealthCheck.Domain = new(domain.(string))
 	}
 	if path, ok := httpMap["path"]; ok {
-		httpHealthCheck.Path = hcloud.Ptr(path.(string))
+		httpHealthCheck.Path = new(path.(string))
 	}
 	if response, ok := httpMap["response"]; ok {
-		httpHealthCheck.Response = hcloud.Ptr(response.(string))
+		httpHealthCheck.Response = new(response.(string))
 	}
 	if tls, ok := httpMap["tls"]; ok {
-		httpHealthCheck.TLS = hcloud.Ptr(tls.(bool))
+		httpHealthCheck.TLS = new(tls.(bool))
 	}
 	if scs, ok := httpMap["status_codes"]; ok {
 		var statusCodes []string
@@ -631,16 +631,16 @@ func parseTFHealthCheckHTTPUpdate(tfHealthCheckHTTP []any) *hcloud.LoadBalancerU
 	httpHealthCheck := &hcloud.LoadBalancerUpdateServiceOptsHealthCheckHTTP{}
 
 	if domain, ok := httpMap["domain"]; ok {
-		httpHealthCheck.Domain = hcloud.Ptr(domain.(string))
+		httpHealthCheck.Domain = new(domain.(string))
 	}
 	if path, ok := httpMap["path"]; ok {
-		httpHealthCheck.Path = hcloud.Ptr(path.(string))
+		httpHealthCheck.Path = new(path.(string))
 	}
 	if response, ok := httpMap["response"]; ok {
-		httpHealthCheck.Response = hcloud.Ptr(response.(string))
+		httpHealthCheck.Response = new(response.(string))
 	}
 	if tls, ok := httpMap["tls"]; ok {
-		httpHealthCheck.TLS = hcloud.Ptr(tls.(bool))
+		httpHealthCheck.TLS = new(tls.(bool))
 	}
 	if scs, ok := httpMap["status_codes"]; ok {
 		var statusCodes []string

--- a/internal/loadbalancer/resource_target.go
+++ b/internal/loadbalancer/resource_target.go
@@ -151,7 +151,7 @@ func resourceLoadBalancerCreateServerTarget(
 	}
 	if v, ok := d.GetOk("use_private_ip"); ok {
 		usePrivateIP = v.(bool)
-		opts.UsePrivateIP = hcloud.Ptr(usePrivateIP)
+		opts.UsePrivateIP = new(usePrivateIP)
 	}
 
 	err = control.Retry(control.DefaultRetries, func() error {
@@ -205,7 +205,7 @@ func resourceLoadBalancerCreateLabelSelectorTarget(
 	}
 
 	if v, ok := d.GetOk("use_private_ip"); ok {
-		opts.UsePrivateIP = hcloud.Ptr(v.(bool))
+		opts.UsePrivateIP = new(v.(bool))
 	}
 
 	tgt = hcloud.LoadBalancerTarget{

--- a/internal/loadbalancer/resource_target_test.go
+++ b/internal/loadbalancer/resource_target_test.go
@@ -134,7 +134,7 @@ func TestAccLoadBalancerTargetResource_ServerTarget_UsePrivateIP(t *testing.T) {
 		Name:                  "target-test-lb-network",
 		LoadBalancerID:        resLoadBalancer.TFID() + ".id",
 		NetworkID:             resNetwork.TFID() + ".id",
-		EnablePublicInterface: hcloud.Ptr(true),
+		EnablePublicInterface: new(true),
 	}
 	resLoadBalancerNetwork.SetRName("test")
 
@@ -301,7 +301,7 @@ func TestAccLoadBalancerTargetResource_LabelSelectorTarget_UsePrivateIP(t *testi
 		Name:                  "target-test-lb-network",
 		LoadBalancerID:        resLoadBalancer.TFID() + ".id",
 		NetworkID:             resNetwork.TFID() + ".id",
-		EnablePublicInterface: hcloud.Ptr(true),
+		EnablePublicInterface: new(true),
 		DependsOn: []string{
 			resNetworkSubNet.TFID(),
 		},

--- a/internal/network/resource.go
+++ b/internal/network/resource.go
@@ -165,7 +165,7 @@ func resourceNetworkUpdate(ctx context.Context, d *schema.ResourceData, m any) d
 
 	if d.HasChange("expose_routes_to_vswitch") {
 		_, _, err := client.Network.Update(ctx, network, hcloud.NetworkUpdateOpts{
-			ExposeRoutesToVSwitch: hcloud.Ptr(d.Get("expose_routes_to_vswitch").(bool)),
+			ExposeRoutesToVSwitch: new(d.Get("expose_routes_to_vswitch").(bool)),
 		})
 		if err != nil {
 			if resourceNetworkIsNotFound(err, d) {

--- a/internal/primaryip/data_source_list_test.go
+++ b/internal/primaryip/data_source_list_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/primaryip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -78,7 +77,7 @@ func TestAccPrimaryIPDataSourceList_UpgradePluginFramework(t *testing.T) {
 		Location:     teste2e.TestLocationName,
 		AssigneeType: "server",
 		Labels:       map[string]string{"key": randutil.GenerateID()},
-		AutoDelete:   hcloud.Ptr(false),
+		AutoDelete:   new(false),
 	}
 	res.SetRName("main")
 

--- a/internal/primaryip/data_source_test.go
+++ b/internal/primaryip/data_source_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/primaryip"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -111,7 +110,7 @@ func TestAccPrimaryIPDataSource_UpgradePluginFramework(t *testing.T) {
 		Location:     teste2e.TestLocationName,
 		Labels:       map[string]string{"key": randutil.GenerateID()},
 		AssigneeType: "server", // Attribute was still required in previous versions
-		AutoDelete:   hcloud.Ptr(false),
+		AutoDelete:   new(false),
 	}
 	res.SetRName("main")
 

--- a/internal/primaryip/helpers.go
+++ b/internal/primaryip/helpers.go
@@ -50,7 +50,7 @@ func CreateRandomPrimaryIP(ctx context.Context, c *hcloud.Client, server *hcloud
 		Name:         "primary_ip-" + strconv.Itoa(randomNumberBetween(1000000, 9999999)),
 		AssigneeID:   &server.ID,
 		AssigneeType: "server",
-		AutoDelete:   hcloud.Ptr(true),
+		AutoDelete:   new(true),
 		Type:         ipType,
 	})
 	if err != nil {

--- a/internal/primaryip/resource_test.go
+++ b/internal/primaryip/resource_test.go
@@ -37,7 +37,7 @@ func TestAccPrimaryIPResource(t *testing.T) {
 	res3 := testtemplate.DeepCopy(t, res1)
 	res3.Name = res1.Name + "-changed"
 	res3.Labels = map[string]string{"key": "changed"}
-	res3.AutoDelete = hcloud.Ptr(true)
+	res3.AutoDelete = new(true)
 	res3.DeleteProtection = false
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -336,7 +336,7 @@ func TestAccPrimaryIPResource_Reassign(t *testing.T) {
 		Type:         "ipv4",
 		AssigneeID:   res1ServerA.TFID() + ".id",
 		AssigneeType: "server",
-		AutoDelete:   hcloud.Ptr(false),
+		AutoDelete:   new(false),
 	}
 	res2.SetRName("main")
 
@@ -534,7 +534,7 @@ func TestAccPrimaryIPResource_DatacenterToLocationForceNew(t *testing.T) {
 		Type:         "ipv6",
 		Datacenter:   teste2e.TestDataCenter,
 		AssigneeType: "server", // Attribute was still required in previous versions
-		AutoDelete:   hcloud.Ptr(false),
+		AutoDelete:   new(false),
 	}
 	res1.SetRName("main")
 
@@ -585,7 +585,7 @@ func TestAccPrimaryIPResource_UpgradePluginFramework(t *testing.T) {
 		AssigneeType: "server",
 		// Labels will default {} after the upgrade, this is a workaround to make the tests pass
 		Labels:     map[string]string{"key": "value"},
-		AutoDelete: hcloud.Ptr(false),
+		AutoDelete: new(false),
 	}
 	res.SetRName("main")
 

--- a/internal/rdns/resource_test.go
+++ b/internal/rdns/resource_test.go
@@ -294,7 +294,7 @@ func TestAccRDNSResource_PrimaryIP_UpgradePluginFramework(t *testing.T) {
 		Name:       randutil.GenerateID(),
 		Type:       "ipv6",
 		Location:   teste2e.TestLocationName,
-		AutoDelete: hcloud.Ptr(false),
+		AutoDelete: new(false),
 	}
 	resPrimaryIP.SetRName("ipv6")
 

--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -436,7 +436,7 @@ func resourceServerCreate(ctx context.Context, d *schema.ResourceData, m any) (d
 		opts.PublicNet = &createPublicNet
 		// if the server has no public net, it has to be created without starting it
 		if err := onServerCreateWithoutPublicNet(&opts, d, func(opts *hcloud.ServerCreateOpts) error {
-			opts.StartAfterCreate = hcloud.Ptr(false)
+			opts.StartAfterCreate = new(false)
 			return nil
 		}); err != nil {
 			diags = append(diags, err...)

--- a/internal/snapshot/resource.go
+++ b/internal/snapshot/resource.go
@@ -53,7 +53,7 @@ func resourceSnapshotCreate(ctx context.Context, d *schema.ResourceData, m any) 
 	serverID := util.CastInt64(d.Get("server_id"))
 	opts := hcloud.ServerCreateImageOpts{
 		Type:        hcloud.ImageTypeSnapshot,
-		Description: hcloud.Ptr(d.Get("description").(string)),
+		Description: new(d.Get("description").(string)),
 	}
 
 	if labels, ok := d.GetOk("labels"); ok {
@@ -122,7 +122,7 @@ func resourceSnapshotUpdate(ctx context.Context, d *schema.ResourceData, m any) 
 	if d.HasChange("description") {
 		description := d.Get("description").(string)
 		_, _, err := client.Image.Update(ctx, image, hcloud.ImageUpdateOpts{
-			Description: hcloud.Ptr(description),
+			Description: new(description),
 		})
 		if err != nil {
 			if resourceSnapshotIsNotFound(err, d) {

--- a/internal/storagebox/model.go
+++ b/internal/storagebox/model.go
@@ -206,11 +206,11 @@ func (m *modelSnapshotPlan) ToAPI(_ context.Context) (hc *hcloud.StorageBoxSnaps
 	hc.Hour = int(m.Hour.ValueInt32())
 
 	if !m.DayOfWeek.IsNull() {
-		hc.DayOfWeek = hcloud.Ptr(time.Weekday(int(m.DayOfWeek.ValueInt32())))
+		hc.DayOfWeek = new(time.Weekday(int(m.DayOfWeek.ValueInt32())))
 	}
 
 	if !m.DayOfMonth.IsNull() {
-		hc.DayOfMonth = hcloud.Ptr(int(m.DayOfMonth.ValueInt32()))
+		hc.DayOfMonth = new(int(m.DayOfMonth.ValueInt32()))
 	}
 
 	return

--- a/internal/storagebox/resource.go
+++ b/internal/storagebox/resource.go
@@ -567,7 +567,7 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	// Disable delete protection before deleting.
 	if !data.DeleteProtection.IsUnknown() && !data.DeleteProtection.IsNull() && data.DeleteProtection.ValueBool() {
 		action, _, err := r.client.StorageBox.ChangeProtection(ctx, storageBox, hcloud.StorageBoxChangeProtectionOpts{
-			Delete: hcloud.Ptr(false),
+			Delete: new(false),
 		})
 		if err != nil {
 			if hcloudutil.APIErrorIsNotFound(err) {

--- a/internal/storageboxtype/model_test.go
+++ b/internal/storageboxtype/model_test.go
@@ -17,8 +17,8 @@ func TestModel(t *testing.T) {
 		ID:                     1333,
 		Name:                   "bx11",
 		Description:            "BX11",
-		SnapshotLimit:          hcloud.Ptr(10),
-		AutomaticSnapshotLimit: hcloud.Ptr(11),
+		SnapshotLimit:          new(10),
+		AutomaticSnapshotLimit: new(11),
 		SubaccountsLimit:       100,
 		Size:                   1 * 1024 * 1024 * 1024 * 1024,
 		DeprecatableResource: hcloud.DeprecatableResource{
@@ -49,8 +49,8 @@ func Test_intPtrToInt64Ptr(t *testing.T) {
 		arg  *int
 		want *int64
 	}{
-		{arg: hcloud.Ptr(0), want: hcloud.Ptr(int64(0))},
-		{arg: hcloud.Ptr(1337), want: hcloud.Ptr(int64(1337))},
+		{arg: new(0), want: new(int64(0))},
+		{arg: new(1337), want: new(int64(1337))},
 		{arg: nil, want: nil},
 	}
 	for i, tt := range tests {

--- a/internal/volume/resource.go
+++ b/internal/volume/resource.go
@@ -103,10 +103,10 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, m any) di
 		opts.Labels = tmpLabels
 	}
 	if automount, ok := d.GetOk("automount"); ok {
-		opts.Automount = hcloud.Ptr(automount.(bool))
+		opts.Automount = new(automount.(bool))
 	}
 	if format, ok := d.GetOk("format"); ok {
-		opts.Format = hcloud.Ptr(format.(string))
+		opts.Format = new(format.(string))
 	}
 
 	result, _, err := c.Volume.Create(ctx, opts)
@@ -147,7 +147,7 @@ func resourceVolumeCreate(ctx context.Context, d *schema.ResourceData, m any) di
 					err := control.Retry(control.DefaultRetries, func() error {
 						o := hcloud.VolumeAttachOpts{Server: opts.Server}
 						if automount, ok := d.GetOk("automount"); ok {
-							opts.Automount = hcloud.Ptr(automount.(bool))
+							opts.Automount = new(automount.(bool))
 						}
 						action, _, err := c.Volume.AttachWithOpts(ctx, result.Volume, o)
 						if err != nil {
@@ -266,7 +266,7 @@ func resourceVolumeUpdate(ctx context.Context, d *schema.ResourceData, m any) di
 			err := control.Retry(control.DefaultRetries, func() error {
 				opts := hcloud.VolumeAttachOpts{Server: &hcloud.Server{ID: serverID}}
 				if automount, ok := d.GetOk("automount"); ok {
-					opts.Automount = hcloud.Ptr(automount.(bool))
+					opts.Automount = new(automount.(bool))
 				}
 
 				action, _, err := c.Volume.AttachWithOpts(ctx, volume, opts)

--- a/internal/volume/resource_attachment.go
+++ b/internal/volume/resource_attachment.go
@@ -63,7 +63,7 @@ func resourceVolumeAttachmentCreate(ctx context.Context, d *schema.ResourceData,
 		Server: server,
 	}
 	if automount, ok := d.GetOk("automount"); ok {
-		opts.Automount = hcloud.Ptr(automount.(bool))
+		opts.Automount = new(automount.(bool))
 	}
 
 	err := control.Retry(control.DefaultRetries, func() error {

--- a/internal/zone/resource.go
+++ b/internal/zone/resource.go
@@ -189,7 +189,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		Mode: hcloud.ZoneMode(data.Mode.ValueString()),
 	}
 	if !data.TTL.IsUnknown() && !data.TTL.IsNull() {
-		opts.TTL = hcloud.Ptr(int(data.TTL.ValueInt32()))
+		opts.TTL = new(int(data.TTL.ValueInt32()))
 	}
 
 	resp.Diagnostics.Append(hcloudutil.TerraformLabelsToHCloud(ctx, data.Labels, &opts.Labels)...)

--- a/internal/zonerecord/model_test.go
+++ b/internal/zonerecord/model_test.go
@@ -18,7 +18,7 @@ func TestModel(t *testing.T) {
 			Type:       hcloud.ZoneRRSetTypeA,
 			Labels:     map[string]string{"key": "value"},
 			Protection: hcloud.ZoneRRSetProtection{Change: false},
-			TTL:        hcloud.Ptr(10800),
+			TTL:        new(10800),
 			Records: []hcloud.ZoneRRSetRecord{
 				{Value: "201.45.3.46", Comment: "some web server"},
 			},

--- a/internal/zonerrset/data_source_test.go
+++ b/internal/zonerrset/data_source_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
-	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/kit/randutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/labelutil"
 	"github.com/hetznercloud/hcloud-go/v2/hcloud/schema"
@@ -38,7 +37,7 @@ func TestAccZoneRRSetDataSource(t *testing.T) {
 			Name:   "www",
 			Type:   "A",
 			Labels: map[string]string{"key": randutil.GenerateID()},
-			TTL:    hcloud.Ptr(10800),
+			TTL:    new(10800),
 			Records: []schema.ZoneRRSetRecord{
 				{Value: "201.42.91.35"},
 				{Value: "201.42.91.36", Comment: "some web server"},

--- a/internal/zonerrset/model_test.go
+++ b/internal/zonerrset/model_test.go
@@ -18,7 +18,7 @@ func TestModel(t *testing.T) {
 			Type:       hcloud.ZoneRRSetTypeA,
 			Labels:     map[string]string{"key": "value"},
 			Protection: hcloud.ZoneRRSetProtection{Change: false},
-			TTL:        hcloud.Ptr(10800),
+			TTL:        new(10800),
 			Records: []hcloud.ZoneRRSetRecord{
 				{Value: "201.45.3.45"},
 				{Value: "201.45.3.46", Comment: "some web server"},

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -156,7 +156,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		Type: hcloud.ZoneRRSetType(data.Type.ValueString()),
 	}
 	if !data.TTL.IsUnknown() && !data.TTL.IsNull() {
-		opts.TTL = hcloud.Ptr(int(data.TTL.ValueInt32()))
+		opts.TTL = new(int(data.TTL.ValueInt32()))
 	}
 	if !data.Labels.IsUnknown() && !data.Labels.IsNull() {
 		hcloudutil.TerraformLabelsToHCloud(ctx, data.Labels, &opts.Labels)
@@ -312,7 +312,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 	if !plan.TTL.IsUnknown() && !plan.TTL.Equal(data.TTL) {
 		opts := hcloud.ZoneRRSetChangeTTLOpts{}
 		if !plan.TTL.IsNull() {
-			opts.TTL = hcloud.Ptr(int(plan.TTL.ValueInt32()))
+			opts.TTL = new(int(plan.TTL.ValueInt32()))
 		}
 
 		action, _, err := r.client.Zone.ChangeRRSetTTL(ctx, rrset, opts)

--- a/internal/zonerrset/resource_test.go
+++ b/internal/zonerrset/resource_test.go
@@ -38,7 +38,7 @@ func TestAccZoneRRSetResource(t *testing.T) {
 			Name:   "www",
 			Type:   "A",
 			Labels: map[string]string{"key": "value"},
-			TTL:    hcloud.Ptr(10800),
+			TTL:    new(10800),
 			Records: []schema.ZoneRRSetRecord{
 				{Value: "201.42.91.35"},
 				{Value: "201.42.91.36", Comment: "some web server"},
@@ -53,7 +53,7 @@ func TestAccZoneRRSetResource(t *testing.T) {
 			Name:   res1.Name,
 			Type:   res1.Type,
 			Labels: map[string]string{"key": "changed"},
-			TTL:    hcloud.Ptr(600),
+			TTL:    new(600),
 			Records: []schema.ZoneRRSetRecord{
 				{Value: "42.42.91.35"},
 				{Value: "42.42.91.36", Comment: "some web server"},

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.26.0
+go 1.26.4
 
 toolchain go1.26.3
 

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module tools
 
-go 1.25.8
+go 1.26.0
 
 toolchain go1.26.3
 


### PR DESCRIPTION
- Bump the go version to v1.26.
- Run `go fix ./...` to benefit from the latest and greatest.