### PR TITLE
fix: handle invalid input errors without details

### DIFF
--- a/internal/util/hcloudutil/error_framework.go
+++ b/internal/util/hcloudutil/error_framework.go
@@ -23,6 +23,23 @@ func APIErrorDiagnostics(err error) diag.Diagnostics {
 
 		if hcloud.IsError(hcloudErr, hcloud.ErrorCodeInvalidInput) {
 			invalidInput := hcloudErr.Details.(hcloud.ErrorDetailsInvalidInput)
+
+			// Gracefully handle when invalid input details are not returned
+			// by the API (should never happen).
+			if len(invalidInput.Fields) == 0 {
+				diagnostics.AddError(
+					"Invalid field in API request",
+					fmt.Sprintf(
+						"An invalid field was encountered during an API request. "+
+							"The field might not map 1:1 to your terraform resource.\n\n"+
+							"%s\n\n"+
+							"Error code: %s\n"+
+							"%s",
+						err.Error(), hcloudErr.Code, statusCodeMessage,
+					))
+				return diagnostics
+			}
+
 			for _, field := range invalidInput.Fields {
 				messages := make([]string, 0, len(field.Messages))
 				for _, message := range field.Messages {

--- a/internal/util/hcloudutil/error_framework_test.go
+++ b/internal/util/hcloudutil/error_framework_test.go
@@ -55,6 +55,28 @@ Status code: 400
 			},
 		},
 		{
+			name: "hcloud invalid input error without details",
+			errRaw: map[string]any{
+				"error": map[string]any{
+					"code":    "invalid_input",
+					"message": "something is fishy",
+					"details": nil,
+				},
+			},
+			errStatusCode: http.StatusBadRequest,
+			diagnostics: []diag.Diagnostic{
+				diag.NewErrorDiagnostic(
+					"Invalid field in API request",
+					`An invalid field was encountered during an API request. The field might not map 1:1 to your terraform resource.
+
+something is fishy (invalid_input)
+
+Error code: invalid_input
+Status code: 400
+`),
+			},
+		},
+		{
 			name: "hcloud error",
 			err: hcloud.Error{
 				Code:    hcloud.ErrorCodeRateLimitExceeded,


### PR DESCRIPTION
While it should never happen, some invalid input error are returned without details. In this case, we never return any diagnostics to the users and the provider fails with a unclear generic error.

```
│ Error: Missing Resource State After Create
│ The Terraform Provider unexpectedly returned no resource state after having no errors in the resource creation. This is always an issue in the Terraform Provider and should be reported to
│ the provider developers.
│ 
│ The resource may have been successfully created, but Terraform is not tracking it. Applying the configuration again with no other action may result in duplicate resource errors. Import
│ the resource if the resource was actually created and Terraform should be tracking it.

```

This fix now handle the case where no details/field were returned by the API.