### PR TITLE
fix(server): drifting labels after first creation

### DIFF
--- a/internal/server/resource.go
+++ b/internal/server/resource.go
@@ -152,6 +152,7 @@ func Resource() *schema.Resource {
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
+				Computed: true,
 				ValidateDiagFunc: func(i any, path cty.Path) diag.Diagnostics { // nolint:revive
 					if ok, err := hcloud.ValidateResourceLabels(i.(map[string]any)); !ok {
 						return diag.FromErr(err)

--- a/internal/server/resource_test.go
+++ b/internal/server/resource_test.go
@@ -130,6 +130,39 @@ func TestAccServerResource(t *testing.T) {
 	})
 }
 
+func TestAccServerResource_Drift(t *testing.T) {
+	tmplMan := testtemplate.Manager{}
+
+	res := &server.RData{
+		Name:         "main",
+		Type:         teste2e.TestServerType,
+		Image:        teste2e.TestImage,
+		LocationName: teste2e.TestLocationName,
+	}
+	res.SetRName("main")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:                 teste2e.PreCheck(t),
+		ProtoV6ProviderFactories: testmux.ProtoV6ProviderFactories(),
+		CheckDestroy:             testsupport.CheckAPIResourceAllAbsent(server.ResourceType, server.GetAPIResource()),
+		Steps: []resource.TestStep{
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", res,
+					"testdata/r/any", `output "server" { value = hcloud_server.main }`,
+				),
+			},
+			{
+				Config: tmplMan.Render(t,
+					"testdata/r/hcloud_server", res,
+					"testdata/r/any", `output "server" { value = hcloud_server.main }`,
+				),
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
 func TestAccServerResource_UnavailableServerType(t *testing.T) {
 	tmplMan := testtemplate.Manager{}
 


### PR DESCRIPTION
Closes #1340

If not provided, the labels are returned by the API, and must therefore be computed.