### PR TITLE
chore(ci): support running acceptance tests from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,16 @@ jobs:
           go-version-file: go.mod
 
       - uses: hetznercloud/tps-action@dc6d67c5768ca43b840429b6c7409cda61cf4092 # main
+        with:
+          # Resolve credentials so the acceptance tests can also run from forks, where the
+          # default OIDC identity is not trusted by the public TPS:
+          #   - if HCLOUD_TOKEN is set, use it directly (skips TPS)
+          #   - otherwise contact TPS at tps-url (override with the TPS_URL variable; defaults
+          #     to the public TPS), authenticating with TPS_TOKEN if set, else GitHub OIDC.
+          # Upstream leaves all three unset, so the current OIDC-against-default-TPS flow is unchanged.
+          token: ${{ secrets.HCLOUD_TOKEN }}
+          tps-url: ${{ vars.TPS_URL || 'https://tps.hc-integrations.de' }}
+          tps-token: ${{ secrets.TPS_TOKEN }}
 
       - if: matrix.tool == 'opentofu'
         run: |
@@ -88,8 +98,9 @@ jobs:
       - run: go test -v -timeout=30m -parallel=8 -coverprofile=coverage.txt -coverpkg=./... ./...
         env:
           # Domain must be available in the account running the tests. This domain is
-          # available in the account running the public integration tests.
-          CERT_DOMAIN: hc-integrations-test.de
+          # available in the account running the public integration tests; forks can point
+          # the certificate tests at a domain in their own account via the CERT_DOMAIN variable.
+          CERT_DOMAIN: ${{ vars.CERT_DOMAIN || 'hc-integrations-test.de' }}
 
           TF_ACC: 1
           TF_LOG: DEBUG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,8 +112,10 @@ jobs:
           TF_LOG: DEBUG
           TF_LOG_PATH_MASK: test-%s.log
 
-          TEST_DATACENTER: ${{ vars.TEST_DATACENTER }}
-          TEST_LOCATION: ${{ vars.TEST_LOCATION }}
+          # Default to the upstream test location so a fork with these variables unset
+          # does not export an empty value (which would override the Go-level default).
+          TEST_DATACENTER: ${{ vars.TEST_DATACENTER || 'hel1-dc2' }}
+          TEST_LOCATION: ${{ vars.TEST_LOCATION || 'hel1' }}
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  # Lets a contributor run the suite from their fork, in the fork's own context
+  # where fork secrets are available. Together with the HCLOUD_TOKEN fallback on
+  # tps-action, this is how a fork runs the acceptance tests against its own
+  # Hetzner Cloud project (see "Running acceptance tests from a fork" in the README).
+  workflow_dispatch:
 
 env:
   GOTOOLCHAIN: local
@@ -32,6 +37,7 @@ jobs:
   e2e:
     if: >
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.draft == false
     needs: [unit]
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ $ go test -v -timeout=30m -parallel=8 ./internal/server
 # ...
 ```
 
+#### Running the acceptance tests from a fork (CI)
+
+The `Test` workflow's `e2e` job provisions a temporary Hetzner Cloud token via
+[`tps-action`](https://github.com/hetznercloud/tps-action) using GitHub OIDC, which is only
+available in this repository. To run the same acceptance tests from your own fork, configure
+one of the following (Settings → Secrets and variables → Actions):
+
+- **`HCLOUD_TOKEN`** secret — an API token from a (preferably throwaway) Hetzner Cloud
+  project. Simplest option; used directly.
+- or a **`TPS_URL`** variable pointing at your own
+  [`tps`](https://github.com/hetznercloud/tps-action) instance (keeps the OIDC / ephemeral-token
+  model), optionally with a **`TPS_TOKEN`** secret.
+
+Some tests need extra account setup: certificate tests use the **`CERT_DOMAIN`** variable (a
+domain available in your account), and server/network tests honour the **`TEST_DATACENTER`** /
+**`TEST_LOCATION`** variables.
+
 ### Running a local build
 
 Choose a terraform cli config file path:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ _Note:_ Acceptance tests create real resources, and often cost money to run.
 $ make testacc
 ```
 
