### PR TITLE
fix(zonerrset): make SOA records settable via update-on-create (#1289)

### DIFF
--- a/docs/resources/zone_rrset.md
+++ b/docs/resources/zone_rrset.md
@@ -13,8 +13,10 @@ description: |-
   RRSets of type SOA:
   SOA records are created or deleted by the Hetzner Cloud API when creating or deleting
   the parent Zone, therefor this Terraform resource will:
-  import the RRSet in the state, instead of creating it.remove the RRSet from the state, instead of deleting it.set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
-  incremented by the API and would cause issues otherwise.
+  import the RRSet in the state, instead of creating it.remove the RRSet from the state, instead of deleting it.update the existing API-managed RRSet with your configured records on create, instead of
+  creating a new one.set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
+  incremented by the API and would cause issues otherwise. You must therefore set the SERIAL field
+  of your SOA records to 0 in your configuration.
 ---
 
 # hcloud_zone_rrset (Resource)
@@ -39,8 +41,11 @@ the parent Zone, therefor this Terraform resource will:
 
 - import the RRSet in the state, instead of creating it.
 - remove the RRSet from the state, instead of deleting it.
+- update the existing API-managed RRSet with your configured `records` on create, instead of
+  creating a new one.
 - set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
-  incremented by the API and would cause issues otherwise.
+  incremented by the API and would cause issues otherwise. You must therefore set the SERIAL field
+  of your SOA `records` to 0 in your configuration.
 
 ## Example Usage
 

--- a/internal/zonerrset/resource.go
+++ b/internal/zonerrset/resource.go
@@ -76,8 +76,11 @@ the parent Zone, therefor this Terraform resource will:
 
 - import the RRSet in the state, instead of creating it.
 - remove the RRSet from the state, instead of deleting it.
+- update the existing API-managed RRSet with your configured ''records'' on create, instead of
+  creating a new one.
 - set the SOA record SERIAL value to 0 before saving it to the state, as this value is automatically
-  incremented by the API and would cause issues otherwise.
+  incremented by the API and would cause issues otherwise. You must therefore set the SERIAL field
+  of your SOA ''records'' to 0 in your configuration.
 `)
 
 	resp.Schema.Attributes = map[string]schema.Attribute{
@@ -179,13 +182,11 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	var err error
 	var actions []*hcloud.Action
 
-	// SOA records are managed by the backend
+	// SOA RRSets are created by the API together with the parent Zone, so they
+	// cannot be created a second time. Instead, look up the existing RRSet and
+	// update it with the user-provided records, so the SOA record can still be
+	// managed through this resource in a single apply (see issue #1289).
 	if data.Type.ValueString() == string(hcloud.ZoneRRSetTypeSOA) {
-		resp.Diagnostics.AddWarning(
-			"SOA records are managed by the API",
-			"Importing the SOA record (managed by the API) in the state.",
-		)
-
 		rrset, _, err := r.client.Zone.GetRRSetByNameAndType(ctx, zone, opts.Name, opts.Type)
 		if err != nil {
 			resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
@@ -193,8 +194,21 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		}
 		if rrset == nil {
 			resp.Diagnostics.Append(hcloudutil.NotFoundDiagnostic("zone rrset", "id", fmt.Sprintf("%s/%s", opts.Name, opts.Type)))
+			return
 		}
 		result.RRSet = rrset
+
+		// Push the user-provided records onto the pre-existing SOA RRSet.
+		if len(opts.Records) > 0 {
+			action, _, err := r.client.Zone.SetRRSetRecords(ctx, rrset, hcloud.ZoneRRSetSetRecordsOpts{
+				Records: opts.Records,
+			})
+			if err != nil {
+				resp.Diagnostics.Append(hcloudutil.APIErrorDiagnostics(err)...)
+				return
+			}
+			actions = append(actions, action)
+		}
 	} else {
 
 		result, _, err = r.client.Zone.CreateRRSet(ctx, zone, opts)
@@ -446,6 +460,12 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 }
 
 // OverrideRecordsSOASerial set the serial value to 0 in a SOA Resource Record Set.
+//
+// The API automatically increments the SOA SERIAL field on every change, so a
+// value returned from the API can never be predicted from the configuration.
+// Normalizing it to 0 both in the state (here) and in the configuration (the
+// user is required to set SERIAL to 0) keeps plan and apply consistent and
+// avoids a perpetual diff.
 func OverrideRecordsSOASerial(hc *hcloud.ZoneRRSet) {
 	if hc.Type != hcloud.ZoneRRSetTypeSOA {
 		return

--- a/internal/zonerrset/resource_test.go
+++ b/internal/zonerrset/resource_test.go
@@ -173,8 +173,24 @@ func TestAccZoneRRSetResource(t *testing.T) {
 	})
 }
 
+// TestAccZoneRRSetResource_SOA covers https://github.com/hetznercloud/terraform-provider-hcloud/issues/1289.
+//
+// A SOA RRSet is created by the API together with the parent Zone, so it cannot
+// be created a second time. The user must still be able to manage its record
+// values: the Create method therefore updates the pre-existing SOA RRSet with
+// the configured records in a single apply. The SERIAL field is normalized to 0
+// on both sides (the user sets it to 0 in the configuration, the provider
+// normalizes it in the state), so plan and apply stay consistent and there is no
+// perpetual diff.
 func TestAccZoneRRSetResource_SOA(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
+
+	// Configured SOA records that differ from the values the API assigns to a
+	// freshly created Zone. Before the fix, applying these produced "Provider
+	// produced inconsistent result after apply". The SERIAL field is set to 0
+	// (see OverrideRecordsSOASerial) as it is managed by the API.
+	const soaValue1 = "ns1.example.com. hostmaster.example.com. 0 3600 600 86400 300"
+	const soaValue2 = "ns2.example.com. hostmaster.example.com. 0 7200 1800 604800 600"
 
 	resZone := &zone.RData{
 		Zone: schema.Zone{
@@ -190,7 +206,7 @@ func TestAccZoneRRSetResource_SOA(t *testing.T) {
 			Name: "@",
 			Type: "SOA",
 			Records: []schema.ZoneRRSetRecord{
-				{Value: "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600"},
+				{Value: soaValue1},
 			},
 		},
 	}
@@ -202,7 +218,7 @@ func TestAccZoneRRSetResource_SOA(t *testing.T) {
 			Name: "@",
 			Type: "SOA",
 			Records: []schema.ZoneRRSetRecord{
-				{Value: "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 600"},
+				{Value: soaValue2},
 			},
 		},
 	}
@@ -214,6 +230,9 @@ func TestAccZoneRRSetResource_SOA(t *testing.T) {
 		CheckDestroy:             testsupport.CheckAPIResourceAllAbsent(zone.ResourceType, zone.GetAPIResource()),
 		Steps: []resource.TestStep{
 			{
+				// Applying user-provided SOA records must succeed in a single
+				// apply (update-on-create), and the state must reflect the
+				// configured value.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_zone", resZone,
 					"testdata/r/hcloud_zone_rrset", res1,
@@ -222,10 +241,19 @@ func TestAccZoneRRSetResource_SOA(t *testing.T) {
 					testsupport.CheckAPIResourcePresent(res1.TFID(), zonerrset.GetAPIResource()),
 					resource.TestCheckResourceAttr(res1.TFID(), "id", "@/SOA"),
 					resource.TestCheckResourceAttr(res1.TFID(), "records.#", "1"),
-					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 3600"),
+					resource.TestCheckResourceAttr(res1.TFID(), "records.0.value", soaValue1),
 				),
 			},
 			{
+				// Re-planning the same configuration produces no diff.
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_zone", resZone,
+					"testdata/r/hcloud_zone_rrset", res1,
+				),
+				PlanOnly: true,
+			},
+			{
+				// Changing the configured SOA records applies the new value.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_zone", resZone,
 					"testdata/r/hcloud_zone_rrset", res2,
@@ -234,10 +262,11 @@ func TestAccZoneRRSetResource_SOA(t *testing.T) {
 					testsupport.CheckAPIResourcePresent(res2.TFID(), zonerrset.GetAPIResource()),
 					resource.TestCheckResourceAttr(res2.TFID(), "id", "@/SOA"),
 					resource.TestCheckResourceAttr(res2.TFID(), "records.#", "1"),
-					resource.TestCheckResourceAttr(res2.TFID(), "records.0.value", "hydrogen.ns.hetzner.com. dns.hetzner.com. 0 86400 10800 3600000 600"),
+					resource.TestCheckResourceAttr(res2.TFID(), "records.0.value", soaValue2),
 				),
 			},
 			{
+				// Re-planning the changed configuration produces no diff.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_zone", resZone,
 					"testdata/r/hcloud_zone_rrset", res2,


### PR DESCRIPTION
## Problem

For `type = "SOA"` RRSets, the RRSet is created by the Hetzner Cloud API together with the parent Zone, so it cannot be created a second time. Previously the `Create` method only **imported** the existing SOA RRSet and ignored the configured `records`. Applying a SOA RRSet whose configured records differed from the values the API assigned to the Zone therefore failed with:

> Provider produced inconsistent result after apply

because the planned `records` (the user's config) never matched the value read back from the API. This is #1289.

## Fix (settable, update-on-create)

Following @jooola's steer on #1289 — *"the Create method for the resource must be able to update the existing SOA record with the user provided value, without having to rely on a 2 steps process"* — SOA `records` stay a normal **settable** attribute, and `Create` now:

1. Looks up the pre-existing API-managed SOA RRSet (`GetRRSetByNameAndType`) to obtain its ID.
2. **Updates it in place** with the user-provided records via `SetRRSetRecords` — so the SOA record is managed through this resource in a **single apply**, no 2-step process.

**SERIAL normalization:** the API auto-increments the SOA `SERIAL` field, so it can never be predicted from config. As @jooola noted, the provider normalizes `SERIAL` to `0` in state (`OverrideRecordsSOASerial`, unchanged) — and the user is required to set `SERIAL` to `0` in their configuration. With both sides pinned to `0`, plan and apply stay consistent and there is no perpetual diff. This is documented on the resource.

Net effect: applying a SOA RRSet with non-default records succeeds in one apply, and subsequent plans are empty — the #1289 symptom is gone.

## Changes

- `internal/zonerrset/resource.go` — `Create` performs update-on-create for SOA (`SetRRSetRecords` against the existing RRSet); dropped the "records are imported/ignored" warning since records are now applied; added a `return` after the not-found diagnostic (the code path previously fell through to a nil deref).
- `internal/zonerrset/resource_test.go` — `TestAccZoneRRSetResource_SOA` now asserts the **settable** behaviour: applying user-provided SOA records (that differ from the API defaults) succeeds and the state reflects the configured value, changing them applies, and re-plans are empty.
- `docs/resources/zone_rrset.md` — regenerated via `make generate`; documents update-on-create and the `SERIAL = 0` requirement.

## Testing

- `go build ./...`, `go vet ./...`, `gofmt -l` — clean.
- Unit tests pass (`TestOverrideRecordsSOASerial`, `TestModel`, `TestTXTRecordFunction`).
- ⚠️ **The acceptance test `TestAccZoneRRSetResource_SOA` has NOT been run** — it needs `TF_ACC=1` + a live `HCLOUD_TOKEN` and hits the real Hetzner DNS API (creates/destroys a real Zone). I've verified it compiles and the plan-consistency reasoning, but it needs a CI run or a maintainer/token run to confirm the API round-trips the configured SOA value exactly.
  - One thing to confirm on the live run: whether the API echoes the configured SOA value byte-for-byte (aside from the auto-incremented SERIAL, which we normalize). If the API canonicalises the SOA string in any other field, the exact-match assertion would need a tweak — flagging so it can be verified against the test account.

Closes #1289

## AI assistance

Disclosing per the [AI / LLM policy](https://github.com/hetznercloud/terraform-provider-hcloud?tab=contributing-ov-file#ai--llm-policy) (thanks for the pointer, @jooola): this PR was developed with AI assistance — **Claude Code** (Anthropic). I reviewed and verified every line, take responsibility for the change, and can explain/defend it in review. This is my only open AI-assisted PR on this repo.
