### PR TITLE
docs: ensure create_before_destroy is set for certificates

### DIFF
--- a/docs/resources/managed_certificate.md
+++ b/docs/resources/managed_certificate.md
@@ -11,6 +11,17 @@ Obtain a Hetzner Cloud managed TLS certificate.
 ## Example Usage
 
 ```terraform
+locals {
+  domain_names = ["example.com", "*.example.com"]
+}
+
+resource "time_static" "main" {
+  triggers = {
+    # Generate a new certificate name each time domain names changes
+    domain_names = join("\n", local.domain_names)
+  }
+}
+
 resource "hcloud_managed_certificate" "main" {
   lifecycle {
     # Important: prevents downtime during replacement, and ensures dependencies first
@@ -18,8 +29,9 @@ resource "hcloud_managed_certificate" "main" {
     create_before_destroy = true
   }
 
-  name         = "example"
-  domain_names = ["example.com", "*.example.com"]
+  // Important: prevents name uniqueness error during replacement.
+  name         = "example-${time_static.main.rfc3339}"
+  domain_names = local.domain_names
   labels = {
     key = "value"
   }

--- a/docs/resources/managed_certificate.md
+++ b/docs/resources/managed_certificate.md
@@ -11,13 +11,17 @@ Obtain a Hetzner Cloud managed TLS certificate.
 ## Example Usage
 
 ```terraform
-resource "hcloud_managed_certificate" "managed_cert" {
-  name         = "managed_cert"
-  domain_names = ["*.example.com", "example.com"]
+resource "hcloud_managed_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  name         = "example"
+  domain_names = ["example.com", "*.example.com"]
   labels = {
-    label_1 = "value_1"
-    label_2 = "value_2"
-    # ...
+    key = "value"
   }
 }
 ```

--- a/docs/resources/uploaded_certificate.md
+++ b/docs/resources/uploaded_certificate.md
@@ -11,8 +11,14 @@ Upload a TLS certificate to Hetzner Cloud.
 ## Example Usage
 
 ```terraform
