### PR TITLE
test: drop terraform v1.14 and add terraform v1.16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,9 +63,9 @@ jobs:
           - tool: opentofu
             version: v1.12.x
           - tool: terraform
-            version: v1.14.x
-          - tool: terraform
             version: v1.15.x
+          - tool: terraform
+            version: v1.16.x
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
```rp-commits
feat: drop support for terraform v1.14 (#1531)
feat: add support for terraform v1.16 (#1531)
```

Update test matrix to use the latest terraform versions.