### PR TITLE
ci: allow running acceptance tests from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
 
 env:
   GOTOOLCHAIN: local
@@ -32,6 +33,7 @@ jobs:
   e2e:
     if: >
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.draft == false
     needs: [unit]
     runs-on: ubuntu-latest
@@ -78,6 +80,8 @@ jobs:
           go-version-file: go.mod
 
       - uses: hetznercloud/tps-action@5bfcef547f41c44aa626d0474c0491a1dbda792a # main
+        with:
+          token: ${{ secrets.HCLOUD_TOKEN }}
 
       - if: matrix.tool == 'opentofu'
         run: |
@@ -86,17 +90,13 @@ jobs:
 
       - run: go test -v -timeout=30m -parallel=8 -coverprofile=coverage.txt -coverpkg=./... ./...
         env:
-          # Domain must be available in the account running the tests. This domain is
-          # available in the account running the public integration tests.
-          CERT_DOMAIN: hc-integrations-test.de
-
           TF_ACC: 1
           TF_ACC_PROVIDER_NAMESPACE: hetznercloud
           TF_LOG: DEBUG
           TF_LOG_PATH_MASK: test-%s.log
 
-          TEST_DATACENTER: ${{ vars.TEST_DATACENTER }}
-          TEST_LOCATION: ${{ vars.TEST_LOCATION }}
+          TEST_CERTIFICATE_DOMAIN: ${{ vars.TEST_CERTIFICATE_DOMAIN || 'hc-integrations-test.de' }}
+          TEST_LOCATION: ${{ vars.TEST_LOCATION || 'hel1' }}
 
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         if: >

--- a/internal/certificate/resource_test.go
+++ b/internal/certificate/resource_test.go
@@ -2,7 +2,6 @@ package certificate_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
@@ -14,12 +13,6 @@ import (
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testmux"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testsupport"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/testtemplate"
-)
-
-var (
-	// Tests using this value should skip if empty.
-	// The domain specified here must be available in Hetzner DNS of the account running the tests.
-	certDomain = os.Getenv("CERT_DOMAIN")
 )
 
 func TestAccCertificateResource_Uploaded(t *testing.T) {
@@ -115,14 +108,14 @@ func TestAccCertificateResource_Uploaded_ChangeCertRequiresNewResource(t *testin
 }
 
 func TestAccCertificateResource_Managed(t *testing.T) {
-	if certDomain == "" {
-		t.Skip("Skipping because CERT_DOMAIN is not set")
+	if teste2e.TestCertificateDomain == "" {
+		t.Skip("Skipping because TEST_CERTIFICATE_DOMAIN is not set")
 	}
 
 	var cert hcloud.Certificate
 
 	res := certificate.NewManagedRData(t, "basic-managed-cert", []string{
-		fmt.Sprintf("tftest-%d.%s", acctest.RandInt(), certDomain),
+		fmt.Sprintf("tftest-%d.%s", acctest.RandInt(), teste2e.TestCertificateDomain),
 	})
 	resRenamed := &certificate.RDataManaged{
 		Name:        res.Name + "-renamed",

--- a/internal/teste2e/testing.go
+++ b/internal/teste2e/testing.go
@@ -39,6 +39,12 @@ var (
 
 	// TestLocationName is the default location where we execute our tests.
 	TestLocationName = getEnv("TEST_LOCATION", "hel1")
+
+	// TestCertificateDomain is the domain used to create managed certificates during
+	// tests. Tests using this value should skip if empty.
+	//
+	// The domain specified here must be available in the account running the tests.
+	TestCertificateDomain = getEnv("TEST_CERTIFICATE_DOMAIN", "")
 )
 
 // PreCheck checks if all conditions for an acceptance test are


### PR DESCRIPTION
- Rename `CERT_DOMAIN` to `TEST_CERTIFICATE_DOMAIN`
- Allow triggering a workflow
- Allow passing `HCLOUD_TOKEN` as Github Action secret