+#### Running the acceptance tests from a fork
+
+In CI the acceptance tests obtain a temporary project from [TPS](https://github.com/hetznercloud/tps-action)
+via GitHub OIDC, which is only trusted for this repository. A pull request opened
+from a fork therefore cannot run them automatically.
+
+To validate your changes against your own Hetzner Cloud project, run the workflow
+in your fork:
+
+1. Create a **separate, throwaway** Hetzner Cloud project — the tests create and
+   destroy real resources.
+2. Configure your fork (once), using a token for that project and a domain you
+   control for the certificate tests:
+
+   ```sh
+   gh secret set HCLOUD_TOKEN --repo <your-fork> --body "<token>"
+   gh variable set CERT_DOMAIN --repo <your-fork> --body "<a-domain-you-own>"
+   # optional, to pin where resources are created:
+   gh variable set TEST_DATACENTER --repo <your-fork> --body "<datacenter>"
+   gh variable set TEST_LOCATION --repo <your-fork> --body "<location>"
+   ```
+
+3. From your fork, open **Actions → Test → Run workflow** and select your branch.
+
+The run executes in your fork's context, so it uses your `HCLOUD_TOKEN` directly
+and skips TPS. Unit tests, linting, and the build still run automatically on every
+pull request.
+
 You may save your acceptance tests environment variables in the `.env` file, for example:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ The run executes in your fork's context, so it uses your `HCLOUD_TOKEN` directly
 and skips TPS. Unit tests, linting, and the build still run automatically on every
 pull request.
 
+Instead of an `HCLOUD_TOKEN` secret, you can set a **`TPS_URL`** variable pointing at your
+own [`tps`](https://github.com/hetznercloud/tps-action) instance to keep the OIDC /
+ephemeral-token model, optionally with a **`TPS_TOKEN`** secret.
+
 You may save your acceptance tests environment variables in the `.env` file, for example:
 
 ```sh
@@ -115,23 +119,6 @@ $ go test -v -timeout=30m -parallel=8 ./internal/server
 === RUN   TestAccHcloudDataSourceServerTest
 # ...
 ```
-
-#### Running the acceptance tests from a fork (CI)
-
-The `Test` workflow's `e2e` job provisions a temporary Hetzner Cloud token via
-[`tps-action`](https://github.com/hetznercloud/tps-action) using GitHub OIDC, which is only
-available in this repository. To run the same acceptance tests from your own fork, configure
-one of the following (Settings → Secrets and variables → Actions):
-
-- **`HCLOUD_TOKEN`** secret — an API token from a (preferably throwaway) Hetzner Cloud
-  project. Simplest option; used directly.
-- or a **`TPS_URL`** variable pointing at your own
-  [`tps`](https://github.com/hetznercloud/tps-action) instance (keeps the OIDC / ephemeral-token
-  model), optionally with a **`TPS_TOKEN`** secret.
-
-Some tests need extra account setup: certificate tests use the **`CERT_DOMAIN`** variable (a
-domain available in your account), and server/network tests honour the **`TEST_DATACENTER`** /
-**`TEST_LOCATION`** variables.
 
 ### Running a local build
 


### PR DESCRIPTION
## What / why

The `Test` workflow's `e2e` job gets its Hetzner Cloud credentials from [`tps-action`](https://github.com/hetznercloud/tps-action), which mints a temporary token from TPS using **GitHub OIDC**. That OIDC identity is only trusted for `hetznercloud/terraform-provider-hcloud`, so **external contributors can't run the acceptance tests from their own forks** — they have to run them locally and hope CI passes after opening the PR.

This makes the same `e2e` job runnable from a fork, in two parts:

**1. Credentials** — thread `tps-action`'s existing inputs through from repository secrets/variables. They resolve as:

1. **`HCLOUD_TOKEN`** secret set → used directly (simplest; a token from a throwaway Hetzner project), else
2. contact TPS at **`tps-url`** (override via the **`TPS_URL`** variable; defaults to the public TPS) authenticating with a **`TPS_TOKEN`** secret if set, else GitHub OIDC.

`CERT_DOMAIN` is likewise made overridable via a variable (it was hardcoded), so certificate tests can point at a domain in the fork's own account. This matches how `hcloud-cloud-controller-manager`'s `test.yml` already threads `token: ${{ secrets.HCLOUD_TOKEN }}` into `tps-action`.

**2. A trigger a fork can fire** — add a `workflow_dispatch` trigger (and run `e2e` on it). A `pull_request` run from a fork executes in this repository's context, where fork secrets are unavailable — so the token fallback alone isn't reachable from a fork PR. `workflow_dispatch` lets a contributor run the suite **in their own fork's context**, where their fork secrets exist. The README documents the one-time setup (`HCLOUD_TOKEN` secret + `CERT_DOMAIN` variable) and the Actions → Run workflow step.

**Backward compatible:** on this repository none of the new secrets/variables are set, so every value falls back to its current default and the existing OIDC-against-default-TPS flow is unchanged. `workflow_dispatch` adds a manual trigger but changes nothing about the automatic `push`/`pull_request` runs.

## Testing

- `test.yml` validated as YAML; the `tps-action` inputs match the action's documented `token` / `tps-url` / `tps-token` interface, and each expression falls back to today's value when the secret/variable is unset.
- The `e2e` job's `if:` now also runs on `workflow_dispatch`; unit/lint/build are unaffected and still run on every pull request (including drafts).
- No behavioural change for the upstream repo (all new inputs resolve to empty/default; `workflow_dispatch` is opt-in).

### AI assistance

Developed with AI assistance (Claude Code, Anthropic — Opus 4.x). **AI's role:** drafted the workflow/README changes and verified the `tps-action` input semantics against the action's README and the sibling `hcloud-cloud-controller-manager` workflow. **My role:** identified the fork-can't-run-acctests gap, designed the token-fallback + `workflow_dispatch` approach, reviewed every line, and I take responsibility for it. Happy to adjust to whatever shape you prefer.
