### PR TITLE
feat(load_balancer_type): add deprecation details and warnings

### DIFF
--- a/docs/data-sources/load_balancer_type.md
+++ b/docs/data-sources/load_balancer_type.md
@@ -41,8 +41,11 @@ resource "hcloud_load_balancer" "main" {
 
 ### Read-Only
 
+- `deprecation_announced` (String) Date of the Load Balancer Type deprecation announcement.
 - `description` (String) Description of the Load Balancer Type.
+- `is_deprecated` (Boolean) Whether the Load Balancer Type is deprecated.
 - `max_assigned_certificates` (Number) Maximum number of certificates that can be assigned for the Load Balancer of this type.
 - `max_connections` (Number) Maximum number of simultaneous open connections for the Load Balancer of this type.
 - `max_services` (Number) Maximum number of services for the Load Balancer of this type.
 - `max_targets` (Number) Maximum number of targets for the Load Balancer of this type.
+- `unavailable_after` (String) Date of the Load Balancer Type removal. After this date, the Load Balancer Type cannot be used anymore.

--- a/docs/data-sources/load_balancer_types.md
+++ b/docs/data-sources/load_balancer_types.md
@@ -29,10 +29,13 @@ data "hcloud_load_balancer_types" "all" {}
 
 Read-Only:
 
+- `deprecation_announced` (String) Date of the Load Balancer Type deprecation announcement.
 - `description` (String) Description of the Load Balancer Type.
 - `id` (Number) ID of the Load Balancer Type.
+- `is_deprecated` (Boolean) Whether the Load Balancer Type is deprecated.
 - `max_assigned_certificates` (Number) Maximum number of certificates that can be assigned for the Load Balancer of this type.
 - `max_connections` (Number) Maximum number of simultaneous open connections for the Load Balancer of this type.
 - `max_services` (Number) Maximum number of services for the Load Balancer of this type.
 - `max_targets` (Number) Maximum number of targets for the Load Balancer of this type.
 - `name` (String) Name of the Load Balancer Type.
+- `unavailable_after` (String) Date of the Load Balancer Type removal. After this date, the Load Balancer Type cannot be used anymore.

--- a/internal/deprecation/deprecation_plugin.go
+++ b/internal/deprecation/deprecation_plugin.go
@@ -30,6 +30,23 @@ func NewDeprecationModel(_ context.Context, in hcloud.Deprecatable) (Deprecation
 		data.UnavailableAfter = types.StringValue(in.UnavailableAfter().Format(time.RFC3339))
 	} else {
 		data.IsDeprecated = types.BoolValue(false)
+		data.DeprecationAnnounced = types.StringNull()
+		data.UnavailableAfter = types.StringNull()
+	}
+
+	return data, diags
+}
+
+func NewLegacyDeprecationModel(_ context.Context, in hcloud.Deprecatable) (DeprecationModel, diag.Diagnostics) {
+	var data DeprecationModel
+	var diags diag.Diagnostics
+
+	if in.IsDeprecated() {
+		data.IsDeprecated = types.BoolValue(true)
+		data.DeprecationAnnounced = types.StringValue(in.DeprecationAnnounced().Format(time.RFC3339))
+		data.UnavailableAfter = types.StringValue(in.UnavailableAfter().Format(time.RFC3339))
+	} else {
+		data.IsDeprecated = types.BoolValue(false)
 
 		// TODO: Stored values should be types.StringNull(), but we use an empty string
 		// for backward compatibility with the SDK.

--- a/internal/deprecation/deprecation_plugin_test.go
+++ b/internal/deprecation/deprecation_plugin_test.go
@@ -18,6 +18,14 @@ func TestNewDeprecationModel(t *testing.T) {
 		data, diags := NewDeprecationModel(ctx, hcloud.ServerType{})
 		assert.Equal(t, false, diags.HasError())
 		assert.Equal(t, false, data.IsDeprecated.ValueBool())
+		assert.Equal(t, true, data.DeprecationAnnounced.IsNull())
+		assert.Equal(t, true, data.UnavailableAfter.IsNull())
+	}
+
+	{
+		data, diags := NewLegacyDeprecationModel(ctx, hcloud.ServerType{})
+		assert.Equal(t, false, diags.HasError())
+		assert.Equal(t, false, data.IsDeprecated.ValueBool())
 		assert.Equal(t, false, data.DeprecationAnnounced.IsNull())
 		assert.Equal(t, "", data.DeprecationAnnounced.ValueString())
 		assert.Equal(t, false, data.UnavailableAfter.IsNull())
@@ -25,7 +33,7 @@ func TestNewDeprecationModel(t *testing.T) {
 	}
 
 	{
-		data, diags := NewDeprecationModel(ctx, hcloud.ServerType{
+		data, diags := NewLegacyDeprecationModel(ctx, hcloud.ServerType{
 			DeprecatableResource: hcloud.DeprecatableResource{
 				Deprecation: &hcloud.DeprecationInfo{
 					Announced:        fakeTime,

--- a/internal/loadbalancertype/data_source.go
+++ b/internal/loadbalancertype/data_source.go
@@ -12,8 +12,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/deprecationutil"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/deprecation"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/datasourceutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/hcloudutil"
+	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/merge"
 )
 
 const (
@@ -32,9 +35,11 @@ type resourceData struct {
 	MaxConnections          types.Int64  `tfsdk:"max_connections"`
 	MaxServices             types.Int64  `tfsdk:"max_services"`
 	MaxTargets              types.Int64  `tfsdk:"max_targets"`
+
+	deprecation.DeprecationModel
 }
 
-var resourceDataAttrTypes = map[string]attr.Type{
+var resourceDataAttrTypes = merge.Maps(map[string]attr.Type{
 	"id":                        types.Int64Type,
 	"name":                      types.StringType,
 	"description":               types.StringType,
@@ -42,11 +47,14 @@ var resourceDataAttrTypes = map[string]attr.Type{
 	"max_connections":           types.Int64Type,
 	"max_services":              types.Int64Type,
 	"max_targets":               types.Int64Type,
-}
+},
+	deprecation.AttrTypes(),
+)
 
-func newResourceData(_ context.Context, in *hcloud.LoadBalancerType) (resourceData, diag.Diagnostics) { //nolint:unparam
+func newResourceData(ctx context.Context, in *hcloud.LoadBalancerType) (resourceData, diag.Diagnostics) { //nolint:unparam
 	var data resourceData
 	var diags diag.Diagnostics
+	var newDiags diag.Diagnostics
 
 	data.ID = types.Int64Value(in.ID)
 	data.Name = types.StringValue(in.Name)
@@ -57,11 +65,14 @@ func newResourceData(_ context.Context, in *hcloud.LoadBalancerType) (resourceDa
 	data.MaxServices = types.Int64Value(int64(in.MaxServices))
 	data.MaxTargets = types.Int64Value(int64(in.MaxTargets))
 
+	data.DeprecationModel, newDiags = deprecation.NewDeprecationModel(ctx, in)
+	diags.Append(newDiags...)
+
 	return data, diags
 }
 
 func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
-	return map[string]schema.Attribute{
+	return merge.Maps(map[string]schema.Attribute{
 		"id": schema.Int64Attribute{
 			MarkdownDescription: "ID of the Load Balancer Type.",
 			Optional:            !readOnly,
@@ -92,7 +103,9 @@ func getCommonDataSchema(readOnly bool) map[string]schema.Attribute {
 			MarkdownDescription: "Maximum number of targets for the Load Balancer of this type.",
 			Computed:            true,
 		},
-	}
+	},
+		deprecation.DataSourceSchema("Load Balancer Type"),
+	)
 }
 
 // Single
@@ -186,6 +199,14 @@ func (d *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		// Should not happen, see [dataSource.ConfigValidators]
 		resp.Diagnostics.AddError("Unexpected internal error", "")
 		return
+	}
+
+	if message, unavailable := deprecationutil.LoadBalancerTypeMessage(result); message != "" {
+		if unavailable {
+			resp.Diagnostics.AddWarning("Load Balancer Type unavailable", message+".")
+		} else {
+			resp.Diagnostics.AddWarning("Load Balancer Type deprecated", message+".")
+		}
 	}
 
 	data, diags := newResourceData(ctx, result)

--- a/internal/loadbalancertype/data_source_test.go
+++ b/internal/loadbalancertype/data_source_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/statecheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/loadbalancertype"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/teste2e"
@@ -30,23 +33,29 @@ func TestAccLoadBalancerTypeDataSource(t *testing.T) {
 					"testdata/d/hcloud_load_balancer_type", byID,
 				),
 
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(byName.TFID(), "id", "1"),
-					resource.TestCheckResourceAttr(byName.TFID(), "name", "lb11"),
-					resource.TestCheckResourceAttr(byName.TFID(), "description", "LB11"),
-					resource.TestCheckResourceAttr(byName.TFID(), "max_assigned_certificates", "10"),
-					resource.TestCheckResourceAttr(byName.TFID(), "max_connections", "10000"),
-					resource.TestCheckResourceAttr(byName.TFID(), "max_services", "5"),
-					resource.TestCheckResourceAttr(byName.TFID(), "max_targets", "25"),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("id"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("name"), knownvalue.StringExact("lb11")),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("description"), knownvalue.StringExact("LB11")),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("max_assigned_certificates"), knownvalue.Int64Exact(10)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("max_connections"), knownvalue.Int64Exact(10000)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("max_services"), knownvalue.Int64Exact(5)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("max_targets"), knownvalue.Int64Exact(25)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("is_deprecated"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("deprecation_announced"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(byName.TFID(), tfjsonpath.New("unavailable_after"), knownvalue.Null()),
 
-					resource.TestCheckResourceAttr(byID.TFID(), "id", "1"),
-					resource.TestCheckResourceAttr(byID.TFID(), "name", "lb11"),
-					resource.TestCheckResourceAttr(byID.TFID(), "description", "LB11"),
-					resource.TestCheckResourceAttr(byID.TFID(), "max_assigned_certificates", "10"),
-					resource.TestCheckResourceAttr(byID.TFID(), "max_connections", "10000"),
-					resource.TestCheckResourceAttr(byID.TFID(), "max_services", "5"),
-					resource.TestCheckResourceAttr(byID.TFID(), "max_targets", "25"),
-				),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("id"), knownvalue.Int64Exact(1)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("name"), knownvalue.StringExact("lb11")),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("description"), knownvalue.StringExact("LB11")),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("max_assigned_certificates"), knownvalue.Int64Exact(10)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("max_connections"), knownvalue.Int64Exact(10000)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("max_services"), knownvalue.Int64Exact(5)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("max_targets"), knownvalue.Int64Exact(25)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("is_deprecated"), knownvalue.Bool(false)),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("deprecation_announced"), knownvalue.Null()),
+					statecheck.ExpectKnownValue(byID.TFID(), tfjsonpath.New("unavailable_after"), knownvalue.Null()),
+				},
 			},
 		},
 	})

--- a/internal/servertype/data_source.go
+++ b/internal/servertype/data_source.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	"github.com/hetznercloud/hcloud-go/v2/hcloud/exp/deprecationutil"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/deprecation"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util"
 	"github.com/hetznercloud/terraform-provider-hcloud/internal/util/datasourceutil"
@@ -119,7 +120,7 @@ func newResourceData(ctx context.Context, in *hcloud.ServerType) (resourceData, 
 				Available:   types.BoolValue(hcItem.Available),
 				Recommended: types.BoolValue(hcItem.Recommended),
 			}
-			m.DeprecationModel, newDiags = deprecation.NewDeprecationModel(ctx, hcItem)
+			m.DeprecationModel, newDiags = deprecation.NewLegacyDeprecationModel(ctx, hcItem)
 			diags.Append(newDiags...)
 
 			tfItem, newDiags := types.ObjectValueFrom(ctx, m.tfAttributesTypes(), m)
@@ -136,7 +137,7 @@ func newResourceData(ctx context.Context, in *hcloud.ServerType) (resourceData, 
 
 	data.IncludedTraffic = types.Int64Value(in.IncludedTraffic) // nolint:staticcheck // Keep as long as it is available
 
-	data.DeprecationModel, newDiags = deprecation.NewDeprecationModel(ctx, in)
+	data.DeprecationModel, newDiags = deprecation.NewLegacyDeprecationModel(ctx, in)
 	diags.Append(newDiags...)
 
 	return data, diags
@@ -327,6 +328,14 @@ func (d *dataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		// Should not happen, see [dataSource.ConfigValidators]
 		resp.Diagnostics.AddError("Unexpected internal error", "")
 		return
+	}
+
+	if message, unavailable := deprecationutil.ServerTypeMessage(result, ""); message != "" {
+		if unavailable {
+			resp.Diagnostics.AddWarning("Server Type unavailable", message+".")
+		} else {
+			resp.Diagnostics.AddWarning("Server Type deprecated", message+".")
+		}
 	}
 
 	data, diags := newResourceData(ctx, result)

--- a/internal/storageboxtype/model.go
+++ b/internal/storageboxtype/model.go
@@ -57,7 +57,7 @@ func (m *model) FromAPI(ctx context.Context, hc *hcloud.StorageBoxType) diag.Dia
 	m.SubaccountsLimit = types.Int64Value(int64(hc.SubaccountsLimit))
 	m.Size = types.Int64Value(hc.Size)
 
-	m.DeprecationModel, newDiags = deprecation.NewDeprecationModel(ctx, hc)
+	m.DeprecationModel, newDiags = deprecation.NewLegacyDeprecationModel(ctx, hc)
 	diags.Append(newDiags...)
 
 	return diags


### PR DESCRIPTION
- Add the deprecation details to the load balancer type schemas
- Add deprecation warning diagnostic when the load balancer type is deprecation or unavailable
- Improve our deprecation util package to not store empty strings instead of null for new attributes (not migrated from the sdk).
- Add deprecation warning diagnostic when the server type is deprecation or unavailable.

```rp-commits
feat(load_balancer_type): add deprecation details and warnings (#1512)
feat(server_type): add deprecation warnings (#1512)
```