### PR TITLE
feat: deprecate `hcloud_datacenter(s)` data sources

### DIFF
--- a/docs/data-sources/datacenter.md
+++ b/docs/data-sources/datacenter.md
@@ -5,6 +5,10 @@ subcategory: ""
 description: |-
   Provides details about a specific Hetzner Cloud Datacenter.
   Use this resource to get detailed information about a specific Datacenter.
+  !> The hcloud_datacenter data source is deprecated, and will be removed after 1 Oct. 2026.
+  After this date, requests to the datacenters API endpoints will return HTTP 410 Gone.
+  Please use the hcloud_location data source instead.
+  See the changelog https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
 ---
 
 # hcloud_datacenter (Data Source)
@@ -12,6 +16,11 @@ description: |-
 Provides details about a specific Hetzner Cloud Datacenter.
 
 Use this resource to get detailed information about a specific Datacenter.
+
+!> The `hcloud_datacenter` data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return `HTTP 410 Gone`.
+Please use the `hcloud_location` data source instead.
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
 
 ## Example Usage
 

--- a/docs/data-sources/datacenters.md
+++ b/docs/data-sources/datacenters.md
@@ -5,6 +5,10 @@ subcategory: ""
 description: |-
   Provides a list of available Hetzner Cloud Datacenters.
   This resource may be useful to create highly available infrastructure, distributed across several Datacenters.
+  !> The hcloud_datacenters data source is deprecated, and will be removed after 1 Oct. 2026.
+  After this date, requests to the datacenters API endpoints will return HTTP 410 Gone.
+  Please use the hcloud_locations data source instead.
+  See the changelog https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
 ---
 
 # hcloud_datacenters (Data Source)
@@ -12,6 +16,11 @@ description: |-
 Provides a list of available Hetzner Cloud Datacenters.
 
 This resource may be useful to create highly available infrastructure, distributed across several Datacenters.
+
+!> The `hcloud_datacenters` data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return `HTTP 410 Gone`.
+Please use the `hcloud_locations` data source instead.
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
 
 ## Example Usage
 

--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -154,11 +154,24 @@ func (d *dataSource) Configure(_ context.Context, req datasource.ConfigureReques
 
 // Schema should return the schema for this data source.
 func (d *dataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema.MarkdownDescription = `
+	resp.Schema.DeprecationMessage = util.MarkdownDescription(`
+The ''hcloud_datacenter'' data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return ''HTTP 410 Gone''.
+
+Please use the ''hcloud_location'' data source instead.
+
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+`)
+	resp.Schema.MarkdownDescription = util.MarkdownDescription(`
 Provides details about a specific Hetzner Cloud Datacenter.
 
 Use this resource to get detailed information about a specific Datacenter.
-`
+
+!> The ''hcloud_datacenter'' data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return ''HTTP 410 Gone''.
+Please use the ''hcloud_location'' data source instead.
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+`)
 	resp.Schema.Attributes = getCommonDataSchema(false)
 }
 
@@ -251,11 +264,25 @@ func (d *dataSourceList) Configure(_ context.Context, req datasource.ConfigureRe
 
 // Schema should return the schema for this data source.
 func (d *dataSourceList) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
-	resp.Schema.MarkdownDescription = `
+	resp.Schema.DeprecationMessage = util.MarkdownDescription(`
+The ''hcloud_datacenters'' data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return ''HTTP 410 Gone''.
+
+Please use the ''hcloud_locations'' data source instead.
+
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+`)
+
+	resp.Schema.MarkdownDescription = util.MarkdownDescription(`
 Provides a list of available Hetzner Cloud Datacenters.
 
 This resource may be useful to create highly available infrastructure, distributed across several Datacenters.
-`
+
+!> The ''hcloud_datacenters'' data source is deprecated, and will be removed after 1 Oct. 2026.
+After this date, requests to the datacenters API endpoints will return ''HTTP 410 Gone''.
+Please use the ''hcloud_locations'' data source instead.
+See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+`)
 
 	resp.Schema.Attributes = map[string]schema.Attribute{
 		"id": schema.StringAttribute{

--- a/internal/datacenter/data_source.go
+++ b/internal/datacenter/data_source.go
@@ -160,7 +160,7 @@ After this date, requests to the datacenters API endpoints will return ''HTTP 41
 
 Please use the ''hcloud_location'' data source instead.
 
-See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
 `)
 	resp.Schema.MarkdownDescription = util.MarkdownDescription(`
 Provides details about a specific Hetzner Cloud Datacenter.
@@ -270,7 +270,7 @@ After this date, requests to the datacenters API endpoints will return ''HTTP 41
 
 Please use the ''hcloud_locations'' data source instead.
 
-See the [changelog](https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated) for more details.
+See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.
 `)
 
 	resp.Schema.MarkdownDescription = util.MarkdownDescription(`


### PR DESCRIPTION
The API endpoints `GET /v1/datacenters` and `GET /v1/datacenters/{id}` are now deprecated and will be removed after 1 Oct. 2026. After this date, requests to these endpoints will return `HTTP 410 Gone`.

See https://docs.hetzner.cloud/changelog#2026-06-02-datacenters-deprecated for more details.