### PR TITLE
test: always configure TF_ACC_PROVIDER_NAMESPACE and fix broken tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
       - if: matrix.tool == 'opentofu'
         run: |
           echo TF_ACC_TERRAFORM_PATH="$(which tofu)" >> $GITHUB_ENV
-          echo TF_ACC_PROVIDER_NAMESPACE="hashicorp" >> $GITHUB_ENV
           echo TF_ACC_PROVIDER_HOST="registry.opentofu.org" >> $GITHUB_ENV
 
       - run: go test -v -timeout=30m -parallel=8 -coverprofile=coverage.txt -coverpkg=./... ./...
@@ -92,6 +91,7 @@ jobs:
           CERT_DOMAIN: hc-integrations-test.de
 
           TF_ACC: 1
+          TF_ACC_PROVIDER_NAMESPACE: hetznercloud
           TF_LOG: DEBUG
           TF_LOG_PATH_MASK: test-%s.log
 

--- a/internal/firewall/attachment_resource_test.go
+++ b/internal/firewall/attachment_resource_test.go
@@ -55,12 +55,7 @@ func TestAccFirewallAttachmentResource_Servers(t *testing.T) {
 			},
 			{
 				ResourceName: fwAttRes.TFID(),
-				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_server", srvRes,
-					"testdata/r/hcloud_firewall", fwRes,
-					"testdata/r/hcloud_firewall_attachment", fwAttRes,
-				),
-				ImportState: true,
+				ImportState:  true,
 			},
 		},
 	})
@@ -110,12 +105,7 @@ func TestAccFirewallAttachmentResource_LabelSelectors(t *testing.T) {
 			},
 			{
 				ResourceName: fwAttRes.TFID(),
-				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_server", srvRes,
-					"testdata/r/hcloud_firewall", fwRes,
-					"testdata/r/hcloud_firewall_attachment", fwAttRes,
-				),
-				ImportState: true,
+				ImportState:  true,
 			},
 		},
 	})

--- a/internal/storagebox/resource_test.go
+++ b/internal/storagebox/resource_test.go
@@ -103,10 +103,8 @@ func TestAccStorageBoxResource(t *testing.T) {
 			},
 			{
 				// Import
-
-				Config:                  tmplMan.Render(t, "testdata/r/hcloud_storage_box", res),
-				ImportState:             true,
 				ResourceName:            res.TFID(),
+				ImportState:             true,
 				ImportStateId:           res.Name,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password"}, // Not returned in the API
@@ -187,10 +185,8 @@ func TestAccStorageBoxResource(t *testing.T) {
 			{
 				// Import resource with all fields set
 				// Regression test for https://github.com/hetznercloud/terraform-provider-hcloud/issues/1287
-
-				Config:                  tmplMan.Render(t, "testdata/r/hcloud_storage_box", resOptional),
-				ImportState:             true,
 				ResourceName:            resOptional.TFID(),
+				ImportState:             true,
 				ImportStateId:           resOptional.Name,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"password", "ssh_keys"}, // Not returned in the API

--- a/internal/storageboxsnapshot/resource_test.go
+++ b/internal/storageboxsnapshot/resource_test.go
@@ -76,13 +76,8 @@ func TestAccStorageBoxSnapshotResource(t *testing.T) {
 			},
 			{
 				// Import
-
-				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_storage_box", resStorageBox,
-					"testdata/r/hcloud_storage_box_snapshot", resMinimal,
-				),
-				ImportState:  true,
 				ResourceName: resMinimal.TFID(),
+				ImportState:  true,
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return fmt.Sprintf("%d/%d", snapshot.StorageBox.ID, snapshot.ID), nil
 				},

--- a/internal/storageboxsubaccount/resource_test.go
+++ b/internal/storageboxsubaccount/resource_test.go
@@ -98,13 +98,8 @@ func TestAccStorageBoxSubaccountResource(t *testing.T) {
 			},
 			{
 				// Import
-
-				Config: tmplMan.Render(t,
-					"testdata/r/hcloud_storage_box", resStorageBox,
-					"testdata/r/hcloud_storage_box_subaccount", res,
-				),
-				ImportState:  true,
 				ResourceName: res.TFID(),
+				ImportState:  true,
 				ImportStateIdFunc: func(_ *terraform.State) (string, error) {
 					return fmt.Sprintf("%d/%d", subaccount.StorageBox.ID, subaccount.ID), nil
 				},


### PR DESCRIPTION
Having the configuration regenerated alongside the import fails when `TF_ACC_PROVIDER_NAMESPACE=hetznercloud`.

