### PR TITLE
test: revert fix opentofu unexpectedly moving resource during tests (#1497)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,7 @@ jobs:
       - if: matrix.tool == 'opentofu'
         run: |
           echo TF_ACC_TERRAFORM_PATH="$(which tofu)" >> $GITHUB_ENV
-          echo TF_ACC_PROVIDER_NAMESPACE="hetznercloud" >> $GITHUB_ENV
+          echo TF_ACC_PROVIDER_NAMESPACE="hashicorp" >> $GITHUB_ENV
           echo TF_ACC_PROVIDER_HOST="registry.opentofu.org" >> $GITHUB_ENV
 
       - run: go test -v -timeout=30m -parallel=8 -coverprofile=coverage.txt -coverpkg=./... ./...


### PR DESCRIPTION
Opentofu released a fix for the original issue, and the now reverted changes were introducing other unexpected breakages.

This reverts commit daab2290504d8b9d46721063f31f4800fec698d1.