### PR TITLE
fix(load_balancer): lift delete protection when deleting the resource

### DIFF
--- a/internal/loadbalancer/resource.go
+++ b/internal/loadbalancer/resource.go
@@ -363,6 +363,15 @@ func resourceLoadBalancerDelete(ctx context.Context, d *schema.ResourceData, m a
 		return nil
 	}
 
+	// As documented, delete protection only prevents other API consumers from
+	// deleting the resource; Terraform lifts the protection so it can delete the
+	// Load Balancer it manages. (#1206)
+	if loadBalancer.Protection.Delete {
+		if err := setProtection(ctx, client, loadBalancer, false); err != nil {
+			return hcloudutil.ErrorToDiag(err)
+		}
+	}
+
 	if _, err := client.LoadBalancer.Delete(ctx, loadBalancer); err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
 			// loadBalancer has already been deleted

--- a/internal/loadbalancer/resource_test.go
+++ b/internal/loadbalancer/resource_test.go
@@ -248,3 +248,36 @@ func TestAccLoadBalancerResource_Protection(t *testing.T) {
 		},
 	})
 }
+
+// TestAccLoadBalancerResource_DeleteProtectionLifted is a regression test for
+// #1206: Terraform must be able to delete a Load Balancer that still has delete
+// protection enabled (protection only guards against other API consumers). The
+// configuration never disables protection, so the CheckDestroy step deletes a
+// still-protected Load Balancer, which fails without the fix.
+func TestAccLoadBalancerResource_DeleteProtectionLifted(t *testing.T) {
+	var lb hcloud.LoadBalancer
+
+	res := &loadbalancer.RData{
+		Name:             "load-balancer-delete-protection-lifted",
+		LocationName:     teste2e.TestLocationName,
+		DeleteProtection: true,
+	}
+
+	tmplMan := testtemplate.Manager{}
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: testmux.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckResourcesDestroyed(loadbalancer.ResourceType, loadbalancer.ByID(t, &lb)),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_load_balancer", res,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testsupport.CheckResourceExists(res.TFID(), loadbalancer.ByID(t, &lb)),
+					resource.TestCheckResourceAttr(res.TFID(), "delete_protection", "true"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Closes #1206.

### Problem

The [delete-protection docs](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs#delete-protection) state that a protected resource can still be deleted by Terraform — protection only prevents *other* API consumers (e.g. the Cloud Console) from deleting it. But `hcloud_load_balancer` failed with `load balancer deletion is protected` instead of deleting.

As @apricote noted in the issue, only `hcloud_zone_rrset` currently lifts protection to make its changes; the other resources don't follow the documented behaviour.

### Fix

In `resourceLoadBalancerDelete`, if the Load Balancer has delete protection enabled, disable it (via the existing `setProtection` helper) before deleting — mirroring `hcloud_zone_rrset`. Adds `TestAccLoadBalancerResource_DeleteProtectionLifted`, which creates a Load Balancer with `delete_protection = true` and never disables it, so the framework's `CheckDestroy` must delete a still-protected resource (fails without this change).

### Scope

I've scoped this to **`hcloud_load_balancer`** — the resource in the issue (and the one that bites the `hcloud-cloud-controller-manager` use case). Your inventory in #1206 lists the same gap for `floating_ip`, `network`, `primary_ip`, `server`, `volume`, and `zone`. Happy to extend this PR to cover the rest in one coordinated change if you'd prefer that over per-resource PRs — just let me know.

### Testing

`go build ./...`, `go vet`, and `gofmt` are clean; the new acceptance test compiles and is skipped without `TF_ACC`. I haven't run it against a live account in this PR — glad for CI / a maintainer to run it, and I can also run it against my own throwaway project if useful.

### AI assistance
Implemented with Claude Code; I directed the change (reusing the in-repo `setProtection` helper and the `zone_rrset` pattern) and verified build/vet/test-compile locally.
