### PR TITLE
fix(server): inconsistent image attribute when using data source

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -54,6 +54,7 @@ func Resource() *schema.Resource {
 			"image": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				ValidateFunc: func(val any, key string) (i []string, errors []error) {
 					image := val.(string)

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -165,6 +165,7 @@ func TestAccServerResource_ImageID(t *testing.T) {
 	resImage := &image.DData{
 		Name:             teste2e.TestImage,
 		WithArchitecture: hcloud.ArchitectureX86,
+		Raw:              `depends_on = [terraform_data.defer]`,
 	}
 	resImage.SetRName("server-image-id")
 
@@ -186,6 +187,7 @@ func TestAccServerResource_ImageID(t *testing.T) {
 				// only.
 				Config: tmplMan.Render(t,
 					"testdata/r/hcloud_ssh_key", resSSHKey,
+					"testdata/r/any", `resource "terraform_data" "defer" { input = "test" }`,
 					"testdata/d/hcloud_image", resImage,
 					"testdata/r/hcloud_server", res,
 				),


### PR DESCRIPTION
Mark the image attribute as computed to allow the provider to populate this value.

Closes #1478 
Related to #1466