### PR TITLE
docs(load_balancer_service): document TLS termination and passthrough

### DIFF
--- a/docs/resources/load_balancer_service.md
+++ b/docs/resources/load_balancer_service.md
@@ -43,6 +43,44 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 }
 ```
 
+## TLS Termination and Passthrough
+
+The Hetzner Cloud API has no dedicated "TLS passthrough" option. Whether the Load
+Balancer terminates TLS or passes it through to the targets is determined by the
+service `protocol`:
+
+- **TLS termination** — set `protocol = "https"` and attach one or more
+  `certificates`. The Load Balancer terminates the TLS connection, so it can
+  inspect and modify HTTP traffic (sticky sessions, HTTP-to-HTTPS redirects, HTTP
+  health checks, etc.).
+
+  ```terraform
+  resource "hcloud_load_balancer_service" "tls_termination" {
+    load_balancer_id = hcloud_load_balancer.load_balancer.id
+    protocol         = "https"
+    listen_port      = 443
+    destination_port = 80
+
+    http {
+      certificates = [hcloud_managed_certificate.cert.id]
+    }
+  }
+  ```
+
+- **TLS passthrough** — set `protocol = "tcp"` and forward the TLS port (usually
+  `443`). The Load Balancer forwards the raw TCP stream to the targets, which
+  terminate TLS themselves. No `certificates` are configured on the Load Balancer,
+  and HTTP-level features are unavailable because the traffic stays encrypted.
+
+  ```terraform
+  resource "hcloud_load_balancer_service" "tls_passthrough" {
+    load_balancer_id = hcloud_load_balancer.load_balancer.id
+    protocol         = "tcp"
+    listen_port      = 443
+    destination_port = 443
+  }
+  ```
+
 ## Argument Reference
 
 - `load_balancer_id` - (Required, int) Id of the load balancer this service belongs to.

--- a/docs/resources/load_balancer_service.md
+++ b/docs/resources/load_balancer_service.md
@@ -43,7 +43,7 @@ resource "hcloud_load_balancer_service" "load_balancer_service" {
 }
 ```
 
-## TLS Termination and Passthrough
+### TLS Termination and Passthrough
 
 The Hetzner Cloud API has no dedicated "TLS passthrough" option. Whether the Load
 Balancer terminates TLS or passes it through to the targets is determined by the

--- a/templates/resources/load_balancer_service.md.tmpl
+++ b/templates/resources/load_balancer_service.md.tmpl
@@ -12,7 +12,7 @@ Define services for Hetzner Cloud Load Balancers.
 
 {{ tffile .ExampleFile }}
 
-## TLS Termination and Passthrough
+### TLS Termination and Passthrough
 
 The Hetzner Cloud API has no dedicated "TLS passthrough" option. Whether the Load
 Balancer terminates TLS or passes it through to the targets is determined by the

--- a/templates/resources/load_balancer_service.md.tmpl
+++ b/templates/resources/load_balancer_service.md.tmpl
@@ -12,6 +12,44 @@ Define services for Hetzner Cloud Load Balancers.
 
 {{ tffile .ExampleFile }}
 
+## TLS Termination and Passthrough
+
+The Hetzner Cloud API has no dedicated "TLS passthrough" option. Whether the Load
+Balancer terminates TLS or passes it through to the targets is determined by the
+service `protocol`:
+
+- **TLS termination** — set `protocol = "https"` and attach one or more
+  `certificates`. The Load Balancer terminates the TLS connection, so it can
+  inspect and modify HTTP traffic (sticky sessions, HTTP-to-HTTPS redirects, HTTP
+  health checks, etc.).
+
+  ```terraform
+  resource "hcloud_load_balancer_service" "tls_termination" {
+    load_balancer_id = hcloud_load_balancer.load_balancer.id
+    protocol         = "https"
+    listen_port      = 443
+    destination_port = 80
+
+    http {
+      certificates = [hcloud_managed_certificate.cert.id]
+    }
+  }
+  ```
+
+- **TLS passthrough** — set `protocol = "tcp"` and forward the TLS port (usually
+  `443`). The Load Balancer forwards the raw TCP stream to the targets, which
+  terminate TLS themselves. No `certificates` are configured on the Load Balancer,
+  and HTTP-level features are unavailable because the traffic stays encrypted.
+
+  ```terraform
+  resource "hcloud_load_balancer_service" "tls_passthrough" {
+    load_balancer_id = hcloud_load_balancer.load_balancer.id
+    protocol         = "tcp"
+    listen_port      = 443
+    destination_port = 443
+  }
+  ```
+
 ## Argument Reference
 
 - `load_balancer_id` - (Required, int) Id of the load balancer this service belongs to.


### PR DESCRIPTION
Closes #1051.

Per @jooola on the issue — the Hetzner Cloud API has no dedicated "TLS passthrough" feature; the equivalent is achieved by choosing the service `protocol`, and the request was to **document both configurations with examples**.

This adds a "TLS Termination and Passthrough" section to the `hcloud_load_balancer_service` docs:

- **TLS termination** — `protocol = "https"` + `certificates` (LB terminates TLS, HTTP features available).
- **TLS passthrough** — `protocol = "tcp"` forwarding port 443 (LB forwards the raw TCP/TLS stream; targets terminate TLS).

Docs-only: edited the template `templates/resources/load_balancer_service.md.tmpl` and regenerated `docs/resources/load_balancer_service.md` via `make generate` (Terraform v1.15.7). No code or schema changes.

### AI assistance
Drafted with Claude Code; I directed the content, confirmed the protocol semantics against the existing docs, and verified the regenerated output. `make generate` touched only the intended files.