-resource "hcloud_uploaded_certificate" "sample_certificate" {
-  name = "test-certificate-%d"
+resource "hcloud_uploaded_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  name = "example"
 
   private_key = <<-EOT
     -----BEGIN RSA PRIVATE KEY-----
@@ -31,9 +37,7 @@ resource "hcloud_uploaded_certificate" "sample_certificate" {
     EOT
 
   labels = {
-    label_1 = "value_1"
-    label_2 = "value_2"
-    # ...
+    key = "value"
   }
 }
 ```

--- a/docs/resources/uploaded_certificate.md
+++ b/docs/resources/uploaded_certificate.md
@@ -11,15 +11,7 @@ Upload a TLS certificate to Hetzner Cloud.
 ## Example Usage
 
 ```terraform
-resource "hcloud_uploaded_certificate" "main" {
-  lifecycle {
-    # Important: prevents downtime during replacement, and ensures dependencies first
-    # stop using the certificate before it is deleted.
-    create_before_destroy = true
-  }
-
-  name = "example"
-
+locals {
   private_key = <<-EOT
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpQIBAAKCAQEAorPccsHibgGLJIub5Sb1yvDvARifoKzg7MIhyAYLnJkGn9B1
@@ -35,6 +27,28 @@ resource "hcloud_uploaded_certificate" "main" {
     TKS8gQ==
     -----END CERTIFICATE-----
     EOT
+}
+
+resource "time_static" "main" {
+  triggers = {
+    # Generate a new certificate name each time private key or certificate changes
+    private_key = local.private_key
+    certificate = local.certificate
+  }
+}
+
+resource "hcloud_uploaded_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  // Important: prevents name uniqueness error during replacement.
+  name = "example-${time_static.main.rfc3339}"
+
+  private_key = local.private_key
+  certificate = local.certificate
 
   labels = {
     key = "value"

--- a/examples/resources/hcloud_managed_certificate/resource.tf
+++ b/examples/resources/hcloud_managed_certificate/resource.tf
@@ -1,9 +1,13 @@
-resource "hcloud_managed_certificate" "managed_cert" {
-  name         = "managed_cert"
-  domain_names = ["*.example.com", "example.com"]
+resource "hcloud_managed_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  name         = "example"
+  domain_names = ["example.com", "*.example.com"]
   labels = {
-    label_1 = "value_1"
-    label_2 = "value_2"
-    # ...
+    key = "value"
   }
 }

--- a/examples/resources/hcloud_managed_certificate/resource.tf
+++ b/examples/resources/hcloud_managed_certificate/resource.tf
@@ -1,3 +1,14 @@
+locals {
+  domain_names = ["example.com", "*.example.com"]
+}
+
+resource "time_static" "main" {
+  triggers = {
+    # Generate a new certificate name each time domain names changes
+    domain_names = join("\n", local.domain_names)
+  }
+}
+
 resource "hcloud_managed_certificate" "main" {
   lifecycle {
     # Important: prevents downtime during replacement, and ensures dependencies first
@@ -5,8 +16,9 @@ resource "hcloud_managed_certificate" "main" {
     create_before_destroy = true
   }
 
-  name         = "example"
-  domain_names = ["example.com", "*.example.com"]
+  // Important: prevents name uniqueness error during replacement.
+  name         = "example-${time_static.main.rfc3339}"
+  domain_names = local.domain_names
   labels = {
     key = "value"
   }

--- a/examples/resources/hcloud_uploaded_certificate/resource.tf
+++ b/examples/resources/hcloud_uploaded_certificate/resource.tf
@@ -1,5 +1,11 @@
-resource "hcloud_uploaded_certificate" "sample_certificate" {
-  name = "test-certificate-%d"
+resource "hcloud_uploaded_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  name = "example"
 
   private_key = <<-EOT
     -----BEGIN RSA PRIVATE KEY-----
@@ -18,8 +24,6 @@ resource "hcloud_uploaded_certificate" "sample_certificate" {
     EOT
 
   labels = {
-    label_1 = "value_1"
-    label_2 = "value_2"
-    # ...
+    key = "value"
   }
 }

--- a/examples/resources/hcloud_uploaded_certificate/resource.tf
+++ b/examples/resources/hcloud_uploaded_certificate/resource.tf
@@ -1,12 +1,4 @@
-resource "hcloud_uploaded_certificate" "main" {
-  lifecycle {
-    # Important: prevents downtime during replacement, and ensures dependencies first
-    # stop using the certificate before it is deleted.
-    create_before_destroy = true
-  }
-
-  name = "example"
-
+locals {
   private_key = <<-EOT
     -----BEGIN RSA PRIVATE KEY-----
     MIIEpQIBAAKCAQEAorPccsHibgGLJIub5Sb1yvDvARifoKzg7MIhyAYLnJkGn9B1
@@ -22,6 +14,28 @@ resource "hcloud_uploaded_certificate" "main" {
     TKS8gQ==
     -----END CERTIFICATE-----
     EOT
+}
+
+resource "time_static" "main" {
+  triggers = {
+    # Generate a new certificate name each time private key or certificate changes
+    private_key = local.private_key
+    certificate = local.certificate
+  }
+}
+
+resource "hcloud_uploaded_certificate" "main" {
+  lifecycle {
+    # Important: prevents downtime during replacement, and ensures dependencies first
+    # stop using the certificate before it is deleted.
+    create_before_destroy = true
+  }
+
+  // Important: prevents name uniqueness error during replacement.
+  name = "example-${time_static.main.rfc3339}"
+
+  private_key = local.private_key
+  certificate = local.certificate
 
   labels = {
     key = "value"

--- a/internal/certificate/resource_test.go
+++ b/internal/certificate/resource_test.go
@@ -75,6 +75,9 @@ func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testin
 	}
 	resOtherCert := &certificate.RDataUploaded{Name: res.Name, PrivateKey: rKey, Certificate: rCert}
 	resOtherCert.SetRName(res.Name)
+	// Prevents name collision with create before destroy lifecycle
+	resOtherCert.Name = "basic-cert-v2"
+
 	tmplMan := testtemplate.Manager{}
 	// Not parallel because number of certificates per domain is limited
 	resource.Test(t, resource.TestCase{
@@ -88,8 +91,7 @@ func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testin
 				Config: tmplMan.Render(t, "testdata/r/hcloud_uploaded_certificate", res),
 				Check: resource.ComposeTestCheckFunc(
 					testsupport.CheckResourceExists(res.TFID(), certificate.ByID(t, &cert)),
-					resource.TestCheckResourceAttr(res.TFID(), "name",
-						fmt.Sprintf("basic-cert--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(res.TFID(), "name", fmt.Sprintf("basic-cert--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(res.TFID(), "private_key", res.PrivateKey),
 					resource.TestCheckResourceAttr(res.TFID(), "certificate", res.Certificate),
 				),
@@ -101,10 +103,8 @@ func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testin
 					"testdata/r/hcloud_uploaded_certificate", resOtherCert,
 				),
 				Check: resource.ComposeAggregateTestCheckFunc(
-
 					testsupport.CheckResourceExists(res.TFID(), certificate.ByID(t, &newCert)),
-					resource.TestCheckResourceAttr(resOtherCert.TFID(), "name",
-						fmt.Sprintf("basic-cert--%d", tmplMan.RandInt)),
+					resource.TestCheckResourceAttr(resOtherCert.TFID(), "name", fmt.Sprintf("basic-cert-v2--%d", tmplMan.RandInt)),
 					resource.TestCheckResourceAttr(resOtherCert.TFID(), "private_key", rKey),
 					resource.TestCheckResourceAttr(resOtherCert.TFID(), "certificate", rCert),
 					testsupport.LiftTCF(isAnotherCert(&newCert, &cert)),

--- a/internal/loadbalancer/resource_service_test.go
+++ b/internal/loadbalancer/resource_service_test.go
@@ -297,9 +297,10 @@ func TestAccLoadBalancerServiceResource_HTTPS(t *testing.T) {
 	})
 }
 
-func TestAccLoadBalancerServiceResource_HTTPS_UpdateUnchangedCertificates(t *testing.T) {
+func TestAccLoadBalancerServiceResource_HTTPS_Certificates(t *testing.T) {
 	certRes1 := certificate.NewUploadedRData(t, "cert-res1", "TFAccTests1")
 	certRes2 := certificate.NewUploadedRData(t, "cert-res2", "TFAccTests2")
+	certRes3 := certificate.NewUploadedRData(t, "cert-res3", "TFAccTests3")
 	lbRes := &loadbalancer.RData{
 		Name:         "load-balancer-certificates-unchanged",
 		LocationName: teste2e.TestLocationName,
@@ -317,6 +318,9 @@ func TestAccLoadBalancerServiceResource_HTTPS_UpdateUnchangedCertificates(t *tes
 		},
 	}
 
+	svcRes2 := testtemplate.DeepCopy(t, svcRes)
+	svcRes2.HTTP.Certificates = []string{certRes1.TFID() + ".id", certRes3.TFID() + ".id"}
+
 	tmplMan := testtemplate.Manager{}
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:                 teste2e.PreCheck(t),
@@ -330,6 +334,14 @@ func TestAccLoadBalancerServiceResource_HTTPS_UpdateUnchangedCertificates(t *tes
 					"testdata/r/hcloud_uploaded_certificate", certRes2,
 					"testdata/r/hcloud_load_balancer", lbRes,
 					"testdata/r/hcloud_load_balancer_service", svcRes,
+				),
+			},
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_uploaded_certificate", certRes1,
+					"testdata/r/hcloud_uploaded_certificate", certRes3,
+					"testdata/r/hcloud_load_balancer", lbRes,
+					"testdata/r/hcloud_load_balancer_service", svcRes2,
 				),
 			},
 		},

--- a/internal/testdata/r/hcloud_managed_certificate.tf.tmpl
+++ b/internal/testdata/r/hcloud_managed_certificate.tf.tmpl
@@ -1,7 +1,11 @@
 {{- /* vim: set ft=terraform: */ -}}
 
 resource "hcloud_managed_certificate" "{{ .RName }}" {
-  name        = "{{ .Name }}--{{ .RInt }}"
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  name         = "{{ .Name }}--{{ .RInt }}"
   domain_names = [{{ .DomainNames | quoteEach | join ", " }}]
   {{- if .Labels }}
   labels = {{ .Labels | toPrettyJson }}

--- a/internal/testdata/r/hcloud_uploaded_certificate.tf.tmpl
+++ b/internal/testdata/r/hcloud_uploaded_certificate.tf.tmpl
@@ -1,6 +1,10 @@
 {{- /* vim: set ft=terraform: */ -}}
 
 resource "hcloud_uploaded_certificate" "{{ .RName }}" {
+  lifecycle {
+    create_before_destroy = true
+  }
+
   name        = "{{ .Name }}--{{ .RInt }}"
   private_key =<<EOT
 {{ .PrivateKey | trim }}


### PR DESCRIPTION
We always want to, in order:
- Create new certificates
- Update dependencies to stop using the old certificates and start using the new ones
- Delete old certificates

This ensure users do not run into the `certificate still in use` error.

Fixes #1141